### PR TITLE
feat: v4.0.10 — loading indicator on Team Health Scorecard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,27 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ---
 
+## [4.0.10] — 2026-08-13
+
+### Overview
+UX follow-up after a scare: a GitHub-side 403 (secondary rate-limiting from repeated testing, not a code issue) made the Team Health Scorecard's loading skeleton sit motionless long enough to look frozen. The skeleton itself gave no signal that anything was actually happening.
+
+### Changed
+
+#### Scorecard loading state
+- Added a spinner + status line ("Collecting data across up to N repositories — a DORA + bus-factor check runs per repo, usually a few seconds…") above the skeleton tiles, so a slow or retrying fetch visibly reads as "working," not "stuck."
+- No behavior change to the fetch itself — this is purely the loading-state UI.
+
+### Rollback
+- **Instant, no rebuild:** promote the v4.0.9 Vercel deployment.
+- **Full revert:** `git revert` this release's commit(s) — one component, no data or API change.
+
+### Changed (infra)
+- Bumped app version from 4.0.9 to 4.0.10
+- Bumped Helm chart version from 0.4.9 to 0.4.10
+
+---
+
 ## [4.0.9] — 2026-08-13
 
 ### Overview

--- a/helm/gitdash/Chart.yaml
+++ b/helm/gitdash/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: gitdash
 description: Self-hosted GitHub Actions metrics dashboard (standalone PAT or GitHub OAuth)
 type: application
-version: 0.4.9
-appVersion: "4.0.9"
+version: 0.4.10
+appVersion: "4.0.10"
 keywords:
   - github-actions
   - dashboard

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gitdash",
-  "version": "4.0.9",
+  "version": "4.0.10",
   "private": true,
   "packageManager": "pnpm@10.30.3",
   "scripts": {

--- a/src/app/docs/page.tsx
+++ b/src/app/docs/page.tsx
@@ -2470,9 +2470,22 @@ pnpm run lint`}
 function ReleaseNotes() {
   const releases = [
     {
-      version: "4.0.9",
+      version: "4.0.10",
       date: "2026-08-13",
       badge: "latest",
+      badgeColor: "bg-emerald-500/15 text-emerald-400 border-emerald-500/20",
+      changes: {
+        added: [],
+        fixed: [],
+        improved: [
+          "Team Health Scorecard loading state: a spinner + \"Collecting data across up to N repositories…\" status line now sits above the skeleton tiles, so a slow fetch (or one hitting GitHub's rate limits) visibly reads as working rather than frozen",
+        ],
+      },
+    },
+    {
+      version: "4.0.9",
+      date: "2026-08-13",
+      badge: null,
       badgeColor: "bg-emerald-500/15 text-emerald-400 border-emerald-500/20",
       changes: {
         added: [],
@@ -2887,7 +2900,7 @@ function DocSidebar({
           <BookOpen className="w-4 h-4 text-violet-400" />
           <span className="text-sm font-semibold text-white">GitDash Docs</span>
           <span className="text-xs px-1.5 py-0.5 rounded bg-violet-500/15 text-violet-400 border border-violet-500/20 font-mono">
-            v{process.env.NEXT_PUBLIC_APP_VERSION ?? "4.0.9"}
+            v{process.env.NEXT_PUBLIC_APP_VERSION ?? "4.0.10"}
           </span>
         </div>
         {/* Mobile close */}
@@ -3136,7 +3149,7 @@ export default function DocsPage() {
 
           {/* Footer */}
           <footer className="mt-8 pb-4 text-center text-xs text-slate-600 space-y-1">
-            <p>GitDash v{process.env.NEXT_PUBLIC_APP_VERSION ?? "4.0.9"} — GitHub Actions Dashboard</p>
+            <p>GitDash v{process.env.NEXT_PUBLIC_APP_VERSION ?? "4.0.10"} — GitHub Actions Dashboard</p>
             <p>
               <a href="https://github.com/dinhdobathi1992/gitdash" target="_blank" rel="noreferrer" className="hover:text-slate-400 transition-colors">
                 Open source on GitHub

--- a/src/app/org/[orgName]/health/page.tsx
+++ b/src/app/org/[orgName]/health/page.tsx
@@ -10,7 +10,7 @@ import { LEVEL_COLORS, LEVEL_LABELS } from "@/lib/dora";
 import type { OrgHealthScorecardResponse, RepoScorecardEntry } from "@/app/api/github/org-health-scorecard/route";
 import {
   Building2, ShieldCheck, TrendingUp, TrendingDown, Minus,
-  ExternalLink, AlertTriangle, ChevronRight, Info,
+  ExternalLink, AlertTriangle, ChevronRight, Info, Loader2,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 
@@ -232,9 +232,15 @@ function RepoRow({ entry }: { entry: RepoScorecardEntry }) {
   );
 }
 
-function ScorecardSkeleton() {
+function ScorecardSkeleton({ limit }: { limit: number }) {
   return (
     <div className="space-y-6">
+      <div className="flex items-center gap-2.5 px-4 py-3 rounded-xl border border-violet-500/20 bg-violet-500/[0.06] text-sm text-violet-200">
+        <Loader2 className="w-4 h-4 animate-spin shrink-0" />
+        <span>
+          Collecting data across up to {limit} repositories — a DORA + bus-factor check runs per repo, usually a few seconds…
+        </span>
+      </div>
       <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
         {Array.from({ length: 4 }).map((_, i) => (
           <div key={i} className="h-[92px] rounded-2xl skeleton" />
@@ -327,7 +333,7 @@ export default function OrgHealthScorecardPage({
         </div>
       ) : (
         <>
-          {isLoading && <ScorecardSkeleton />}
+          {isLoading && <ScorecardSkeleton limit={limit} />}
 
           {error && (
             <div className="px-4 py-3 rounded-xl border border-red-500/25 bg-red-500/10 text-sm text-red-300">


### PR DESCRIPTION
## Summary
Follow-up to the freeze scare: the underlying cause was GitHub's secondary rate-limiting on both tokens (confirmed via server logs — 403s in ~100ms, not a hang — and it self-cleared, unrelated to any merged code). But the bare skeleton gave zero signal that anything was happening, so a slow/retrying fetch looked indistinguishable from broken.

- Adds a spinner (`Loader2`, animate-spin) + status line above the skeleton tiles: "Collecting data across up to N repositories — a DORA + bus-factor check runs per repo, usually a few seconds…"
- No change to the fetch/retry logic itself — purely the loading-state UI.

## Test plan
- [x] `tsc --noEmit` — 0 errors
- [x] `npm test` — 63/63 passing
- [x] `eslint` on changed files — clean
- [x] `rm -rf .next && npm run build` — succeeds