### PR TITLE
feat: v4.0.7 + v4.0.8 — Team Health Scorecard discoverability + redesign

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,27 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ---
 
+## [4.0.9] — 2026-08-13
+
+### Overview
+Drive-by fix reported alongside v4.0.8 testing: the browser console logged `Error with Permissions-Policy header: Unrecognized feature: 'interest-cohort'` on every page load.
+
+### Fixed
+
+#### Stale Permissions-Policy directive
+- **Root cause:** the security-headers config in `next.config.ts` disabled `interest-cohort` (Google's FLoC/Topics cohort-tracking feature) via the `Permissions-Policy` header. FLoC was discontinued and modern browsers no longer recognize `interest-cohort` as a valid Permissions-Policy feature, so every request logged a harmless-but-noisy console warning.
+- Removed the directive. `camera`, `microphone`, and `geolocation` remain disabled — no functional change, this is not the cause of any loading issue.
+
+### Rollback
+- **Instant, no rebuild:** promote the v4.0.8 Vercel deployment.
+- **Full revert:** `git revert` this release's commit(s) — one header value in `next.config.ts`.
+
+### Changed (infra)
+- Bumped app version from 4.0.8 to 4.0.9
+- Bumped Helm chart version from 0.4.8 to 0.4.9
+
+---
+
 ## [4.0.8] — 2026-08-13
 
 ### Overview

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,27 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ---
 
+## [4.0.7] — 2026-08-13
+
+### Overview
+Fix for a UI discoverability gap reported after v4.0.0 shipped: the Team Health Scorecard (`/org/[orgName]/health`) had no visible entry point from the main dashboard — it could only be reached by manually typing the URL, or by first noticing an unlabeled icon-only "Org overview" button (`QuickActions`) that leads to the org page, which *then* has the labeled button.
+
+### Fixed
+
+#### No visible way to reach the Team Health Scorecard
+- **Root cause:** the only labeled "Team Health Scorecard" link lives in the header of `/org/[orgName]` — but the main dashboard (`/`) never links there directly. The sole path was through `QuickActions`, a small unlabeled icon (title-only tooltip) mixed in with the Alerts and Docs icon buttons.
+- The main dashboard header now shows a labeled "Team Health Scorecard" button (same style as the one on the org page) whenever an org is selected — one click from wherever a leader already is, no detour through the org overview page required.
+
+### Rollback
+- **Instant, no rebuild:** promote the v4.0.6 Vercel deployment.
+- **Full revert:** `git revert` this release's commit(s) — additive UI only, no data or API change.
+
+### Changed (infra)
+- Bumped app version from 4.0.6 to 4.0.7
+- Bumped Helm chart version from 0.4.6 to 0.4.7
+
+---
+
 ## [4.0.6] — 2026-08-13
 
 ### Overview

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,31 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ---
 
+## [4.0.8] — 2026-08-13
+
+### Overview
+Visual redesign of the Team Health Scorecard, requested directly after v4.0.7: the flat list of same-weight rows gave a leader no at-a-glance read of overall org health. Implemented from a design imported via Claude Design ("Scorecard board redesign" project), adapted to the app's existing Geist typography and DORA color tokens rather than introducing a separate font/palette for one page.
+
+### Changed
+
+#### Team Health Scorecard redesign
+- Added an "Estate distribution" card in the header — total repo count, a segmented proportion bar, and a legend — plus four stat tiles below it: At Risk / Watch / Healthy counts (each with a "% of estate" note) and a Median Score tile.
+- Repos are now a proper grouped table: a column header row (Repository / DORA / Bus factor / Critical / Trend / Composite), then "At Risk" / "Watch" / "Healthy" sections with a labeled group header (count chip + one-line description of what the band means), instead of one undifferentiated worst-first list.
+- Added interactive filter pills (All / At Risk / Watch / Healthy, each showing its count) and sort pills (Lowest score / Most critical / A–Z) — client-side, no extra fetches.
+- Bus factor is now a number plus a 3-pip strength indicator, colored by the same risk tone as the composite-score bar. Critical-module count is color-coded (muted at zero, amber under 5, red above).
+- Each row is a single click target with a colored left accent bar; the composite score keeps a linear bar (glow-tinted by risk band) next to the number rather than switching to a radial gauge.
+- No API or data changes — same `/api/github/org-health-scorecard` response, purely presentational.
+
+### Rollback
+- **Instant, no rebuild:** promote the v4.0.7 Vercel deployment.
+- **Full revert:** `git revert` this release's commit(s) — one file (`src/app/org/[orgName]/health/page.tsx`), no data or schema change.
+
+### Changed (infra)
+- Bumped app version from 4.0.7 to 4.0.8
+- Bumped Helm chart version from 0.4.7 to 0.4.8
+
+---
+
 ## [4.0.7] — 2026-08-13
 
 ### Overview

--- a/helm/gitdash/Chart.yaml
+++ b/helm/gitdash/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: gitdash
 description: Self-hosted GitHub Actions metrics dashboard (standalone PAT or GitHub OAuth)
 type: application
-version: 0.4.7
-appVersion: "4.0.7"
+version: 0.4.8
+appVersion: "4.0.8"
 keywords:
   - github-actions
   - dashboard

--- a/helm/gitdash/Chart.yaml
+++ b/helm/gitdash/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: gitdash
 description: Self-hosted GitHub Actions metrics dashboard (standalone PAT or GitHub OAuth)
 type: application
-version: 0.4.6
-appVersion: "4.0.6"
+version: 0.4.7
+appVersion: "4.0.7"
 keywords:
   - github-actions
   - dashboard

--- a/helm/gitdash/Chart.yaml
+++ b/helm/gitdash/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: gitdash
 description: Self-hosted GitHub Actions metrics dashboard (standalone PAT or GitHub OAuth)
 type: application
-version: 0.4.8
-appVersion: "4.0.8"
+version: 0.4.9
+appVersion: "4.0.9"
 keywords:
   - github-actions
   - dashboard

--- a/next.config.ts
+++ b/next.config.ts
@@ -39,7 +39,7 @@ const nextConfig: NextConfig = {
           // Referrer policy
           { key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },
           // Disable browser features we don't use
-          { key: "Permissions-Policy", value: "camera=(), microphone=(), geolocation=(), interest-cohort=()" },
+          { key: "Permissions-Policy", value: "camera=(), microphone=(), geolocation=()" },
           // MED-003: HSTS — only in production (browsers ignore it over HTTP)
           ...(isDev ? [] : [{
             key: "Strict-Transport-Security",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gitdash",
-  "version": "4.0.8",
+  "version": "4.0.9",
   "private": true,
   "packageManager": "pnpm@10.30.3",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gitdash",
-  "version": "4.0.7",
+  "version": "4.0.8",
   "private": true,
   "packageManager": "pnpm@10.30.3",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gitdash",
-  "version": "4.0.6",
+  "version": "4.0.7",
   "private": true,
   "packageManager": "pnpm@10.30.3",
   "scripts": {

--- a/src/app/docs/page.tsx
+++ b/src/app/docs/page.tsx
@@ -2470,9 +2470,22 @@ pnpm run lint`}
 function ReleaseNotes() {
   const releases = [
     {
-      version: "4.0.8",
+      version: "4.0.9",
       date: "2026-08-13",
       badge: "latest",
+      badgeColor: "bg-emerald-500/15 text-emerald-400 border-emerald-500/20",
+      changes: {
+        added: [],
+        fixed: [
+          "Every page logged \"Error with Permissions-Policy header: Unrecognized feature: 'interest-cohort'\" — a stale FLoC-related directive no browser recognizes anymore. Removed; camera/microphone/geolocation stay disabled",
+        ],
+        improved: [],
+      },
+    },
+    {
+      version: "4.0.8",
+      date: "2026-08-13",
+      badge: null,
       badgeColor: "bg-emerald-500/15 text-emerald-400 border-emerald-500/20",
       changes: {
         added: [],
@@ -2874,7 +2887,7 @@ function DocSidebar({
           <BookOpen className="w-4 h-4 text-violet-400" />
           <span className="text-sm font-semibold text-white">GitDash Docs</span>
           <span className="text-xs px-1.5 py-0.5 rounded bg-violet-500/15 text-violet-400 border border-violet-500/20 font-mono">
-            v{process.env.NEXT_PUBLIC_APP_VERSION ?? "4.0.8"}
+            v{process.env.NEXT_PUBLIC_APP_VERSION ?? "4.0.9"}
           </span>
         </div>
         {/* Mobile close */}
@@ -3123,7 +3136,7 @@ export default function DocsPage() {
 
           {/* Footer */}
           <footer className="mt-8 pb-4 text-center text-xs text-slate-600 space-y-1">
-            <p>GitDash v{process.env.NEXT_PUBLIC_APP_VERSION ?? "4.0.8"} — GitHub Actions Dashboard</p>
+            <p>GitDash v{process.env.NEXT_PUBLIC_APP_VERSION ?? "4.0.9"} — GitHub Actions Dashboard</p>
             <p>
               <a href="https://github.com/dinhdobathi1992/gitdash" target="_blank" rel="noreferrer" className="hover:text-slate-400 transition-colors">
                 Open source on GitHub

--- a/src/app/docs/page.tsx
+++ b/src/app/docs/page.tsx
@@ -2470,9 +2470,22 @@ pnpm run lint`}
 function ReleaseNotes() {
   const releases = [
     {
-      version: "4.0.7",
+      version: "4.0.8",
       date: "2026-08-13",
       badge: "latest",
+      badgeColor: "bg-emerald-500/15 text-emerald-400 border-emerald-500/20",
+      changes: {
+        added: [],
+        fixed: [],
+        improved: [
+          "Team Health Scorecard redesign, implemented from a Claude Design import: estate-distribution card + stat tiles in the header, a proper grouped table (column headers, risk-band sections with count chips), interactive filter/sort pills, and bus-factor pip indicators. Presentational only — same API, same data",
+        ],
+      },
+    },
+    {
+      version: "4.0.7",
+      date: "2026-08-13",
+      badge: null,
       badgeColor: "bg-emerald-500/15 text-emerald-400 border-emerald-500/20",
       changes: {
         added: [],
@@ -2861,7 +2874,7 @@ function DocSidebar({
           <BookOpen className="w-4 h-4 text-violet-400" />
           <span className="text-sm font-semibold text-white">GitDash Docs</span>
           <span className="text-xs px-1.5 py-0.5 rounded bg-violet-500/15 text-violet-400 border border-violet-500/20 font-mono">
-            v{process.env.NEXT_PUBLIC_APP_VERSION ?? "4.0.7"}
+            v{process.env.NEXT_PUBLIC_APP_VERSION ?? "4.0.8"}
           </span>
         </div>
         {/* Mobile close */}
@@ -3110,7 +3123,7 @@ export default function DocsPage() {
 
           {/* Footer */}
           <footer className="mt-8 pb-4 text-center text-xs text-slate-600 space-y-1">
-            <p>GitDash v{process.env.NEXT_PUBLIC_APP_VERSION ?? "4.0.7"} — GitHub Actions Dashboard</p>
+            <p>GitDash v{process.env.NEXT_PUBLIC_APP_VERSION ?? "4.0.8"} — GitHub Actions Dashboard</p>
             <p>
               <a href="https://github.com/dinhdobathi1992/gitdash" target="_blank" rel="noreferrer" className="hover:text-slate-400 transition-colors">
                 Open source on GitHub

--- a/src/app/docs/page.tsx
+++ b/src/app/docs/page.tsx
@@ -2470,9 +2470,22 @@ pnpm run lint`}
 function ReleaseNotes() {
   const releases = [
     {
-      version: "4.0.6",
+      version: "4.0.7",
       date: "2026-08-13",
       badge: "latest",
+      badgeColor: "bg-emerald-500/15 text-emerald-400 border-emerald-500/20",
+      changes: {
+        added: [],
+        fixed: [
+          "Team Health Scorecard had no visible entry point from the main dashboard — the only labeled link lived in the /org/[orgName] header, reachable solely via an unlabeled icon-only \"Org overview\" button. The main dashboard header now shows a labeled \"Team Health Scorecard\" button directly whenever an org is selected",
+        ],
+        improved: [],
+      },
+    },
+    {
+      version: "4.0.6",
+      date: "2026-08-13",
+      badge: null,
       badgeColor: "bg-emerald-500/15 text-emerald-400 border-emerald-500/20",
       changes: {
         added: [],
@@ -2848,7 +2861,7 @@ function DocSidebar({
           <BookOpen className="w-4 h-4 text-violet-400" />
           <span className="text-sm font-semibold text-white">GitDash Docs</span>
           <span className="text-xs px-1.5 py-0.5 rounded bg-violet-500/15 text-violet-400 border border-violet-500/20 font-mono">
-            v{process.env.NEXT_PUBLIC_APP_VERSION ?? "4.0.6"}
+            v{process.env.NEXT_PUBLIC_APP_VERSION ?? "4.0.7"}
           </span>
         </div>
         {/* Mobile close */}
@@ -3097,7 +3110,7 @@ export default function DocsPage() {
 
           {/* Footer */}
           <footer className="mt-8 pb-4 text-center text-xs text-slate-600 space-y-1">
-            <p>GitDash v{process.env.NEXT_PUBLIC_APP_VERSION ?? "4.0.6"} — GitHub Actions Dashboard</p>
+            <p>GitDash v{process.env.NEXT_PUBLIC_APP_VERSION ?? "4.0.7"} — GitHub Actions Dashboard</p>
             <p>
               <a href="https://github.com/dinhdobathi1992/gitdash" target="_blank" rel="noreferrer" className="hover:text-slate-400 transition-colors">
                 Open source on GitHub

--- a/src/app/org/[orgName]/health/page.tsx
+++ b/src/app/org/[orgName]/health/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { use, useState } from "react";
+import { use, useMemo, useState } from "react";
 import Link from "next/link";
 import useSWR from "swr";
 import { fetcher } from "@/lib/swr";
@@ -14,88 +14,238 @@ import {
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 
-const RISK_META: Record<RepoScorecardEntry["risk_band"], { label: string; text: string; bg: string; border: string }> = {
-  healthy: { label: "Healthy", text: "text-emerald-400", bg: "bg-emerald-500/10", border: "border-emerald-500/25" },
-  watch: { label: "Watch", text: "text-amber-400", bg: "bg-amber-500/10", border: "border-amber-500/25" },
-  at_risk: { label: "At Risk", text: "text-red-400", bg: "bg-red-500/10", border: "border-red-500/25" },
+type Band = RepoScorecardEntry["risk_band"];
+type FilterKey = "all" | Band;
+type SortKey = "score" | "crit" | "name";
+
+// Design reference: claude.ai/design "Scorecard board redesign" project,
+// adapted to the app's existing Geist typography and DORA color tokens.
+const BAND_ORDER: Band[] = ["at_risk", "watch", "healthy"];
+
+const RISK_META: Record<Band, {
+  label: string; text: string; textSoft: string; bg: string; border: string;
+  dot: string; ringHex: string; barGrad: string; groupBg: string;
+  hint: string;
+}> = {
+  at_risk: {
+    label: "At Risk", text: "text-red-400", textSoft: "text-red-300/80",
+    bg: "bg-red-500/[0.06]", border: "border-red-500/20", dot: "bg-red-400",
+    ringHex: "#f87171", barGrad: "bg-gradient-to-r from-red-500 to-red-400",
+    groupBg: "bg-gradient-to-r from-red-500/[0.08] via-red-500/[0.02] to-transparent",
+    hint: "Single-owner risk — assign a second maintainer",
+  },
+  watch: {
+    label: "Watch", text: "text-amber-400", textSoft: "text-amber-300/80",
+    bg: "bg-amber-500/[0.06]", border: "border-amber-500/20", dot: "bg-amber-400",
+    ringHex: "#fbbf24", barGrad: "bg-gradient-to-r from-amber-500 to-amber-400",
+    groupBg: "bg-gradient-to-r from-amber-500/[0.07] via-amber-500/[0.02] to-transparent",
+    hint: "Thin coverage or slipping throughput",
+  },
+  healthy: {
+    label: "Healthy", text: "text-emerald-400", textSoft: "text-emerald-300/80",
+    bg: "bg-emerald-500/[0.06]", border: "border-emerald-500/20", dot: "bg-emerald-400",
+    ringHex: "#34d399", barGrad: "bg-gradient-to-r from-emerald-500 to-emerald-400",
+    groupBg: "bg-gradient-to-r from-emerald-500/[0.07] via-emerald-500/[0.02] to-transparent",
+    hint: "Sustainable ownership and delivery",
+  },
 };
 
-function TrendIcon({ trend }: { trend: RepoScorecardEntry["trend"] }) {
-  if (trend === "up") return <TrendingUp className="w-3.5 h-3.5 text-emerald-400" />;
-  if (trend === "down") return <TrendingDown className="w-3.5 h-3.5 text-red-400" />;
-  return <Minus className="w-3.5 h-3.5 text-slate-500" />;
+const GRID_COLS = "minmax(180px,1.4fr) 92px 130px 120px 120px 168px";
+
+function busTone(bus: number): Band {
+  if (bus <= 1) return "at_risk";
+  if (bus === 2) return "watch";
+  return "healthy";
 }
 
-function ScoreBar({ score }: { score: number }) {
-  const tone = score >= 80 ? "bg-emerald-500" : score >= 50 ? "bg-amber-500" : "bg-red-500";
+function median(nums: number[]): number {
+  if (nums.length === 0) return 0;
+  const sorted = [...nums].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  return sorted.length % 2 !== 0 ? sorted[mid] : Math.round((sorted[mid - 1] + sorted[mid]) / 2);
+}
+
+function TrendGlyph({ trend }: { trend: RepoScorecardEntry["trend"] }) {
+  if (trend === "up") return <TrendingUp className="w-3.5 h-3.5 text-emerald-400 shrink-0" />;
+  if (trend === "down") return <TrendingDown className="w-3.5 h-3.5 text-red-400 shrink-0" />;
+  return <Minus className="w-3.5 h-3.5 text-slate-500 shrink-0" />;
+}
+
+// ── Header: estate distribution card ───────────────────────────────────────────
+
+function EstateDistribution({ counts, total }: { counts: Record<Band, number>; total: number }) {
   return (
-    <div className="w-24 h-1.5 rounded-full bg-slate-800 overflow-hidden shrink-0">
-      <div className={cn("h-full rounded-full", tone)} style={{ width: `${Math.max(2, score)}%` }} />
+    <div className="flex flex-col gap-3 min-w-[280px] px-4 py-3.5 rounded-2xl border border-slate-800 bg-gradient-to-b from-slate-900/70 to-slate-950/80 shadow-[0_18px_40px_-28px_rgba(0,0,0,0.9)]">
+      <div className="flex items-baseline justify-between">
+        <span className="text-[10.5px] font-semibold uppercase tracking-[0.14em] text-slate-500">Estate distribution</span>
+        <span className="font-mono text-xs text-slate-400">{total} repos</span>
+      </div>
+      <div className="flex gap-[3px] h-2">
+        {BAND_ORDER.map((band) => counts[band] > 0 && (
+          <div
+            key={band}
+            className={cn("rounded-sm", RISK_META[band].barGrad)}
+            style={{ flex: counts[band], boxShadow: `0 0 12px -3px ${RISK_META[band].ringHex}` }}
+          />
+        ))}
+      </div>
+      <div className="flex items-center gap-4 flex-wrap">
+        {BAND_ORDER.map((band) => (
+          <div key={band} className="flex items-center gap-1.5 text-xs text-slate-400">
+            <span className={cn("w-1.5 h-1.5 rounded-full", RISK_META[band].dot)} />
+            <span>{RISK_META[band].label}</span>
+            <span className={cn("font-mono", RISK_META[band].text)}>{counts[band]}</span>
+          </div>
+        ))}
+      </div>
     </div>
   );
 }
 
-function RepoScoreRow({ entry }: { entry: RepoScorecardEntry }) {
-  const risk = RISK_META[entry.risk_band];
-  const doraMeta = LEVEL_COLORS[entry.dora_level];
+// ── Stat tiles ────────────────────────────────────────────────────────────────
 
+function StatTile({ label, value, note, tone }: { label: string; value: number; note: string; tone: Band | "neutral" }) {
+  const meta = tone === "neutral"
+    ? { text: "text-slate-100", barGrad: "bg-gradient-to-r from-slate-500 to-slate-400" }
+    : RISK_META[tone];
   return (
-    <div className={cn("rounded-xl border p-4 flex items-center gap-4 flex-wrap", risk.border, risk.bg)}>
-      <div className="min-w-0 flex-1">
-        <div className="flex items-center gap-2 mb-1">
-          <Link
-            href={`/repos/${entry.owner}/${entry.repo}`}
-            className="text-sm font-semibold text-white hover:text-violet-300 transition-colors font-mono truncate"
-          >
-            {entry.repo}
-          </Link>
-          <span className={cn("text-[10px] font-medium px-1.5 py-0.5 rounded-full border", risk.text, risk.border)}>
-            {risk.label}
-          </span>
-          {entry.partial && (
-            <AlertTriangle className="w-3 h-3 text-amber-400 shrink-0" aria-label="Computed from partial data" />
-          )}
-        </div>
-        <div className="flex items-center gap-3 text-xs text-slate-400 flex-wrap">
-          <span className={cn("px-1.5 py-0.5 rounded font-medium", doraMeta.bg, doraMeta.text)}>
-            DORA: {LEVEL_LABELS[entry.dora_level]}
-          </span>
-          <span>
-            Bus factor: <span className="text-slate-300 font-medium">{entry.overall_bus_factor}</span>
-          </span>
-          {entry.critical_modules > 0 && (
-            <span className="text-red-400">{entry.critical_modules} critical module{entry.critical_modules === 1 ? "" : "s"}</span>
-          )}
-          <span className="flex items-center gap-1">
-            <TrendIcon trend={entry.trend} /> throughput {entry.trend}
-          </span>
-        </div>
-      </div>
-
-      <div className="flex items-center gap-3 shrink-0">
-        <ScoreBar score={entry.composite_score} />
-        <span className="text-lg font-bold text-white w-8 text-right">{entry.composite_score}</span>
-        <Link
-          href={`/repos/${entry.owner}/${entry.repo}`}
-          className="text-slate-600 hover:text-slate-300 transition-colors"
-          aria-label={`Open ${entry.repo}`}
-        >
-          <ChevronRight className="w-4 h-4" />
-        </Link>
+    <div className="relative overflow-hidden flex flex-col gap-3 px-4 py-4 rounded-2xl border border-slate-800 bg-gradient-to-b from-slate-900/60 to-slate-950/70 shadow-[0_20px_44px_-32px_rgba(0,0,0,0.95)]">
+      <span className={cn("absolute inset-y-0 left-0 w-[3px]", meta.barGrad)} />
+      <span className="text-[10.5px] font-semibold uppercase tracking-[0.14em] text-slate-500">{label}</span>
+      <div className="flex items-baseline gap-2">
+        <span className={cn("font-mono text-3xl font-bold tabular-nums leading-none tracking-tight", meta.text)}>{value}</span>
+        <span className="text-[11px] text-slate-500">{note}</span>
       </div>
     </div>
+  );
+}
+
+// ── Filter / sort toolbar ────────────────────────────────────────────────────
+
+function Pill({ active, onClick, children }: { active: boolean; onClick: () => void; children: React.ReactNode }) {
+  return (
+    <button
+      onClick={onClick}
+      className={cn(
+        "px-3 py-1.5 rounded-lg text-xs whitespace-nowrap transition-colors border",
+        active
+          ? "bg-gradient-to-b from-slate-700/80 to-slate-800/80 border-slate-600 text-white shadow-[inset_0_1px_0_rgba(255,255,255,0.08)]"
+          : "bg-transparent border-transparent text-slate-500 hover:text-slate-300",
+      )}
+    >
+      {children}
+    </button>
+  );
+}
+
+// ── Group header ──────────────────────────────────────────────────────────────
+
+function GroupHeader({ band, count }: { band: Band; count: number }) {
+  const meta = RISK_META[band];
+  return (
+    <div className={cn("flex items-center gap-2.5 px-5 py-2.5 border-y border-slate-800/80", meta.groupBg)}>
+      <span className={cn("w-1.5 h-1.5 rounded-full shrink-0", meta.dot)} style={{ boxShadow: `0 0 8px ${meta.ringHex}` }} />
+      <span className={cn("text-[11px] font-semibold uppercase tracking-[0.12em]", meta.text)}>{meta.label}</span>
+      <span className={cn("font-mono text-[11px] px-1.5 py-0.5 rounded border", meta.border, meta.text)}>{count}</span>
+      <div className="flex-1 h-px bg-gradient-to-r from-slate-800 to-transparent" />
+      <span className="text-[11.5px] text-slate-500 whitespace-nowrap hidden sm:inline">{meta.hint}</span>
+    </div>
+  );
+}
+
+// ── Repo row ──────────────────────────────────────────────────────────────────
+
+function RepoRow({ entry }: { entry: RepoScorecardEntry }) {
+  const risk = RISK_META[entry.risk_band];
+  const doraMeta = LEVEL_COLORS[entry.dora_level];
+  const bus = RISK_META[busTone(entry.overall_bus_factor)];
+  const critTone: "none" | "warn" | "danger" =
+    entry.critical_modules === 0 ? "none" : entry.critical_modules > 5 ? "danger" : "warn";
+  const critLabel = entry.critical_modules === 0
+    ? "none"
+    : `${entry.critical_modules} module${entry.critical_modules === 1 ? "" : "s"}`;
+  const trendLabel = entry.trend === "up" ? "rising" : entry.trend === "down" ? "falling" : "flat";
+  const trendColor = entry.trend === "up" ? "text-emerald-400" : entry.trend === "down" ? "text-red-400" : "text-slate-500";
+  const pct = Math.max(2, Math.min(100, entry.composite_score));
+
+  return (
+    <Link
+      href={`/repos/${entry.owner}/${entry.repo}`}
+      className="group relative grid items-center gap-3 px-5 py-3 border-b border-slate-800/60 last:border-b-0 transition-colors hover:bg-slate-800/40"
+      style={{ gridTemplateColumns: GRID_COLS }}
+    >
+      <span className={cn("absolute inset-y-0 left-0 w-[2px]", risk.barGrad)} />
+
+      <div className="min-w-0 flex items-center gap-1.5">
+        <span className="font-mono text-[13.5px] font-medium text-slate-100 group-hover:text-white transition-colors truncate">
+          {entry.repo}
+        </span>
+        {entry.partial && (
+          <AlertTriangle className="w-3 h-3 text-amber-400 shrink-0" aria-label="Computed from partial data" />
+        )}
+      </div>
+
+      <span className={cn("justify-self-start text-[11px] font-medium uppercase tracking-wide px-2 py-1 rounded-md border", doraMeta.bg, doraMeta.text, doraMeta.border)}>
+        {LEVEL_LABELS[entry.dora_level]}
+      </span>
+
+      <div className="flex items-center gap-2">
+        <span className={cn("font-mono text-[13.5px]", entry.overall_bus_factor <= 1 ? "text-red-400" : "text-slate-200")}>
+          {entry.overall_bus_factor}
+        </span>
+        <div className="flex gap-[3px]">
+          {[0, 1, 2].map((i) => (
+            <span
+              key={i}
+              className={cn("w-[3px] h-3.5 rounded-sm", i < entry.overall_bus_factor ? bus.dot : "bg-slate-800")}
+            />
+          ))}
+        </div>
+      </div>
+
+      <span
+        className={cn(
+          "font-mono text-xs whitespace-nowrap",
+          critTone === "none" ? "text-slate-500" : critTone === "danger" ? "text-red-400" : "text-amber-300",
+        )}
+      >
+        {critLabel}
+      </span>
+
+      <div className={cn("flex items-center gap-1.5 text-xs whitespace-nowrap", trendColor)}>
+        <TrendGlyph trend={entry.trend} /> {trendLabel}
+      </div>
+
+      <div className="flex items-center justify-end gap-2.5">
+        <div className="relative w-14 h-1 rounded-full bg-slate-800 overflow-hidden">
+          <div
+            className={cn("absolute inset-y-0 left-0 rounded-full", risk.barGrad)}
+            style={{ width: `${pct}%`, boxShadow: `0 0 8px -1px ${risk.ringHex}` }}
+          />
+        </div>
+        <span className="font-mono text-xl font-bold tracking-tight text-white w-8 text-right tabular-nums">
+          {entry.composite_score}
+        </span>
+        <ChevronRight className="w-3.5 h-3.5 text-slate-700 group-hover:text-slate-400 transition-colors shrink-0" />
+      </div>
+    </Link>
   );
 }
 
 function ScorecardSkeleton() {
   return (
-    <div className="space-y-3">
-      {Array.from({ length: 6 }).map((_, i) => (
-        <div key={i} className="h-[72px] rounded-xl skeleton" />
-      ))}
+    <div className="space-y-6">
+      <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <div key={i} className="h-[92px] rounded-2xl skeleton" />
+        ))}
+      </div>
+      <div className="h-[400px] rounded-2xl skeleton" />
     </div>
   );
 }
+
+// ── Page ──────────────────────────────────────────────────────────────────────
 
 export default function OrgHealthScorecardPage({
   params,
@@ -105,6 +255,8 @@ export default function OrgHealthScorecardPage({
   const { orgName } = use(params);
   const { flags } = useFeatureFlags();
   const [limit, setLimit] = useState(10);
+  const [filter, setFilter] = useState<FilterKey>("all");
+  const [sort, setSort] = useState<SortKey>("score");
 
   const { data, error, isLoading } = useSWR<OrgHealthScorecardResponse>(
     flags.healthScorecard
@@ -113,8 +265,33 @@ export default function OrgHealthScorecardPage({
     fetcher<OrgHealthScorecardResponse>,
   );
 
+  const repos = useMemo(() => data?.repos ?? [], [data]);
+
+  const counts = useMemo<Record<Band, number>>(() => ({
+    at_risk: repos.filter((r) => r.risk_band === "at_risk").length,
+    watch: repos.filter((r) => r.risk_band === "watch").length,
+    healthy: repos.filter((r) => r.risk_band === "healthy").length,
+  }), [repos]);
+
+  const medianScore = useMemo(() => median(repos.map((r) => r.composite_score)), [repos]);
+
+  const groups = useMemo(() => {
+    const sorters: Record<SortKey, (a: RepoScorecardEntry, b: RepoScorecardEntry) => number> = {
+      score: (a, b) => a.composite_score - b.composite_score,
+      crit: (a, b) => b.critical_modules - a.critical_modules,
+      name: (a, b) => a.repo.localeCompare(b.repo),
+    };
+    const filtered = repos.filter((r) => filter === "all" || r.risk_band === filter);
+    const sorted = [...filtered].sort(sorters[sort]);
+    return BAND_ORDER
+      .map((band) => ({ band, rows: sorted.filter((r) => r.risk_band === band) }))
+      .filter((g) => g.rows.length > 0);
+  }, [repos, filter, sort]);
+
+  const total = repos.length;
+
   return (
-    <div className="p-8 space-y-6 max-w-4xl">
+    <div className="p-8 space-y-6 max-w-6xl">
       <Breadcrumb
         items={[
           { label: "Repositories", href: "/" },
@@ -123,16 +300,24 @@ export default function OrgHealthScorecardPage({
         ]}
       />
 
-      <div className="flex items-center gap-3">
-        <div className="w-10 h-10 rounded-xl bg-violet-500/20 border border-violet-500/30 flex items-center justify-center">
-          <ShieldCheck className="w-5 h-5 text-violet-400" />
+      <div className="flex items-start justify-between gap-8 flex-wrap">
+        <div className="flex items-start gap-3">
+          <div className="w-10 h-10 rounded-xl bg-violet-500/20 border border-violet-500/30 flex items-center justify-center shrink-0">
+            <ShieldCheck className="w-5 h-5 text-violet-400" />
+          </div>
+          <div>
+            <div className="flex items-center gap-1.5 mb-1">
+              <span className="w-1.5 h-1.5 rounded-full bg-violet-400 shadow-[0_0_8px_rgba(167,139,250,0.9)]" />
+              <span className="font-mono text-[10.5px] uppercase tracking-[0.16em] text-slate-500">{orgName}</span>
+            </div>
+            <h1 className="text-2xl font-bold text-white">Team Health Scorecard</h1>
+            <p className="text-sm text-slate-400 max-w-md mt-1">
+              Composite of 60% DORA tier and 40% bus-factor risk. Trend compares recent against prior throughput.
+            </p>
+          </div>
         </div>
-        <div>
-          <h1 className="text-2xl font-bold text-white">Team Health Scorecard</h1>
-          <p className="text-sm text-slate-400">
-            Every repo in <span className="font-mono text-slate-300">{orgName}</span>, ranked worst-first
-          </p>
-        </div>
+
+        {data && total > 0 && <EstateDistribution counts={counts} total={total} />}
       </div>
 
       {!flags.healthScorecard ? (
@@ -142,25 +327,6 @@ export default function OrgHealthScorecardPage({
         </div>
       ) : (
         <>
-          <div className="flex items-center gap-3 flex-wrap">
-            <div className="flex items-center gap-1.5 text-xs text-slate-500">
-              <Info className="w-3.5 h-3.5" />
-              Composite score: 60% DORA tier + 40% bus-factor risk. Trend compares recent vs. prior throughput.
-            </div>
-            <div className="ml-auto flex items-center gap-2">
-              <label className="text-xs text-slate-500">Repos analysed</label>
-              <select
-                value={limit}
-                onChange={(e) => setLimit(Number(e.target.value))}
-                className="px-2 py-1 bg-slate-900/60 border border-slate-700 rounded-lg text-xs text-slate-200 focus:outline-none focus:ring-2 focus:ring-violet-500/40 cursor-pointer"
-              >
-                {[5, 10, 15, 20].map((n) => (
-                  <option key={n} value={n}>{n}</option>
-                ))}
-              </select>
-            </div>
-          </div>
-
           {isLoading && <ScorecardSkeleton />}
 
           {error && (
@@ -169,35 +335,115 @@ export default function OrgHealthScorecardPage({
             </div>
           )}
 
-          {data && data.repos.length === 0 && (
+          {data && total === 0 && (
             <div className="flex flex-col items-center justify-center py-16 gap-2 text-center">
               <Building2 className="w-8 h-8 text-slate-600" />
               <p className="text-sm text-slate-500">No repos with enough activity to score yet.</p>
             </div>
           )}
 
-          {data && data.repos.length > 0 && (
-            <div className="space-y-3">
+          {data && total > 0 && (
+            <>
+              {/* Stat tiles */}
+              <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+                <StatTile label="At Risk" value={counts.at_risk} note={`${Math.round((counts.at_risk / total) * 100)}% of estate`} tone="at_risk" />
+                <StatTile label="Watch" value={counts.watch} note={`${Math.round((counts.watch / total) * 100)}% of estate`} tone="watch" />
+                <StatTile label="Healthy" value={counts.healthy} note={`${Math.round((counts.healthy / total) * 100)}% of estate`} tone="healthy" />
+                <StatTile label="Median Score" value={medianScore} note="of 100" tone="neutral" />
+              </div>
+
+              {/* Toolbar */}
+              <div className="flex items-center justify-between gap-3 flex-wrap">
+                <div className="flex items-center gap-1 p-1 rounded-xl border border-slate-800 bg-slate-900/60 flex-wrap">
+                  <Pill active={filter === "all"} onClick={() => setFilter("all")}>
+                    All <span className="ml-1.5 font-mono text-[11px] opacity-60">{total}</span>
+                  </Pill>
+                  {BAND_ORDER.map((band) => (
+                    <Pill key={band} active={filter === band} onClick={() => setFilter(band)}>
+                      {RISK_META[band].label} <span className="ml-1.5 font-mono text-[11px] opacity-60">{counts[band]}</span>
+                    </Pill>
+                  ))}
+                </div>
+
+                <div className="flex items-center gap-3 flex-wrap">
+                  <div className="flex items-center gap-2">
+                    <span className="text-[11px] uppercase tracking-wide text-slate-500">Sort</span>
+                    <div className="flex items-center gap-1">
+                      <Pill active={sort === "score"} onClick={() => setSort("score")}>Lowest score</Pill>
+                      <Pill active={sort === "crit"} onClick={() => setSort("crit")}>Most critical</Pill>
+                      <Pill active={sort === "name"} onClick={() => setSort("name")}>A–Z</Pill>
+                    </div>
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <label className="text-[11px] uppercase tracking-wide text-slate-500">Analysed</label>
+                    <select
+                      value={limit}
+                      onChange={(e) => setLimit(Number(e.target.value))}
+                      className="px-2 py-1 bg-slate-900/60 border border-slate-700 rounded-lg text-xs text-slate-200 focus:outline-none focus:ring-2 focus:ring-violet-500/40 cursor-pointer"
+                    >
+                      {[5, 10, 15, 20].map((n) => (
+                        <option key={n} value={n}>{n}</option>
+                      ))}
+                    </select>
+                  </div>
+                </div>
+              </div>
+
               {data.repos_analysed < data.repos_attempted && (
                 <div className="flex items-center gap-2 px-3 py-2 rounded-lg bg-amber-500/10 border border-amber-500/20 text-xs text-amber-300">
                   <AlertTriangle className="w-3.5 h-3.5 shrink-0" />
                   Scored {data.repos_analysed}/{data.repos_attempted} repos — the rest failed to fetch (rate limit or access).
                 </div>
               )}
-              {data.repos.map((entry) => (
-                <RepoScoreRow key={`${entry.owner}/${entry.repo}`} entry={entry} />
-              ))}
-            </div>
-          )}
 
-          <a
-            href={`https://github.com/${encodeURIComponent(orgName)}`}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="inline-flex items-center gap-1 text-xs text-slate-500 hover:text-violet-400 transition-colors"
-          >
-            View {orgName} on GitHub <ExternalLink className="w-3 h-3" />
-          </a>
+              {/* Grouped table */}
+              <div className="rounded-2xl border border-slate-800 bg-gradient-to-b from-slate-900/50 to-slate-950/70 shadow-[0_40px_80px_-50px_rgba(0,0,0,1)] overflow-hidden">
+                <div className="overflow-x-auto">
+                  <div className="min-w-[820px]">
+                    <div
+                      className="grid items-center gap-3 px-5 py-2.5 border-b border-slate-800 text-[10px] font-semibold uppercase tracking-[0.14em] text-slate-500"
+                      style={{ gridTemplateColumns: GRID_COLS }}
+                    >
+                      <div>Repository</div>
+                      <div>DORA</div>
+                      <div>Bus factor</div>
+                      <div>Critical</div>
+                      <div>Trend</div>
+                      <div className="text-right">Composite</div>
+                    </div>
+
+                    {groups.length === 0 && (
+                      <div className="px-5 py-10 text-center text-sm text-slate-500">No repos match this filter.</div>
+                    )}
+
+                    {groups.map(({ band, rows }) => (
+                      <div key={band}>
+                        <GroupHeader band={band} count={rows.length} />
+                        {rows.map((entry) => (
+                          <RepoRow key={`${entry.owner}/${entry.repo}`} entry={entry} />
+                        ))}
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              </div>
+
+              <div className="flex items-center justify-between gap-4 flex-wrap text-xs text-slate-500">
+                <div className="flex items-center gap-1.5">
+                  <Info className="w-3.5 h-3.5 shrink-0" />
+                  Bus factor counts contributors carrying more than half of recent changes; critical modules have a single owner.
+                </div>
+                <a
+                  href={`https://github.com/${encodeURIComponent(orgName)}`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex items-center gap-1 hover:text-violet-400 transition-colors"
+                >
+                  View {orgName} on GitHub <ExternalLink className="w-3 h-3" />
+                </a>
+              </div>
+            </>
+          )}
         </>
       )}
     </div>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -13,7 +13,7 @@ import { formatDistanceToNow } from "date-fns";
 import {
   Search, Lock, Unlock, AlertCircle, ChevronRight, ChevronLeft,
   RefreshCw, Building2, User, ChevronDown, X,
-  AlertTriangle, Keyboard,
+  AlertTriangle, Keyboard, ShieldCheck,
 } from "lucide-react";
 import { cn, fuzzyMatch, highlightSegments } from "@/lib/utils";
 import { RunHistoryBars, TrendSparkline, StatusBadge, HealthBadge } from "@/components/WorkflowMetrics";
@@ -647,6 +647,14 @@ function HomeContent() {
         <div className="flex items-center gap-1.5 shrink-0">
           {orgs && (
             <OrgSelector orgs={orgs} current={orgParam} onSelect={handleOrgSelect} />
+          )}
+          {orgParam && (
+            <Link
+              href={`/org/${encodeURIComponent(orgParam)}/health`}
+              className="inline-flex items-center gap-1.5 px-2.5 py-1.5 text-xs font-medium text-violet-300 bg-violet-500/10 border border-violet-500/25 rounded-lg hover:bg-violet-500/20 transition-colors"
+            >
+              <ShieldCheck className="w-3.5 h-3.5" /> <span className="hidden sm:inline">Team Health Scorecard</span>
+            </Link>
           )}
           <button
             onClick={handleRefresh}


### PR DESCRIPTION
## Summary
Two related fixes to the Team Health Scorecard, shipped as two commits/versions for independent rollback:

**v4.0.7 — Discoverability fix**
- The scorecard had no visible entry point from the main dashboard. The main dashboard header now shows a labeled "Team Health Scorecard" button whenever an org is selected.

**v4.0.8 — Visual redesign**
- Implemented from a design imported via Claude Design ("Scorecard board redesign" project — https://claude.ai/design/p/9142b13a-6930-48a8-9b2c-ab0c973b97c8), adapted to the app's existing Geist typography and DORA color tokens instead of the design's IBM Plex fonts, to stay consistent with the rest of the app.
- Estate-distribution card + stat tiles in the header, a proper grouped table (column headers, risk-band sections with count chips and descriptions), interactive filter/sort pills, bus-factor pip indicators, linear glow score bars.
- Presentational only — same `/api/github/org-health-scorecard` response, no data/API changes.

Live preview already deployed to the standalone Vercel project for visual verification: https://standalone.gitdash.info/org/aboitiz-data-innovation/health

## Test plan
- [x] `tsc --noEmit` — 0 errors
- [x] `npm test` — 63/63 passing
- [x] `eslint` on changed files — clean
- [x] `rm -rf .next && npm run build` — succeeds
- [x] Deployed to gitdash-standalone production for visual check