### PR TITLE
fix: org switcher hides orgs with no explanation or workaround

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,28 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ---
 
+## [4.0.4] — 2026-08-13
+
+### Overview
+Fix for a real usability gap reported after v4.0.0-4.0.3 shipped: on some accounts, the org switcher shows only "Personal repos" with no way to reach organization-scoped features (Team Health Scorecard, Weekly Leadership Digest), even for users who genuinely belong to orgs.
+
+### Fixed
+
+#### Org switcher silently hid orgs with no way to work around it
+- **Root cause:** the switcher only lists orgs GitHub's `orgs.listForAuthenticatedUser` API returns for the *current* token — which depends on when that token was authorized, not just current org membership. A session authorized before `read:org` was added to the OAuth scope list (or a fine-grained PAT, which cannot see org data at all) silently returns an empty list even for a user who belongs to orgs. There was no feedback and no fallback.
+- The org switcher now includes a "Go to org by name" input, always available, that navigates directly to any org by name — this works independently of the discovery list, because the actual repo fetch (`/api/github/org-repos`) checks real GitHub access itself rather than relying on the membership-listing API.
+- When the discovered org list is empty, the switcher now explains why (stale OAuth scope, fine-grained PAT limitation, or org visibility settings) instead of silently showing nothing.
+- Fixed a related cosmetic bug: navigating to an org not in the discovered list (e.g. via the new manual input, or a bookmarked `?org=` URL) previously fell back to showing "Personal Repos" as the page title even though the repo list was correctly filtered to that org — the title now always reflects the actual org being viewed.
+- Added a FAQ entry in the in-app docs explaining the scope/discovery gap and the workaround.
+
+Team Health Scorecard (`/org/[orgName]/health`) and the org-repos view already worked correctly by URL for any org name — this fix is entirely about *reaching* them when the switcher's auto-discovery falls short. No API or data-layer changes.
+
+### Changed (infra)
+- Bumped app version from 4.0.3 to 4.0.4
+- Bumped Helm chart version from 0.4.3 to 0.4.4
+
+---
+
 ## [4.0.3] — 2026-08-13
 
 ### Overview

--- a/helm/gitdash/Chart.yaml
+++ b/helm/gitdash/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: gitdash
 description: Self-hosted GitHub Actions metrics dashboard (standalone PAT or GitHub OAuth)
 type: application
-version: 0.4.3
-appVersion: "4.0.3"
+version: 0.4.4
+appVersion: "4.0.4"
 keywords:
   - github-actions
   - dashboard

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gitdash",
-  "version": "4.0.3",
+  "version": "4.0.4",
   "private": true,
   "packageManager": "pnpm@10.30.3",
   "scripts": {

--- a/src/app/docs/page.tsx
+++ b/src/app/docs/page.tsx
@@ -2112,6 +2112,35 @@ function FAQ() {
       q: "Can I use a fine-grained PAT instead of a classic PAT?",
       a: <>Yes. Use a fine-grained PAT with <Code>Actions: read</Code> and <Code>Contents: read</Code> scoped to specific repositories. Note: fine-grained PATs cannot access organization data (<Code>read:org</Code>), so org-level features will not work.</>,
     },
+    {
+      q: "My organizations don't show up in the org switcher, even though I'm a member.",
+      a: <>
+        The switcher only lists what GitHub&apos;s <Code>orgs.listForAuthenticatedUser</Code> API
+        returns for your current token — which depends on when that token was
+        authorized, not just what orgs you belong to today:
+        <ul className="list-disc pl-5 mt-2 space-y-1">
+          <li>
+            <strong>Organization mode (OAuth):</strong> if you authorized GitDash
+            before <Code>read:org</Code> was added to the requested scopes, your
+            existing session won&apos;t have it. Sign out and sign back in to
+            re-authorize with the current scope list.
+          </li>
+          <li>
+            <strong>Standalone mode (PAT):</strong> a classic PAT needs the{" "}
+            <Code>read:org</Code> scope explicitly checked; a fine-grained PAT
+            cannot see organization data at all (see the previous question).
+          </li>
+          <li>
+            Some orgs hide private membership from this API even with the
+            right scope, depending on the org&apos;s own visibility settings.
+          </li>
+        </ul>
+        In any case, you can still reach an org directly — type its name into
+        the &quot;Go to org by name&quot; box in the org switcher, or open{" "}
+        <Code>/org/&lt;name&gt;</Code> directly. Both work independently of the
+        discovery list, using your token&apos;s actual repo access.
+      </>,
+    },
   ];
 
   return (
@@ -2213,9 +2242,25 @@ pnpm run lint`}
 function ReleaseNotes() {
   const releases = [
     {
-      version: "4.0.3",
+      version: "4.0.4",
       date: "2026-08-13",
       badge: "latest",
+      badgeColor: "bg-emerald-500/15 text-emerald-400 border-emerald-500/20",
+      changes: {
+        added: [
+          "Org switcher: \"Go to org by name\" input, always available — reaches any org directly regardless of what GitHub's org-discovery API returns for your token",
+        ],
+        fixed: [
+          "Org switcher showed only \"Personal repos\" with no explanation or workaround when GitHub's orgs.listForAuthenticatedUser API returned an empty list (stale OAuth scope, fine-grained PAT, or org visibility settings) — now explains why and offers the manual org input as a fallback",
+          "Navigating to an org not in the auto-discovered list incorrectly showed \"Personal Repos\" as the page title even though the repo list was correctly filtered to that org",
+        ],
+        improved: [],
+      },
+    },
+    {
+      version: "4.0.3",
+      date: "2026-08-13",
+      badge: null,
       badgeColor: "bg-emerald-500/15 text-emerald-400 border-emerald-500/20",
       changes: {
         added: [
@@ -2546,7 +2591,7 @@ function DocSidebar({
           <BookOpen className="w-4 h-4 text-violet-400" />
           <span className="text-sm font-semibold text-white">GitDash Docs</span>
           <span className="text-xs px-1.5 py-0.5 rounded bg-violet-500/15 text-violet-400 border border-violet-500/20 font-mono">
-            v{process.env.NEXT_PUBLIC_APP_VERSION ?? "4.0.3"}
+            v{process.env.NEXT_PUBLIC_APP_VERSION ?? "4.0.4"}
           </span>
         </div>
         {/* Mobile close */}
@@ -2791,7 +2836,7 @@ export default function DocsPage() {
 
           {/* Footer */}
           <footer className="mt-8 pb-4 text-center text-xs text-slate-600 space-y-1">
-            <p>GitDash v{process.env.NEXT_PUBLIC_APP_VERSION ?? "4.0.3"} — GitHub Actions Dashboard</p>
+            <p>GitDash v{process.env.NEXT_PUBLIC_APP_VERSION ?? "4.0.4"} — GitHub Actions Dashboard</p>
             <p>
               <a href="https://github.com/dinhdobathi1992/gitdash" target="_blank" rel="noreferrer" className="hover:text-slate-400 transition-colors">
                 Open source on GitHub

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -332,6 +332,14 @@ function OrgSelector({
   onSelect: (org: string | null) => void;
 }) {
   const [open, setOpen] = useState(false);
+  const [manualOrg, setManualOrg] = useState("");
+  // GitHub's "orgs the user belongs to" endpoint only lists what the current
+  // token's scope allows it to see — a token authorized before read:org was
+  // added to the OAuth scope (or a fine-grained PAT without org access
+  // granted) silently returns an empty list even for a user who genuinely
+  // belongs to orgs. This input lets someone reach an org directly by name;
+  // the actual repo fetch (/api/github/org-repos) checks real GitHub access
+  // itself, so this works whenever discovery alone falls short.
   const selected = orgs.find((o) => o.login === current);
   const containerRef = useRef<HTMLDivElement>(null);
 
@@ -369,6 +377,13 @@ function OrgSelector({
             <img src={selected.avatar_url} alt={selected.login} width={16} height={16} className="w-4 h-4 rounded-sm" />
             <span className="font-mono">{selected.login}</span>
           </>
+        ) : current ? (
+          // Reached by typed-in org name, not in the auto-discovered list —
+          // still show it as selected rather than falling back to "Personal".
+          <>
+            <Building2 className="w-4 h-4" />
+            <span className="font-mono">{current}</span>
+          </>
         ) : (
           <>
             <User className="w-4 h-4" />
@@ -391,9 +406,7 @@ function OrgSelector({
             <span>Personal repos</span>
           </button>
 
-          {orgs.length > 0 && (
-            <div className="my-1 border-t border-slate-700/50" />
-          )}
+          <div className="my-1 border-t border-slate-700/50" />
 
           {orgs.map((org) => (
             <button
@@ -409,6 +422,37 @@ function OrgSelector({
               <span className="font-mono truncate">{org.login}</span>
             </button>
           ))}
+
+          {orgs.length === 0 && (
+            <p className="px-3 py-1.5 text-[11px] text-slate-500 leading-snug">
+              No organizations found. If you belong to one, your token may
+              predate the <code className="text-slate-400">read:org</code> scope
+              — try signing out and back in, or type the org below.
+            </p>
+          )}
+
+          <div className="my-1 border-t border-slate-700/50" />
+          <form
+            onSubmit={(e) => {
+              e.preventDefault();
+              const org = manualOrg.trim();
+              if (!org) return;
+              onSelect(org);
+              setManualOrg("");
+              setOpen(false);
+            }}
+            className="px-3 py-2"
+          >
+            <label className="block text-[10px] text-slate-500 uppercase tracking-wider mb-1">
+              Go to org by name
+            </label>
+            <input
+              value={manualOrg}
+              onChange={(e) => setManualOrg(e.target.value)}
+              placeholder="org-name"
+              className="w-full px-2 py-1.5 bg-slate-900/60 border border-slate-700 rounded-lg text-xs text-slate-100 font-mono placeholder-slate-600 focus:outline-none focus:ring-2 focus:ring-violet-500/40"
+            />
+          </form>
         </div>
       )}
     </div>
@@ -560,13 +604,21 @@ function HomeContent() {
       {/* ── Header ── */}
       <div className="flex items-center justify-between mb-5 gap-3 flex-wrap">
         <div className="flex items-center gap-3 min-w-0">
-          {orgParam && selectedOrg ? (
+          {orgParam ? (
             <>
-              {/* eslint-disable-next-line @next/next/no-img-element */}
-              <img src={selectedOrg.avatar_url} alt={selectedOrg.login} width={36} height={36} className="w-9 h-9 rounded-xl ring-1 ring-slate-700 shrink-0" />
+              {selectedOrg ? (
+                // eslint-disable-next-line @next/next/no-img-element
+                <img src={selectedOrg.avatar_url} alt={selectedOrg.login} width={36} height={36} className="w-9 h-9 rounded-xl ring-1 ring-slate-700 shrink-0" />
+              ) : (
+                // Reached by typed-in org name (not in the auto-discovered
+                // list) — still a valid, working org view, just no avatar.
+                <div className="w-9 h-9 rounded-xl bg-slate-800 ring-1 ring-slate-700 shrink-0 flex items-center justify-center">
+                  <Building2 className="w-4 h-4 text-slate-500" />
+                </div>
+              )}
               <div className="min-w-0">
                 <div className="flex items-center gap-2 flex-wrap">
-                  <h1 className="text-xl font-bold text-white font-mono truncate">{selectedOrg.login}</h1>
+                  <h1 className="text-xl font-bold text-white font-mono truncate">{orgParam}</h1>
                   <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full bg-blue-500/10 border border-blue-500/20 text-xs text-blue-300 shrink-0">
                     <Building2 className="w-3 h-3" /> Org
                   </span>


### PR DESCRIPTION
## Summary

Reported after v4.0.0–v4.0.3 shipped: the org switcher on the home page showed only "Personal repos" with no way to reach organization-scoped features (Team Health Scorecard, Weekly Leadership Digest), even for accounts that genuinely belong to orgs.

**Root cause:** the switcher only lists orgs GitHub's `orgs.listForAuthenticatedUser` API returns for the *current* token — which depends on when that token was authorized, not current org membership:
- **Organization mode (OAuth):** a session authorized before `read:org` was added to the requested scope list won't have it, and GitHub doesn't retroactively grant new scopes to an existing authorization.
- **Standalone mode (PAT):** a classic PAT needs `read:org` explicitly checked; a fine-grained PAT cannot see org data at all.
- Some orgs hide private membership from this API regardless of scope, depending on the org's own visibility settings.

There was no feedback when this happened and no way to work around it — even though the org-scoped pages (`/org/[orgName]`, `/org/[orgName]/health`) already work correctly for any org name by URL, since the real repo fetch checks GitHub access directly and doesn't depend on the discovery list at all.

## Changes

- Org switcher: new **"Go to org by name"** input, always available — navigates directly to any org regardless of what the discovery API returned.
- Empty-state text explains the likely cause when no orgs are listed (stale OAuth scope / fine-grained PAT / org visibility).
- Fixed a related cosmetic bug: navigating to an org not in the discovered list fell back to showing "Personal Repos" as the page title even though the repo list was correctly filtered to that org.
- New FAQ entry in the in-app docs covering the scope/discovery gap and the workaround.
- No API or data-layer changes — this is entirely about *reaching* already-working pages.
- Version bump 4.0.3 → 4.0.4 (CHANGELOG, Helm chart, in-app docs release notes).

## Test plan

- [x] `tsc --noEmit` clean
- [x] `eslint` clean on changed files
- [x] 63/63 unit tests pass
- [x] Production build succeeds
- [x] In-app API Reference verified 38/38 routes documented, zero drift
- [ ] Manual verification once merged: confirm the "Go to org by name" input navigates correctly and the empty-state message renders when `/api/github/orgs` returns `[]`