### PR TITLE
fix: contributor profile 404s when repo owner is a personal account

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,27 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ---
 
+## [4.0.5] — 2026-08-13
+
+### Overview
+Fix for a contributor-profile crash reported right after v4.0.4: "Failed to fetch contributor profile" whenever the repo owner is a personal GitHub account rather than an organization.
+
+### Fixed
+
+#### Contributor profile broke for personal-account-owned repos
+- **Root cause:** `/api/github/contributor-profile` always called `GET /orgs/{org}/repos` to list the owner's repos. That endpoint 404s whenever `owner` is a personal account, not an organization — which is the common case for most users (personal repos, not org repos). Any click into a contributor from a personal repo's Team Analytics page failed outright.
+- Added a fallback: try the org-repos endpoint first (the common path when contributor profiles are reached from org-owned repos), and on 404 fall back to `GET /users/{username}/repos` for personal accounts. No behavior change for org-owned repos.
+
+### Rollback
+- **Instant, no rebuild:** promote the v4.0.4 Vercel deployment.
+- **Full revert:** `git revert` this release's commit(s) — no migration, no schema change.
+
+### Changed (infra)
+- Bumped app version from 4.0.4 to 4.0.5
+- Bumped Helm chart version from 0.4.4 to 0.4.5
+
+---
+
 ## [4.0.4] — 2026-08-13
 
 ### Overview

--- a/helm/gitdash/Chart.yaml
+++ b/helm/gitdash/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: gitdash
 description: Self-hosted GitHub Actions metrics dashboard (standalone PAT or GitHub OAuth)
 type: application
-version: 0.4.4
-appVersion: "4.0.4"
+version: 0.4.5
+appVersion: "4.0.5"
 keywords:
   - github-actions
   - dashboard

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gitdash",
-  "version": "4.0.4",
+  "version": "4.0.5",
   "private": true,
   "packageManager": "pnpm@10.30.3",
   "scripts": {

--- a/src/app/api/github/contributor-profile/route.ts
+++ b/src/app/api/github/contributor-profile/route.ts
@@ -116,6 +116,41 @@ function getWeekStart(date: Date): string {
   return d.toISOString().slice(0, 10);
 }
 
+/**
+ * `owner` is a repo owner, which may be an organization OR a personal
+ * account — GitHub has no single endpoint for "repos owned by X" that
+ * works for both. GET /orgs/{org}/repos 404s for a personal account, so
+ * try that first (the common case: contributor profiles are usually
+ * reached from org-owned repos) and fall back to GET /users/{username}/repos
+ * on 404, rather than requiring a separate account-type lookup up front.
+ */
+async function listOwnerRepos(
+  octokit: ReturnType<typeof getOctokit>,
+  owner: string,
+): Promise<Awaited<ReturnType<typeof octokit.rest.repos.listForOrg>>["data"]> {
+  try {
+    const { data } = await octokit.rest.repos.listForOrg({
+      org: owner,
+      per_page: 100,
+      sort: "updated",
+      direction: "desc",
+      type: "all",
+    });
+    return data;
+  } catch (e) {
+    const status = (e as { status?: number }).status;
+    if (status !== 404) throw e;
+    const { data } = await octokit.rest.repos.listForUser({
+      username: owner,
+      per_page: 100,
+      sort: "updated",
+      direction: "desc",
+      type: "all",
+    });
+    return data;
+  }
+}
+
 // ── Handler ───────────────────────────────────────────────────────────────────
 
 export async function GET(req: NextRequest) {
@@ -140,22 +175,16 @@ export async function GET(req: NextRequest) {
     const ninetyDaysAgo = new Date(now.getTime() - 90 * 24 * 60 * 60 * 1000);
     const since = ninetyDaysAgo.toISOString();
 
-    // ── Parallel: user profile + org repos + search PRs authored + search PRs reviewed
-    const [userRes, orgReposRes] = await Promise.all([
+    // ── Parallel: user profile + owner's repos + search PRs authored + search PRs reviewed
+    const [userRes, ownerRepos] = await Promise.all([
       octokit.rest.users.getByUsername({ username: login }),
-      octokit.rest.repos.listForOrg({
-        org: owner,
-        per_page: 100,
-        sort: "updated",
-        direction: "desc",
-        type: "all",
-      }),
+      listOwnerRepos(octokit, owner),
     ]);
 
     const user = userRes.data;
-    const orgRepos = orgReposRes.data.slice(0, 30); // Cap to 30 repos
+    const ownerRepoList = ownerRepos.slice(0, 30); // Cap to 30 repos
 
-    // ── Fetch PRs authored by login across org repos (batched) ──────────────
+    // ── Fetch PRs authored by login across the owner's repos (batched) ──────
     const allPrs: ContributorPrSummary[] = [];
     const allReviews: ContributorReviewSummary[] = [];
     const commitCounts: Record<string, number> = {};
@@ -171,7 +200,7 @@ export async function GET(req: NextRequest) {
     let reviewFetchAttempted = 0;
 
     await pLimitSettled(
-      orgRepos.map((repo) => async () => {
+      ownerRepoList.map((repo) => async () => {
           const repoFullName = `${owner}/${repo.name}`;
 
           // Fetch PRs by this author
@@ -455,8 +484,8 @@ export async function GET(req: NextRequest) {
 
       partial: reposPrFailed + reposCommitsFailed + reviewFetchRejected > 0,
       fetched_requests:
-        orgRepos.length * 2 - reposPrFailed - reposCommitsFailed + reviewFetchAttempted - reviewFetchRejected,
-      total_requests_attempted: orgRepos.length * 2 + reviewFetchAttempted,
+        ownerRepoList.length * 2 - reposPrFailed - reposCommitsFailed + reviewFetchAttempted - reviewFetchRejected,
+      total_requests_attempted: ownerRepoList.length * 2 + reviewFetchAttempted,
     };
 
     return NextResponse.json(response, {

--- a/src/app/docs/page.tsx
+++ b/src/app/docs/page.tsx
@@ -2242,9 +2242,22 @@ pnpm run lint`}
 function ReleaseNotes() {
   const releases = [
     {
-      version: "4.0.4",
+      version: "4.0.5",
       date: "2026-08-13",
       badge: "latest",
+      badgeColor: "bg-emerald-500/15 text-emerald-400 border-emerald-500/20",
+      changes: {
+        added: [],
+        fixed: [
+          "Contributor profile failed with \"Failed to fetch contributor profile\" whenever the repo owner is a personal GitHub account rather than an organization — the route always called GET /orgs/{org}/repos, which 404s for personal accounts. Now falls back to GET /users/{username}/repos on 404",
+        ],
+        improved: [],
+      },
+    },
+    {
+      version: "4.0.4",
+      date: "2026-08-13",
+      badge: null,
       badgeColor: "bg-emerald-500/15 text-emerald-400 border-emerald-500/20",
       changes: {
         added: [
@@ -2591,7 +2604,7 @@ function DocSidebar({
           <BookOpen className="w-4 h-4 text-violet-400" />
           <span className="text-sm font-semibold text-white">GitDash Docs</span>
           <span className="text-xs px-1.5 py-0.5 rounded bg-violet-500/15 text-violet-400 border border-violet-500/20 font-mono">
-            v{process.env.NEXT_PUBLIC_APP_VERSION ?? "4.0.4"}
+            v{process.env.NEXT_PUBLIC_APP_VERSION ?? "4.0.5"}
           </span>
         </div>
         {/* Mobile close */}
@@ -2836,7 +2849,7 @@ export default function DocsPage() {
 
           {/* Footer */}
           <footer className="mt-8 pb-4 text-center text-xs text-slate-600 space-y-1">
-            <p>GitDash v{process.env.NEXT_PUBLIC_APP_VERSION ?? "4.0.4"} — GitHub Actions Dashboard</p>
+            <p>GitDash v{process.env.NEXT_PUBLIC_APP_VERSION ?? "4.0.5"} — GitHub Actions Dashboard</p>
             <p>
               <a href="https://github.com/dinhdobathi1992/gitdash" target="_blank" rel="noreferrer" className="hover:text-slate-400 transition-colors">
                 Open source on GitHub


### PR DESCRIPTION
## Summary

Reported: "Failed to fetch contributor profile" when clicking into a contributor from a personal repo's Team Analytics page (e.g. `dinhdobathi1992/gitdash` → Team Analytics → click a contributor).

**Root cause:** `/api/github/contributor-profile` always called `GET /orgs/{org}/repos` to list the owner's repos. That endpoint 404s whenever `owner` is a personal GitHub account rather than an organization — which is the common case for most users (personal repos, not org repos). Every contributor-profile lookup on a personal-account-owned repo failed outright.

## Changes

- Added `listOwnerRepos()`: tries `repos.listForOrg` first (the common path when contributor profiles are reached from org-owned repos), and on 404 falls back to `repos.listForUser` for personal accounts. No behavior change for org-owned repos.
- Renamed the now-inaccurate `orgRepos` variable to `ownerRepoList` and fixed a stale "across org repos" comment while touching this code.
- Version bump 4.0.4 → 4.0.5 (CHANGELOG, Helm chart, in-app docs release notes).

## Test plan

- [x] `tsc --noEmit` clean
- [x] `eslint` clean on changed files
- [x] 63/63 unit tests pass
- [x] Production build succeeds
- [x] In-app API Reference verified 38/38 routes documented, zero drift
- [ ] Manual verification once merged: open a contributor profile from a personal-account-owned repo's Team Analytics page and confirm it loads