### PR TITLE
feat: v4.1.0 — AI insight layer and AI Insights panel

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -62,3 +62,19 @@ NEXT_PUBLIC_APP_URL=http://localhost:3000
 # SMTP_PASS=your_smtp_password_or_api_key
 # SMTP_FROM=alerts@yourdomain.com
 # SENDGRID_API_KEY=SG....   # alternative to SMTP_PASS for SendGrid
+
+# ── AI features (optional) ────────────────────────────────────────────────────
+# When no key is set, every AI surface is hidden and GitDash behaves exactly as
+# it did before v4.1.0. Gemini is tried first; Qwen is the fallback.
+# GEMINI_API_KEY=...
+# GEMINI_MODEL=gemini-2.5-flash
+# QWEN_API_KEY=...
+# QWEN_MODEL=qwen-plus
+#
+# Safety valves:
+# AI_DISABLED=true              # hard-kill the layer regardless of keys
+# AI_TIMEOUT_MS=15000           # per provider attempt
+# AI_TOTAL_BUDGET_MS=45000      # across all attempts within one request
+# AI_DAILY_TOKEN_BUDGET=2000000 # per instance per UTC day; 0 = unlimited.
+#                               # In-process counter: a damage-limiter, not a
+#                               # hard global cap on a multi-instance deploy.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,54 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ---
 
+## [4.1.0] — 2026-08-14
+
+### Overview
+First release of the AI insight layer: an optional LLM analysis of the metrics GitDash already computes. **Entirely opt-in — with no AI provider key configured, every surface is hidden and the app behaves exactly as it did in v4.0.11.** Design and plan: `docs/specs/2026-08-14-ai-features-design.md`, `docs/plans/2026-08-14-ai-features-plan.md`.
+
+### Added
+
+#### AI provider layer (`src/lib/ai.ts`)
+- Gemini primary, Qwen fallback, both through their OpenAI-compatible chat-completions endpoints — **zero new dependencies**, just `fetch`.
+- `generateJson()` **never throws.** Every failure (no keys, disabled, timeout, HTTP error, unparseable body) returns a typed `AiFailure` with a machine-readable reason, so callers own their fallback UX instead of wrapping everything in try/catch.
+- A single wall-clock deadline (`AI_TOTAL_BUDGET_MS`, default 45s) spans *all* provider attempts, so one slow primary can never push a request past its route's `maxDuration`. Per-attempt timeout is `AI_TIMEOUT_MS` (default 15s).
+- Non-retryable statuses (400/401/403) skip straight to the next provider; 429/5xx retry once before falling through.
+- Nothing logs prompt content or snapshot payloads — provider, model, latency, status and token counts only.
+
+#### AI Insights panel
+- New card on `/repos/[owner]/[repo]` and `/org/[orgName]/health`: a summary, findings grounded in the snapshot's numbers, and up to three suggested actions.
+- New `GET /api/ai/insights` (repo and org surfaces) and `GET /api/ai/status` (capability probe — reports which providers are configured, never key material).
+- New `aiInsights` feature flag in Settings. Double-gated: the server must have keys **and** the flag must be on. The client flag controls visibility only — routes check `aiEnabled()` server-side themselves, because the flag is localStorage-backed and trivially flipped.
+- Failure is a non-event by design: an unavailable provider renders a muted one-liner, not an error box. The page's own metrics are unaffected.
+
+#### Privacy enforcement
+- Prompts are assembled server-side from typed snapshots (`src/lib/ai-snapshots.ts`) built field-by-field against an explicit interface — never by spreading a GitHub API object, so a field absent from the type cannot leak even if an upstream fetcher starts returning more.
+- **Sent:** aggregate metrics, repository/workflow/job/step names, contributor logins, dates. **Never sent:** tokens, run logs, source code, workflow YAML, PR/commit message bodies, email addresses.
+- `tests/ai-snapshots.test.ts` walks the serialized output of every builder and fails on a forbidden key. Fixtures deliberately carry commit messages, SHAs and URLs to prove the builder drops them.
+- No free-form user input enters any prompt, so the injection surface is zero by construction.
+
+#### Cost controls
+- 15-minute response caching, fingerprinted on the snapshot so unchanged metrics reuse the previous generation.
+- 20 requests/minute per token via a new `aiRateLimit()` helper that keys on the token hash rather than IP — AI cost follows the token, not the network.
+- `AI_DAILY_TOKEN_BUDGET` (default 2,000,000 tokens/day) short-circuits before any provider call once spent.
+- **These are in-process counters**, so on a multi-instance deployment they bound cost per instance rather than globally. Documented in-app and in-code as a damage-limiter, not a hard spend cap.
+
+### Changed
+- `tests/` gained its first route-handler tests (`api-ai-status`, `api-ai-insights`). Everything prior tested pure `src/lib` functions; the pattern is documented in `tests/api-ai-status.test.ts` for reuse.
+- Test count 63 → 142.
+
+### Rollback
+Three independent levers, in increasing order of cost:
+1. **Unset the AI env keys** — every surface hides immediately. No redeploy, no code change.
+2. **Promote the v4.0.11 Vercel deployment** — instant, no rebuild.
+3. **`git revert` this release's commit(s)** — **no migration to undo, zero schema changes.**
+
+### Changed (infra)
+- Bumped app version from 4.0.11 to 4.1.0
+- Bumped Helm chart version from 0.4.11 to 0.5.0
+
+---
+
 ## [4.0.11] — 2026-08-13
 
 ### Overview

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ https://github.com/user-attachments/assets/8cf2625a-3a88-4494-a703-07cb5181c11a
 | **Cost Analytics** | Track GitHub Actions spend month-over-month to identify expensive workflows and optimize CI budgets. |
 | **Enterprise-Grade Security** | AES-256-GCM encrypted sessions, zero browser token exposure, and workflow configuration static analysis. |
 | **DB-Backed Reporting** | Persist historical data beyond GitHub's 90-day retention and evaluate advanced alerting rules. |
+| **AI Insights** *(optional)* | Plain-English analysis of your metrics via Gemini or Qwen. Entirely opt-in — hidden unless you configure a provider key, and only aggregate metrics and names are ever sent. |
 
 ---
 

--- a/docs/plans/2026-08-13-quick-wins.md
+++ b/docs/plans/2026-08-13-quick-wins.md
@@ -1,0 +1,1011 @@
+# GitDash Quick Wins Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship four low-risk, high-value improvements: deduplicate percentile math, deduplicate repo-summary/run-timing logic, make the Weekly Leadership Digest resilient to missed/repeated cron runs, rate-limit expensive fan-out endpoints, and add a Helm CronJob so scheduled sync works off Vercel.
+
+**Architecture:** All new logic is pure functions in `src/lib` (unit-testable with the existing vitest setup), DB state added through the existing versioned-migration mechanism in `src/lib/db.ts`, and the Helm chart gains one optional template. No API contract changes, no UI changes.
+
+**Tech Stack:** Next.js 16 route handlers, TypeScript strict, vitest (tests in `tests/**`, alias `@` → `src`), Helm 3.
+
+---
+
+## Context for the implementer
+
+- Repo: `/Users/thi/Devops/gitdash`. Package manager is **pnpm** (`corepack enable pnpm`), pinned via `packageManager` in `package.json`.
+- Commands: `pnpm run lint`, `pnpm exec tsc --noEmit`, `pnpm test` (vitest run). Tests live in `tests/*.test.ts` and import via `@/lib/...`.
+- Commit style (see `git log --oneline`): Conventional Commits, e.g. `feat:`, `fix:`, `refactor:` with a short imperative summary.
+- There is no TODO/FIXME culture here — write header comments in the style of the surrounding files (block comment explaining *why*).
+- Every task ends with lint + typecheck + tests green, then one commit.
+
+---
+
+### Task 1: Shared percentile helpers (`src/lib/math.ts`)
+
+**Why:** `percentile()` is implemented 6 times with two different algorithms — linear interpolation (`src/lib/optimization.ts:28`, `src/lib/queue-analysis.ts:50`, `src/lib/dora.ts:157`, `src/app/api/github/open-pr-health/route.ts:65`) and ceil-index (`src/lib/github.ts:633`, `src/app/api/github/runner-stats/route.ts:38`). Unify on the interpolation variant (majority, and statistically standard). This changes the ceil-index call sites slightly (sub-one-rank differences on small samples) — that is intentional and acceptable for p50/p95 display metrics.
+
+**Files:**
+- Create: `src/lib/math.ts`
+- Test: `tests/math.test.ts`
+- Modify: `src/lib/optimization.ts`, `src/lib/queue-analysis.ts`, `src/lib/dora.ts`, `src/lib/github.ts`, `src/app/api/github/open-pr-health/route.ts`, `src/app/api/github/runner-stats/route.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/math.test.ts`:
+
+```ts
+import { describe, it, expect } from "vitest";
+import { percentile, percentileOf } from "@/lib/math";
+
+describe("percentile", () => {
+  it("returns 0 for empty input", () => {
+    expect(percentile([], 0.5)).toBe(0);
+  });
+
+  it("returns the only element for single-element input", () => {
+    expect(percentile([42], 0.5)).toBe(42);
+    expect(percentile([42], 0.95)).toBe(42);
+  });
+
+  it("returns exact endpoints for p=0 and p=1", () => {
+    expect(percentile([1, 2, 3, 4], 0)).toBe(1);
+    expect(percentile([1, 2, 3, 4], 1)).toBe(4);
+  });
+
+  it("interpolates between closest ranks", () => {
+    // idx = 0.5 * (4-1) = 1.5 -> halfway between 2 and 3
+    expect(percentile([1, 2, 3, 4], 0.5)).toBe(2.5);
+    // idx = 0.95 * 3 = 2.85 -> 3 + (4-3) * 0.85
+    expect(percentile([1, 2, 3, 4], 0.95)).toBeCloseTo(3.85);
+  });
+
+  it("handles two-element arrays", () => {
+    expect(percentile([10, 20], 0.5)).toBe(15);
+    expect(percentile([10, 20], 0.95)).toBe(19.5);
+  });
+});
+
+describe("percentileOf", () => {
+  it("sorts a copy without mutating the input", () => {
+    const input = [9, 1, 5, 3];
+    expect(percentileOf(input, 0.5)).toBe(4);
+    expect(input).toEqual([9, 1, 5, 3]);
+  });
+
+  it("returns 0 for empty input", () => {
+    expect(percentileOf([], 0.9)).toBe(0);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pnpm test tests/math.test.ts`
+Expected: FAIL — cannot resolve `@/lib/math`.
+
+- [ ] **Step 3: Implement `src/lib/math.ts`**
+
+```ts
+/**
+ * Shared percentile helpers.
+ *
+ * Every analytics module must use these instead of local copies. Uses
+ * linear interpolation between closest ranks (the "linear" method — same
+ * as NumPy's default), which is the algorithm 4 of the 6 historical
+ * call sites already used.
+ */
+
+/**
+ * Percentile of an array that is ALREADY sorted ascending. p is in [0, 1].
+ * Returns 0 for empty input (matches every historical call site).
+ */
+export function percentile(sorted: number[], p: number): number {
+  if (!sorted.length) return 0;
+  const idx = p * (sorted.length - 1);
+  const lo = Math.floor(idx);
+  const hi = Math.ceil(idx);
+  return lo === hi ? sorted[lo] : sorted[lo] + (sorted[hi] - sorted[lo]) * (idx - lo);
+}
+
+/** Percentile of an unsorted array — copies and sorts first, input is not mutated. */
+export function percentileOf(values: number[], p: number): number {
+  return percentile([...values].sort((a, b) => a - b), p);
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pnpm test tests/math.test.ts`
+Expected: PASS (7 tests).
+
+- [ ] **Step 5: Replace the interpolation-variant call sites (behavior unchanged)**
+
+`src/lib/optimization.ts` — delete the local `function percentile(arr: number[], p: number)` (line 28, it sorts internally), add to imports at the top:
+
+```ts
+import { percentileOf } from "@/lib/math";
+```
+
+and change the single call site (line 75):
+
+```ts
+    const p95 = percentileOf(waits, 0.95);
+```
+
+`src/lib/queue-analysis.ts` — delete the local `function percentile(sorted: number[], p: number)` (line 50), add import:
+
+```ts
+import { percentile } from "@/lib/math";
+```
+
+Call sites (lines 83, 84, 150) already pass sorted arrays — unchanged.
+
+`src/lib/dora.ts` — delete the local `function percentile(sorted: number[], p: number)` (line 157), add import:
+
+```ts
+import { percentile } from "@/lib/math";
+```
+
+Call sites (lines 208, 209, 419, 420) unchanged.
+
+`src/app/api/github/open-pr-health/route.ts` — delete the local `function percentile(sorted: number[], p: number)` (line 65), add import:
+
+```ts
+import { percentile } from "@/lib/math";
+```
+
+Call sites (lines 263–266) unchanged.
+
+- [ ] **Step 6: Replace the ceil-index call sites (minor behavior change, intentional)**
+
+`src/lib/github.ts` — delete the local `function percentile(sorted: number[], p: number)` (line 633, the `sorted[Math.ceil(p * sorted.length) - 1]` variant), add import near the other lib imports:
+
+```ts
+import { percentile } from "@/lib/math";
+```
+
+Call sites (lines 704, 705, 723) unchanged.
+
+`src/app/api/github/runner-stats/route.ts` — delete the local `function percentile(sorted: number[], p: number)` (line 38, ceil-index variant), add import:
+
+```ts
+import { percentile } from "@/lib/math";
+```
+
+Call site (line 131) unchanged.
+
+- [ ] **Step 7: Full verification**
+
+Run: `pnpm test && pnpm exec tsc --noEmit && pnpm run lint`
+Expected: all existing tests still pass (`dora.test.ts` exercises the interpolation algorithm through `dora.ts`, so it guards against regressions), typecheck clean, lint clean.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/lib/math.ts tests/math.test.ts src/lib/optimization.ts src/lib/queue-analysis.ts src/lib/dora.ts src/lib/github.ts src/app/api/github/open-pr-health/route.ts src/app/api/github/runner-stats/route.ts
+git commit -m "refactor: consolidate six percentile implementations into lib/math"
+```
+
+---
+
+### Task 2: Deduplicate repo-summary construction
+
+**Why:** `getRepoSummary` (`src/lib/github.ts:243-306`) and the inline block inside `getRepoOverview` (`src/lib/github.ts:351-391`, commented "same logic as getRepoSummary") build an identical `RepoSummary` from a runs array. Extract a pure `buildRepoSummary(runs)` and call it from both.
+
+**Files:**
+- Modify: `src/lib/github.ts`
+- Test: `tests/repo-summary.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/repo-summary.test.ts`:
+
+```ts
+import { describe, it, expect } from "vitest";
+import { buildRepoSummary } from "@/lib/github";
+
+const day = (daysAgo: number) => new Date(Date.now() - daysAgo * 86_400_000).toISOString();
+
+const runs = [
+  {
+    id: 3,
+    conclusion: "success" as string | null,
+    status: "completed" as string | null,
+    created_at: day(0),
+    actor: { login: "alice" },
+    head_sha: "abcdef1234567890",
+    head_commit: { message: "Fix thing\n\nlong body" },
+  },
+  {
+    id: 2,
+    conclusion: "failure" as string | null,
+    status: "completed" as string | null,
+    created_at: day(1),
+    actor: null,
+    head_sha: null,
+    head_commit: null,
+  },
+  {
+    id: 1,
+    conclusion: null as string | null,
+    status: "in_progress" as string | null,
+    created_at: day(2),
+    actor: null,
+    head_sha: null,
+    head_commit: null,
+  },
+];
+
+describe("buildRepoSummary", () => {
+  it("exposes the latest run's fields", () => {
+    const s = buildRepoSummary(runs);
+    expect(s.latest_conclusion).toBe("success");
+    expect(s.latest_status).toBe("completed");
+    expect(s.latest_actor).toBe("alice");
+    expect(s.latest_sha).toBe("abcdef1");
+    expect(s.latest_message).toBe("Fix thing");
+  });
+
+  it("computes success rate over completed runs only", () => {
+    const s = buildRepoSummary(runs);
+    // 1 success out of 2 completed (in_progress run excluded)
+    expect(s.success_rate).toBe(50);
+  });
+
+  it("returns recent run points newest-first", () => {
+    const s = buildRepoSummary(runs);
+    expect(s.recent_runs.map((r) => r.id)).toEqual([3, 2, 1]);
+  });
+
+  it("buckets the 30-day trend by calendar day", () => {
+    const s = buildRepoSummary(runs);
+    expect(s.trend_30d).toHaveLength(2);
+    expect(s.trend_30d.every((t) => t.total === 1)).toBe(true);
+    expect(s.trend_30d[1].success).toBe(1); // newest day sorted last
+  });
+
+  it("handles an empty runs array", () => {
+    const s = buildRepoSummary([]);
+    expect(s.latest_conclusion).toBeNull();
+    expect(s.success_rate).toBe(0);
+    expect(s.recent_runs).toEqual([]);
+    expect(s.trend_30d).toEqual([]);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pnpm test tests/repo-summary.test.ts`
+Expected: FAIL — `buildRepoSummary` is not exported from `@/lib/github`.
+
+- [ ] **Step 3: Extract `buildRepoSummary` in `src/lib/github.ts`**
+
+Add this directly above the existing `getRepoSummary` (before line 243). The minimal run shape keeps it usable with both `listWorkflowRunsForRepo` and `listWorkflowRuns` responses:
+
+```ts
+/** Minimal shape buildRepoSummary needs — matches GitHub's workflow_run fields. */
+export interface SummaryRun {
+  id: number;
+  conclusion: string | null;
+  status: string | null;
+  created_at: string;
+  actor?: { login: string } | null;
+  head_sha?: string | null;
+  head_commit?: { message?: string | null } | null;
+}
+
+/**
+ * Build a RepoSummary from a newest-first runs array. Pure — shared by
+ * getRepoSummary (repo-level) and getRepoOverview (per-workflow), which
+ * previously duplicated this logic.
+ */
+export function buildRepoSummary(runs: SummaryRun[]): RepoSummary {
+  const latest = runs[0] ?? null;
+
+  const recent_runs: RepoRunPoint[] = runs.slice(0, 10).map((r) => ({
+    id: r.id,
+    conclusion: r.conclusion ?? null,
+    status: r.status ?? null,
+    created_at: r.created_at,
+  }));
+
+  const completed10 = runs.filter((r) => r.status === "completed").slice(0, 10);
+  const successCount = completed10.filter((r) => r.conclusion === "success").length;
+  const success_rate = completed10.length
+    ? Math.round((successCount / completed10.length) * 100)
+    : 0;
+
+  const now = Date.now();
+  const cutoff = now - 30 * 24 * 60 * 60 * 1000;
+  const buckets: Record<string, { success: number; total: number }> = {};
+  for (const r of runs) {
+    const ts = new Date(r.created_at).getTime();
+    if (ts < cutoff || r.status !== "completed") continue;
+    const day = r.created_at.slice(0, 10);
+    if (!buckets[day]) buckets[day] = { success: 0, total: 0 };
+    buckets[day].total++;
+    if (r.conclusion === "success") buckets[day].success++;
+  }
+  const trend_30d: TrendPoint[] = Object.entries(buckets)
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([date, { success, total }]) => ({ date, success, total }));
+
+  return {
+    latest_conclusion: latest?.conclusion ?? null,
+    latest_status: latest?.status ?? null,
+    latest_run_at: latest?.created_at ?? null,
+    latest_actor: latest?.actor?.login ?? null,
+    latest_sha: latest?.head_sha?.slice(0, 7) ?? null,
+    latest_message: latest?.head_commit?.message?.split("\n")[0] ?? null,
+    recent_runs,
+    trend_30d,
+    success_rate,
+  };
+}
+```
+
+- [ ] **Step 4: Slim down `getRepoSummary` (lines 243-306)**
+
+Replace its body after the fetch with a single call. The function becomes:
+
+```ts
+export async function getRepoSummary(
+  token: string,
+  owner: string,
+  repo: string
+): Promise<RepoSummary> {
+  const octokit = getOctokit(token);
+
+  const { data } = await octokit.rest.actions.listWorkflowRunsForRepo({
+    owner,
+    repo,
+    per_page: 30,
+  });
+
+  return buildRepoSummary(data.workflow_runs);
+}
+```
+
+- [ ] **Step 5: Replace the inline duplicate in `getRepoOverview` (lines 351-391)**
+
+Delete the block from the `// Build summary (same logic as getRepoSummary)` comment through the `};` that closes `const summary: RepoSummary = {`, and replace it with:
+
+```ts
+        const summary = buildRepoSummary(runs);
+```
+
+(The surrounding code — `runs`, then `dur_points` construction, then the `results.push({ ... summary ... })` — stays as-is.)
+
+- [ ] **Step 6: Full verification**
+
+Run: `pnpm test && pnpm exec tsc --noEmit && pnpm run lint`
+Expected: PASS, clean.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/lib/github.ts tests/repo-summary.test.ts
+git commit -m "refactor: extract buildRepoSummary, remove duplicated summary construction"
+```
+
+---
+
+### Task 3: Deduplicate run duration/queue-wait computation
+
+**Why:** Identical `duration_ms`/`queue_wait_ms` math exists in `src/lib/sync.ts:58-68` and `src/app/api/webhooks/github/route.ts:104-114`. Extract `computeRunTiming`. Note: `src/lib/github.ts:526-545` is deliberately NOT touched — that variant uses `completed_at` and a different null-fallback contract for the live-runs API.
+
+**Files:**
+- Create: `src/lib/run-timing.ts`
+- Test: `tests/run-timing.test.ts`
+- Modify: `src/lib/sync.ts`, `src/app/api/webhooks/github/route.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/run-timing.test.ts`:
+
+```ts
+import { describe, it, expect } from "vitest";
+import { computeRunTiming } from "@/lib/run-timing";
+
+describe("computeRunTiming", () => {
+  const base = {
+    created_at: "2026-08-13T10:00:00Z",
+    run_started_at: "2026-08-13T10:00:30Z",
+    updated_at: "2026-08-13T10:05:00Z",
+  };
+
+  it("computes duration and queue wait for completed runs", () => {
+    const t = computeRunTiming({ ...base, status: "completed" });
+    expect(t.queue_wait_ms).toBe(30_000);
+    expect(t.duration_ms).toBe(270_000);
+  });
+
+  it("returns null duration for in-progress runs but keeps queue wait", () => {
+    const t = computeRunTiming({ ...base, status: "in_progress" });
+    expect(t.duration_ms).toBeNull();
+    expect(t.queue_wait_ms).toBe(30_000);
+  });
+
+  it("returns nulls when run_started_at is missing", () => {
+    const t = computeRunTiming({ ...base, status: "completed", run_started_at: null });
+    expect(t.duration_ms).toBeNull();
+    expect(t.queue_wait_ms).toBeNull();
+  });
+
+  it("never returns negative values", () => {
+    const t = computeRunTiming({
+      status: "completed",
+      created_at: "2026-08-13T10:00:30Z",
+      run_started_at: "2026-08-13T10:00:00Z",
+      updated_at: "2026-08-13T09:59:00Z",
+    });
+    expect(t.queue_wait_ms).toBe(0);
+    expect(t.duration_ms).toBe(0);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pnpm test tests/run-timing.test.ts`
+Expected: FAIL — cannot resolve `@/lib/run-timing`.
+
+- [ ] **Step 3: Implement `src/lib/run-timing.ts`**
+
+```ts
+/**
+ * Canonical duration/queue-wait computation for workflow runs.
+ *
+ * Shared by the DB sync path (src/lib/sync.ts) and webhook ingest
+ * (src/app/api/webhooks/github/route.ts) — both must agree byte-for-byte,
+ * because webhook rows and synced rows upsert into the same workflow_runs
+ * table and feed the same Reports charts.
+ *
+ * The live-runs API path in src/lib/github.ts intentionally keeps its own
+ * variant: it prefers the completed_at field and returns undefined (not
+ * null) to match its response type.
+ */
+
+export interface RunTimingInput {
+  status: string | null;
+  run_started_at: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface RunTiming {
+  /** Execution time for completed runs (updated_at - run_started_at); null otherwise. */
+  duration_ms: number | null;
+  /** Time between creation and first job start; null if run_started_at is missing. */
+  queue_wait_ms: number | null;
+}
+
+export function computeRunTiming(r: RunTimingInput): RunTiming {
+  const startedAt = r.run_started_at ? new Date(r.run_started_at).getTime() : null;
+  const updatedAt = new Date(r.updated_at).getTime();
+  const createdAt = new Date(r.created_at).getTime();
+
+  return {
+    duration_ms:
+      r.status === "completed" && startedAt
+        ? Math.max(0, updatedAt - startedAt)
+        : null,
+    queue_wait_ms: startedAt ? Math.max(0, startedAt - createdAt) : null,
+  };
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pnpm test tests/run-timing.test.ts`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Use it in `src/lib/sync.ts`**
+
+Add to the existing imports from local libs (near line 16):
+
+```ts
+import { computeRunTiming } from "@/lib/run-timing";
+```
+
+Replace lines 58-68 (the `startedAt` / `updatedAt` / `createdAt` / `durationMs` / `queueWaitMs` block) with:
+
+```ts
+      const { duration_ms, queue_wait_ms } = computeRunTiming({
+        status: r.status ?? null,
+        run_started_at: r.run_started_at ?? null,
+        created_at: r.created_at,
+        updated_at: r.updated_at,
+      });
+```
+
+and in the `rows.push({...})` below, change the two fields:
+
+```ts
+        duration_ms,
+        queue_wait_ms,
+```
+
+- [ ] **Step 6: Use it in `src/app/api/webhooks/github/route.ts`**
+
+Add the import (with the other `@/lib` imports at the top):
+
+```ts
+import { computeRunTiming } from "@/lib/run-timing";
+```
+
+Replace lines 104-114 (the `// 6. Compute duration and queue wait` block) with:
+
+```ts
+  // 6. Compute duration and queue wait (same math as the sync path)
+  const { duration_ms, queue_wait_ms } = computeRunTiming({
+    status: r.status,
+    run_started_at: r.run_started_at,
+    created_at: r.created_at,
+    updated_at: r.updated_at,
+  });
+```
+
+and in `const row: RunUpsertRow = {...}` change:
+
+```ts
+    duration_ms,
+    queue_wait_ms,
+```
+
+(If the payload type marks these fields optional, pass `r.status ?? null` / `r.run_started_at ?? null` — match whatever `tsc` requires; the math is identical.)
+
+- [ ] **Step 7: Full verification**
+
+Run: `pnpm test && pnpm exec tsc --noEmit && pnpm run lint`
+Expected: PASS, clean.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/lib/run-timing.ts tests/run-timing.test.ts src/lib/sync.ts src/app/api/webhooks/github/route.ts
+git commit -m "refactor: extract computeRunTiming shared by sync and webhook ingest"
+```
+
+---
+
+### Task 4: Persisted weekly-digest dedupe state
+
+**Why:** The Weekly Leadership Digest fires only when `new Date().getUTCDay() === 1` (`src/app/api/cron/sync/route.ts:80`). A missed Monday (deploy, outage, Vercel Hobby cron hiccup) silently skips the whole week, and a manual re-trigger on Monday double-sends. Add a persisted ISO-week marker via a new `app_meta` key/value table, following the existing versioned-migration pattern in `src/lib/db.ts`.
+
+**Design decisions:**
+- Marker updates only when the send actually succeeded or there were zero rules — a fully-failed Monday run stays retryable.
+- The Monday guard stays; the week marker only dedupes within/after that Monday.
+- DB read failure degrades to the old behavior (`lastWeek = null`), never blocks the daily sync.
+
+**Files:**
+- Create: `src/lib/time.ts`
+- Test: `tests/time.test.ts`
+- Modify: `src/lib/db.ts` (migration v5 + `getMeta`/`setMeta`), `src/app/api/cron/sync/route.ts`
+
+- [ ] **Step 1: Write the failing tests for `isoWeekKey`**
+
+Create `tests/time.test.ts`:
+
+```ts
+import { describe, it, expect } from "vitest";
+import { isoWeekKey } from "@/lib/time";
+
+describe("isoWeekKey", () => {
+  it("labels a mid-year week correctly", () => {
+    // 2026-08-13 is a Thursday in ISO week 33
+    expect(isoWeekKey(new Date("2026-08-13T12:00:00Z"))).toBe("2026-W33");
+  });
+
+  it("groups Monday and Sunday of the same ISO week", () => {
+    const monday = isoWeekKey(new Date("2026-08-10T00:00:00Z"));
+    const sunday = isoWeekKey(new Date("2026-08-16T23:59:59Z"));
+    expect(monday).toBe(sunday);
+    expect(monday).toBe("2026-W33");
+  });
+
+  it("assigns Dec 29 2025 to ISO week 2026-W01 (year boundary)", () => {
+    expect(isoWeekKey(new Date("2025-12-29T12:00:00Z"))).toBe("2026-W01");
+  });
+
+  it("assigns Jan 1 2026 to ISO week 2026-W01", () => {
+    expect(isoWeekKey(new Date("2026-01-01T12:00:00Z"))).toBe("2026-W01");
+  });
+
+  it("zero-pads single-digit weeks", () => {
+    expect(isoWeekKey(new Date("2026-01-05T12:00:00Z"))).toBe("2026-W02");
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pnpm test tests/time.test.ts`
+Expected: FAIL — cannot resolve `@/lib/time`.
+
+- [ ] **Step 3: Implement `src/lib/time.ts`**
+
+```ts
+/**
+ * ISO-8601 week helpers for scheduled-job dedupe.
+ */
+
+/**
+ * ISO week key for a date, e.g. "2026-W33". Weeks start on Monday; week 1
+ * is the week containing the year's first Thursday. Used to persist "this
+ * weekly job already ran for this week" markers so re-runs don't double-send
+ * and a single missed day doesn't silently skip the week.
+ */
+export function isoWeekKey(date: Date): string {
+  const d = new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()));
+  const dayNum = d.getUTCDay() || 7; // Mon=1 ... Sun=7
+  d.setUTCDate(d.getUTCDate() + 4 - dayNum); // move to this week's Thursday
+  const yearStart = new Date(Date.UTC(d.getUTCFullYear(), 0, 1));
+  const weekNo = Math.ceil(((d.getTime() - yearStart.getTime()) / 86_400_000 + 1) / 7);
+  return `${d.getUTCFullYear()}-W${String(weekNo).padStart(2, "0")}`;
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pnpm test tests/time.test.ts`
+Expected: PASS (5 tests).
+
+- [ ] **Step 5: Add migration v5 + meta helpers to `src/lib/db.ts`**
+
+Append to the `MIGRATIONS` array (after the version-4 entry ending at line 268):
+
+```ts
+  {
+    version: 5,
+    name: "app_meta",
+    up: [
+      // Key/value state for scheduled jobs (e.g. "leadership_digest_last_week").
+      // Keeps weekly jobs idempotent across missed or repeated cron invocations.
+      `CREATE TABLE IF NOT EXISTS app_meta (
+        key         TEXT PRIMARY KEY,
+        value       TEXT NOT NULL,
+        updated_at  TIMESTAMPTZ DEFAULT NOW()
+      )`,
+    ],
+  },
+```
+
+Add these functions after `markDigestSent` (around line 671), before `updateAlertEventDeliveryStatus`:
+
+```ts
+// ── App metadata (key/value scheduled-job state) ─────────────────────────────
+
+export async function getMeta(key: string): Promise<string | null> {
+  await ensureSchema();
+  const rows = await getDb()`SELECT value FROM app_meta WHERE key = ${key}` as { value: string }[];
+  return rows[0]?.value ?? null;
+}
+
+export async function setMeta(key: string, value: string): Promise<void> {
+  await ensureSchema();
+  await getDb()`
+    INSERT INTO app_meta (key, value, updated_at)
+    VALUES (${key}, ${value}, NOW())
+    ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value, updated_at = NOW()
+  `;
+}
+```
+
+- [ ] **Step 6: Wire the dedupe into `src/app/api/cron/sync/route.ts`**
+
+Update the imports:
+
+```ts
+import { listSyncedRepos, getMeta, setMeta } from "@/lib/db";
+import { isoWeekKey } from "@/lib/time";
+```
+
+Replace the leadership-digest block (lines 79-89, from `// Monday = 1 ...` through the closing `}` of `if (isMonday)`) with:
+
+```ts
+  // Weekly Leadership Digest: Monday guard + persisted ISO-week marker, so a
+  // re-run on the same Monday can't double-send and the marker makes skipped
+  // weeks visible instead of silently lost. DB read failure degrades to the
+  // pre-v4.0.12 behavior (send on Monday regardless).
+  const now = new Date();
+  const isMonday = now.getUTCDay() === 1;
+  const weekKey = isoWeekKey(now);
+  const lastWeek = await getMeta("leadership_digest_last_week").catch(() => null);
+
+  let leadershipDigest: Awaited<ReturnType<typeof sendWeeklyLeadershipDigests>> | { skipped: true } = { skipped: true };
+  if (isMonday && lastWeek !== weekKey) {
+    try {
+      leadershipDigest = await sendWeeklyLeadershipDigests(octokit, process.env.GITHUB_TOKEN);
+      // Mark the week sent only on success (or when there was nothing to send),
+      // so a fully-failed Monday run stays retryable.
+      if (leadershipDigest.sent > 0 || leadershipDigest.rules_processed === 0) {
+        await setMeta("leadership_digest_last_week", weekKey);
+      }
+    } catch (e) {
+      console.error("[cron] Leadership digest error:", e);
+      leadershipDigest = { rules_processed: 0, sent: 0, failures: 1 };
+    }
+  }
+```
+
+Also update the stale header comment (lines 23-26): replace the paragraph starting `* On Mondays (UTC) only, also sends the Weekly Leadership Digest` with:
+
+```ts
+ * On Mondays (UTC) only, also sends the Weekly Leadership Digest (v4.0.3)
+ * to every "leadership_digest" alert rule. A persisted ISO-week marker
+ * (app_meta."leadership_digest_last_week") makes the send idempotent within
+ * a week and keeps fully-failed Mondays retryable.
+```
+
+- [ ] **Step 7: Full verification**
+
+Run: `pnpm test && pnpm exec tsc --noEmit && pnpm run lint`
+Expected: PASS, clean. (The migration runs lazily via `ensureSchema()` — no manual SQL step needed.)
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/lib/time.ts tests/time.test.ts src/lib/db.ts src/app/api/cron/sync/route.ts
+git commit -m "feat: persist weekly leadership digest cadence in app_meta (idempotent cron)"
+```
+
+---
+
+### Task 5: Rate-limit expensive fan-out endpoints
+
+**Why:** Only `/api/auth/setup` and `/api/auth/login` are rate-limited today. Authenticated users can spam org-wide fan-outs (`org-overview`, `org-health-scorecard`, `bus-factor`), each of which fires dozens of GitHub API calls per miss. Add a subject-keyed limiter (token hash, not IP — IPs are spoofable and shared behind NAT) and apply it to the three expensive routes. Cache hits remain cheap, so legitimate UI use is unaffected.
+
+**Files:**
+- Modify: `src/lib/ratelimit.ts`
+- Test: `tests/ratelimit.test.ts`
+- Modify: `src/app/api/github/org-overview/route.ts`, `src/app/api/github/org-health-scorecard/route.ts`, `src/app/api/github/bus-factor/route.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/ratelimit.test.ts`:
+
+```ts
+import { describe, it, expect } from "vitest";
+import { apiRateLimit } from "@/lib/ratelimit";
+
+describe("apiRateLimit", () => {
+  const req = new Request("http://localhost/api/x", {
+    headers: { "x-forwarded-for": "203.0.113.9" },
+  });
+
+  it("allows requests under the budget and blocks over it", () => {
+    for (let i = 0; i < 5; i++) {
+      expect(apiRateLimit(req, "t:over", { limit: 5, windowMs: 60_000 }).allowed).toBe(true);
+    }
+    const blocked = apiRateLimit(req, "t:over", { limit: 5, windowMs: 60_000 });
+    expect(blocked.allowed).toBe(false);
+    expect(blocked.retryAfterMs).toBeGreaterThan(0);
+  });
+
+  it("keys by subject when provided, independent of IP", () => {
+    const a = apiRateLimit(req, "t:sub", { limit: 1, windowMs: 60_000, subject: "hashA" });
+    const b = apiRateLimit(req, "t:sub", { limit: 1, windowMs: 60_000, subject: "hashB" });
+    expect(a.allowed).toBe(true);
+    expect(b.allowed).toBe(true);
+    const aAgain = apiRateLimit(req, "t:sub", { limit: 1, windowMs: 60_000, subject: "hashA" });
+    expect(aAgain.allowed).toBe(false);
+  });
+
+  it("keeps separate budgets per prefix", () => {
+    const x = apiRateLimit(req, "t:px", { limit: 1, windowMs: 60_000 });
+    const y = apiRateLimit(req, "t:py", { limit: 1, windowMs: 60_000 });
+    expect(x.allowed).toBe(true);
+    expect(y.allowed).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pnpm test tests/ratelimit.test.ts`
+Expected: FAIL — `apiRateLimit` is not exported.
+
+- [ ] **Step 3: Add `apiRateLimit` to `src/lib/ratelimit.ts`**
+
+Append after `getRateLimitKey` (line 49):
+
+```ts
+/**
+ * Rate-limit check for expensive API routes. Prefer `subject` = SHA-256 token
+ * hash (from cache.hashKey) for authenticated routes: x-forwarded-for is
+ * spoofable without a trusted proxy and shared behind NAT. Falls back to IP
+ * when no subject is given.
+ */
+export function apiRateLimit(
+  req: Request,
+  prefix: string,
+  opts: { limit: number; windowMs: number; subject?: string | null },
+): { allowed: boolean; retryAfterMs?: number } {
+  const key = opts.subject ? `${prefix}:sub:${opts.subject}` : getRateLimitKey(req, prefix);
+  return rateLimit(key, opts.limit, opts.windowMs);
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pnpm test tests/ratelimit.test.ts`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Apply to the three expensive routes**
+
+The guard is identical in all three — insert it right after the token/validation checks and before any cache/compute work:
+
+```ts
+  const rl = apiRateLimit(req, "<PREFIX>", {
+    limit: <LIMIT>,
+    windowMs: 60_000,
+    subject: hashKey(token),
+  });
+  if (!rl.allowed) {
+    return NextResponse.json(
+      { error: "Rate limit exceeded. Please wait before retrying." },
+      {
+        status: 429,
+        headers: { "Retry-After": String(Math.ceil((rl.retryAfterMs ?? 60_000) / 1000)) },
+      },
+    );
+  }
+```
+
+Per-route values (add `import { apiRateLimit } from "@/lib/ratelimit";` to each; all three already import `hashKey` from `@/lib/cache`):
+
+| Route file | `<PREFIX>` | `<LIMIT>` | Insert after |
+| --- | --- | --- | --- |
+| `src/app/api/github/org-overview/route.ts` | `github:org-overview` | `30` | the `limit` validation (~line 51), before `try {` |
+| `src/app/api/github/org-health-scorecard/route.ts` | `github:org-health-scorecard` | `20` | the `limit` validation (~line 45), before `try {` |
+| `src/app/api/github/bus-factor/route.ts` | `github:bus-factor` | `20` | the `repo` validation (~line 25), before `try {` |
+
+- [ ] **Step 6: Full verification**
+
+Run: `pnpm test && pnpm exec tsc --noEmit && pnpm run lint`
+Expected: PASS, clean.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/lib/ratelimit.ts tests/ratelimit.test.ts src/app/api/github/org-overview/route.ts src/app/api/github/org-health-scorecard/route.ts src/app/api/github/bus-factor/route.ts
+git commit -m "feat: rate-limit expensive org-wide fan-out endpoints by token hash"
+```
+
+---
+
+### Task 6: Helm CronJob for scheduled sync
+
+**Why:** `/api/cron/sync` is only triggered by Vercel Cron (`vercel.json`). Docker/Kubernetes deploys of the Helm chart silently never sync — the chart has no CronJob. Add an opt-in `cron.enabled` CronJob that calls the in-cluster service with `wget` (busybox wget ships in node:20-alpine; curl does not).
+
+**Files:**
+- Create: `helm/gitdash/templates/cronjob.yaml`
+- Modify: `helm/gitdash/values.yaml`, `README.md`
+
+- [ ] **Step 1: Add values**
+
+Append to `helm/gitdash/values.yaml` (after the `serviceAccount:` block, before `terminationGracePeriodSeconds`):
+
+```yaml
+# ── Scheduled sync (Kubernetes equivalent of vercel.json crons) ───────────────
+cron:
+  # Vercel deploys run the sync via vercel.json crons — leave this disabled
+  # there. For Kubernetes deploys, enable this AND ensure GITHUB_TOKEN and
+  # CRON_SECRET are present in the chart secret (or injected via extraEnv).
+  enabled: false
+  schedule: "17 3 * * *"
+  # Hard cap on how long one sync job may run before Kubernetes kills it
+  activeDeadlineSeconds: 600
+  # How many finished Job objects to keep for debugging
+  historyLimit: 3
+```
+
+- [ ] **Step 2: Create `helm/gitdash/templates/cronjob.yaml`**
+
+```yaml
+{{- if .Values.cron.enabled }}
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ include "gitdash.fullname" . }}-sync
+  namespace: {{ include "gitdash.namespace" . }}
+  labels:
+    {{- include "gitdash.labels" . | nindent 4 }}
+spec:
+  schedule: {{ .Values.cron.schedule | quote }}
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: {{ .Values.cron.historyLimit }}
+  failedJobsHistoryLimit: {{ .Values.cron.historyLimit }}
+  jobTemplate:
+    spec:
+      activeDeadlineSeconds: {{ .Values.cron.activeDeadlineSeconds }}
+      template:
+        metadata:
+          labels:
+            {{- include "gitdash.selectorLabels" . | nindent 12 }}
+        spec:
+          restartPolicy: Never
+          {{- with .Values.imagePullSecrets }}
+          imagePullSecrets:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          securityContext:
+            {{- toYaml .Values.podSecurityContext | nindent 12 }}
+          containers:
+            - name: sync
+              image: {{ include "gitdash.image" . }}
+              imagePullPolicy: {{ .Values.image.pullPolicy }}
+              # busybox wget ships with node:20-alpine (curl does not).
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  wget -qO- --header="Authorization: Bearer $CRON_SECRET" \
+                    "http://{{ include "gitdash.fullname" . }}:{{ .Values.service.port }}/api/cron/sync"
+              envFrom:
+                - configMapRef:
+                    name: {{ include "gitdash.configmapName" . }}
+                - secretRef:
+                    name: {{ include "gitdash.secretName" . }}
+              securityContext:
+                {{- toYaml .Values.containerSecurityContext | nindent 16 }}
+              resources:
+                requests:
+                  cpu: 50m
+                  memory: 64Mi
+                limits:
+                  cpu: 100m
+                  memory: 128Mi
+{{- end }}
+```
+
+- [ ] **Step 3: Verify with helm**
+
+Run:
+
+```bash
+helm lint helm/gitdash
+helm template gitdash helm/gitdash --set cron.enabled=true | grep -A5 "kind: CronJob"
+helm template gitdash helm/gitdash | grep -c "kind: CronJob" || true
+```
+
+Expected: lint passes; the first template render contains a CronJob named `<fullname>-sync` with schedule `"17 3 * * *"`; the second render (cron disabled by default) outputs `0`.
+
+- [ ] **Step 4: Document in README**
+
+In `README.md`, in the "Optional: Historical DB + Webhooks" section, replace the bullet about `/api/cron/sync` with:
+
+```markdown
+- `/api/cron/sync` re-syncs every previously-synced repo daily. On Vercel this is wired via `vercel.json` crons; on Kubernetes set `cron.enabled: true` in `helm/gitdash/values.yaml` (requires `GITHUB_TOKEN` and `CRON_SECRET` in the chart secret)
+```
+
+- [ ] **Step 5: Full verification**
+
+Run: `pnpm test && pnpm exec tsc --noEmit && pnpm run lint && helm lint helm/gitdash`
+Expected: all clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add helm/gitdash/templates/cronjob.yaml helm/gitdash/values.yaml README.md
+git commit -m "feat: add optional Helm CronJob for scheduled sync (parity with Vercel crons)"
+```
+
+---
+
+## Rollback
+
+Every task is an independent commit — `git revert <sha>` per task. Notes:
+
+- Task 4: reverting drops the `app_meta` table usage; the table itself is harmless to leave.
+- Task 6: default `cron.enabled: false` — zero impact unless explicitly enabled.
+- Task 1's behavior change (ceil-index → interpolation in `github.ts` job-stats and `runner-stats`) is the only metric-visible change: p50/p95 values on small samples shift by at most one rank.
+
+## Out of scope (follow-up plans)
+
+- Route-level test coverage for middleware/webhook HMAC, `db.ts` alert evaluation.
+- Splitting `docs/page.tsx` (3187 lines) and `db.ts`.
+- Multi-replica cache/rate-limit sharing (Redis/DB-backed).
+- `updateAlertRule` single-statement transaction.

--- a/docs/plans/2026-08-14-ai-features-plan.md
+++ b/docs/plans/2026-08-14-ai-features-plan.md
@@ -1,0 +1,604 @@
+# GitDash AI Features Implementation Plan (v4.1.0)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Design spec:** [`docs/specs/2026-08-14-ai-features-design.md`](../specs/2026-08-14-ai-features-design.md) — read it first. This plan implements rev 2 of that spec; where the two disagree, the spec wins.
+
+**Goal:** Add an LLM insight layer over existing computed metrics — an AI Insights panel (F1), anomaly explanations (F4), an AI executive summary in the weekly digest (F2), and failure root-cause hypotheses (F3) — gated entirely by env-key presence so a deployment with no AI keys behaves exactly as v4.0.11 does today.
+
+**Shipped as four independent releases: v4.1.0 → v4.1.3. One feature = one version = one PR.**
+
+**Architecture:** One provider module (`src/lib/ai.ts`, raw `fetch`, zero new deps), pure allowlisting snapshot builders (`src/lib/ai-snapshots.ts`), versioned prompt constants (`src/lib/ai-prompts.ts`), and thin GET route handlers under `src/app/api/ai/`. No database schema changes. No new GitHub API surface — every fetch reuses an existing function.
+
+**Tech Stack:** Next.js 16 route handlers, React 19, TypeScript strict, vitest (tests in `tests/**`, alias `@` → `src`), Tailwind v4.
+
+---
+
+## Context for the implementer
+
+- Repo: `/Users/thi/Devops/gitdash`. Package manager is **pnpm** (`corepack enable pnpm`), pinned via `packageManager` in `package.json`.
+- Commands: `pnpm run lint`, `pnpm exec tsc --noEmit`, `pnpm test` (vitest run). Tests live in `tests/*.test.ts` and import via `@/lib/...`.
+- Commit style: Conventional Commits (`feat:`, `fix:`, `refactor:`) with a short imperative summary. **Never add `Co-Authored-By`.**
+- There is no TODO/FIXME culture here — write header comments in the style of the surrounding files (block comment explaining *why*, not *what*).
+- Every task ends with lint + typecheck + tests green, then one commit.
+
+### 🔒 Release discipline — applies to every phase, no exceptions
+
+This repo ships **one feature per version per PR**, established in v4.0.0–v4.0.3
+and reaffirmed by the owner. Four releases in this plan:
+
+| Release | Phase | Contents |
+| --- | --- | --- |
+| **v4.1.0** (chart `0.5.0`) | 0 + 1 | Core AI layer + F1 AI Insights Panel |
+| **v4.1.1** (chart `0.5.1`) | 2 | F4 Anomaly Explanations |
+| **v4.1.2** (chart `0.5.2`) | 3 | F2 AI Leadership Digest |
+| **v4.1.3** (chart `0.5.3`) | 4 | F3 Root-Cause Hypotheses |
+
+> If F2 is still blocked by the email precondition when its turn comes, **skip it
+> and ship F3 as v4.1.2.** Never reserve a version for an unshipped feature.
+
+**Every release ends with the Release Checklist below. Do not defer it to the end
+of the plan — an unreleased phase is an unfinished phase.**
+
+<a id="release-checklist"></a>
+### ✅ Release Checklist (repeat verbatim at the end of each phase)
+
+- [ ] **Bump the version in all 7 locations** — a release is incomplete if any is missed:
+  | # | File | What |
+  | --- | --- | --- |
+  | 1 | `package.json` | `"version": "X.Y.Z"` |
+  | 2 | `helm/gitdash/Chart.yaml` | `version:` (chart — see mapping table above) |
+  | 3 | `helm/gitdash/Chart.yaml` | `appVersion: "X.Y.Z"` |
+  | 4 | `src/app/docs/page.tsx` | `ReleaseNotes()` — **insert** new top entry, `badge: "latest"` |
+  | 5 | `src/app/docs/page.tsx` | demote previous top entry to `badge: null` |
+  | 6 | `src/app/docs/page.tsx` | `NEXT_PUBLIC_APP_VERSION ?? "X.Y.Z"` — sidebar badge |
+  | 7 | `src/app/docs/page.tsx` | `NEXT_PUBLIC_APP_VERSION ?? "X.Y.Z"` — footer |
+  | 8 | `CHANGELOG.md` | new `## [X.Y.Z] — YYYY-MM-DD` section at the top |
+
+  > ⚠️ **Step 4 has been broken before** (v4.0.4): an edit *overwrote* the previous
+  > top entry instead of inserting above it. After editing, re-read the file and
+  > confirm **both** entries exist with the correct badges.
+
+  Self-check:
+  ```bash
+  grep -n 'NEXT_PUBLIC_APP_VERSION ?? "' src/app/docs/page.tsx   # both must show the new version
+  grep -n '"version"' package.json
+  grep -n "^version:\|^appVersion:" helm/gitdash/Chart.yaml
+  grep -n 'version: "' src/app/docs/page.tsx | head -3           # top 2 release entries
+  ```
+
+- [ ] **Docs — the feature gets its own page** (not just a changelog line):
+  1. `feat-*` entry in the docs `NAV` array under **Features**
+  2. Index card in `Features()` with `since: "X.Y.Z"` → renders the `VersionBadge`
+  3. Detail component registered in `SECTION_COMPONENTS`
+  4. Any new `/api/*` rows added to the **API Reference** section
+
+- [ ] **CHANGELOG entry** in the established format: `### Overview`, `### Added`
+      (one `####` per feature), `### Rollback`, `### Changed (infra)`.
+      Rollback section must list all three levers: unset AI env keys · promote
+      previous Vercel deployment · `git revert` (no migration).
+
+- [ ] **Full verification gate** (below) — all green.
+
+- [ ] **PR** — `gh pr create` with a test-plan checklist in the body.
+      **Wait for the owner to merge. Never self-merge.**
+
+- [ ] **After merge:** `git checkout main && git pull origin main` before starting
+      the next phase.
+
+### Verification gate
+
+Run after every task (first three) and in full before every release commit:
+
+```bash
+pnpm exec tsc --noEmit           # must be 0 errors
+pnpm test                         # all green — record the count for the PR body
+pnpm exec eslint <changed files>  # 0 errors (pre-existing warnings elsewhere are OK)
+rm -rf .next && pnpm run build    # must succeed
+
+# API Reference parity — documented paths vs actual routes:
+grep -o 'path: "/api/[^"]*"' src/app/docs/page.tsx | sed 's/path: "//;s/"//' | sort -u > /tmp/documented.txt
+find src/app/api -name route.ts | sed 's|src/app||;s|/route.ts||' | sort -u > /tmp/actual.txt
+comm -13 /tmp/documented.txt /tmp/actual.txt   # must be empty (no undocumented routes)
+```
+
+**Baseline at v4.0.11 (verified 2026-08-14):** 0 tsc errors · 63/63 tests ·
+0 lint errors (11 pre-existing warnings) · build succeeds · route parity clean.
+**Any regression against this baseline blocks the release.**
+
+### Branch workflow
+
+```bash
+git checkout main && git pull origin main
+git checkout -b feat/vX.Y.Z-<slug>
+# …tasks, one commit each…
+# …Release Checklist…
+git push -u origin feat/vX.Y.Z-<slug>
+gh pr create --title "feat: vX.Y.Z — <feature>" --body "…"
+```
+
+> ⚠️ **Known hazard:** a PR merged before a later commit is pushed silently drops
+> that commit (this happened with the v4.0.6 screenshots — they had to be
+> re-landed in a follow-up PR). Confirm `git status` is clean and the branch is
+> fully pushed **before** asking for merge.
+
+### Ground rules specific to this feature
+
+1. **Never log prompt content or snapshot payloads.** Log provider, model, latency, HTTP status, token counts only.
+2. **Never send** to a provider: tokens, run logs, file contents, workflow YAML, PR/commit message bodies, email addresses. Logins and repo/workflow/step names are allowed.
+3. **Every AI route calls `aiEnabled()` itself.** The client feature flag is localStorage-backed and is not a security control.
+4. **`generateJson` never throws.** Every failure path returns an `AiFailure`.
+5. **Every AI route declares `export const maxDuration = 60;`**
+
+---
+
+## Phase 0 + 1 → **Release v4.1.0** (chart `0.5.0`)
+
+**Branch:** `feat/v4.1.0-ai-insights`
+**Contents:** core AI layer (tasks 0a–0c) + F1 AI Insights Panel (tasks 1a–1d) + release (task 1e).
+**Why bundled:** the core layer produces no user-visible surface on its own — releasing it alone would mean a version bump whose release notes describe nothing a user can see. They remain separate *commits*, so F1 can be reverted independently of the layer.
+
+### Task 0a: Provider module (`src/lib/ai.ts`)
+
+**Why:** One place that owns keys, provider fallback, timeouts, budget accounting, and the never-throw contract. Everything else in this plan depends on it.
+
+**Files:**
+- Create: `src/lib/ai.ts`
+- Create: `tests/ai.test.ts`
+- Modify: `.env.local.example`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/ai.test.ts`. Mock `globalThis.fetch` with `vi.fn()`; reset `process.env` and module state between tests (`vi.resetModules()` + dynamic `await import("@/lib/ai")` so env is re-read).
+
+Cover:
+
+```ts
+describe("aiEnabled", () => {
+  it("false when no keys are set");
+  it("false when AI_DISABLED=true even with keys");
+  it("true when GEMINI_API_KEY is set");
+  it("true when only QWEN_API_KEY is set");
+});
+
+describe("configuredProviders", () => {
+  it("returns [] with no keys");
+  it("returns ['gemini','qwen'] in priority order when both keys set");
+  it("never includes key material in its output");
+});
+
+describe("generateJson", () => {
+  it("returns {ok:false, reason:'no_keys'} when unconfigured — and does not call fetch");
+  it("returns {ok:false, reason:'disabled'} when AI_DISABLED=true");
+  it("posts to <GEMINI_BASE_URL>/chat/completions with response_format json_object and temperature 0.2");
+  it("returns ok:true with provider 'gemini' on a 200");
+  it("falls back to qwen on a 401 from gemini WITHOUT retrying gemini");
+  it("retries once after a 429, then falls back to qwen");
+  it("falls back to qwen on a 500");
+  it("returns reason:'provider_error' when all providers fail");
+  it("returns reason:'timeout' when a provider exceeds AI_TIMEOUT_MS");
+  it("returns reason:'timeout' when the total budget is exhausted mid-fallback");
+  it("returns reason:'budget_exceeded' once the daily token budget is spent — without calling fetch");
+  it("never throws, for every failure mode above");
+});
+```
+
+- [ ] **Step 2: Implement `src/lib/ai.ts`**
+
+Export exactly the interface in spec §3.1 (`AiProvider`, `AiSuccess`, `AiFailure`, `AiResult`, `aiEnabled`, `configuredProviders`, `generateJson`).
+
+Implementation notes:
+
+- Read env **inside** the functions, not at module scope, so tests can vary it.
+- Provider config table:
+  ```ts
+  const PROVIDERS = [
+    { name: "gemini" as const, keyEnv: "GEMINI_API_KEY", baseEnv: "GEMINI_BASE_URL",
+      modelEnv: "GEMINI_MODEL",
+      defaultBase: "https://generativelanguage.googleapis.com/v1beta/openai",
+      defaultModel: "gemini-2.5-flash" },
+    { name: "qwen" as const, keyEnv: "QWEN_API_KEY", baseEnv: "QWEN_BASE_URL",
+      modelEnv: "QWEN_MODEL",
+      defaultBase: "https://dashscope-intl.aliyuncs.com/compatible-mode/v1",
+      defaultModel: "qwen-plus" },
+  ];
+  ```
+- Request shape (both providers are OpenAI-compatible):
+  ```ts
+  await fetch(`${baseUrl}/chat/completions`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", Authorization: `Bearer ${key}` },
+    body: JSON.stringify({
+      model,
+      messages: [
+        { role: "system", content: systemPrompt },
+        { role: "user", content: JSON.stringify(userPayload) },
+      ],
+      temperature: opts?.temperature ?? 0.2,
+      max_tokens: opts?.maxOutputTokens ?? 900,
+      response_format: { type: "json_object" },
+    }),
+    signal: attemptController.signal,
+  });
+  ```
+- **Total-budget guard:** compute `const deadline = Date.now() + totalBudgetMs` once at the top. Before each attempt, `if (Date.now() >= deadline) return { ok:false, reason:"timeout", … }`. Each attempt's own timeout is `Math.min(perAttemptMs, deadline - Date.now())`.
+- **Daily token counter:** module-level `let budget = { day: "", tokens: 0 }`. Key on `new Date().toISOString().slice(0,10)`; reset when the day changes. Add `usage.prompt_tokens + usage.completion_tokens` after each success. Short-circuit when `AI_DAILY_TOKEN_BUDGET > 0 && budget.tokens >= limit`. **Write a header comment stating plainly that this is per-instance and therefore a damage-limiter, not a global cap** (spec §6.2).
+- Extract `content` from `json.choices?.[0]?.message?.content`. If missing/empty → treat as a provider error and fall through.
+
+- [ ] **Step 3: Add the env block to `.env.local.example`**
+
+Match the file's existing comment style (`# ── Section ──` headers, commented-out values):
+
+```bash
+# ── AI features (optional) ────────────────────────────────────────────────────
+# When no key is set, every AI surface is hidden and GitDash behaves exactly as
+# it did before v4.1.0. Gemini is tried first, Qwen is the fallback.
+# GEMINI_API_KEY=...
+# GEMINI_MODEL=gemini-2.5-flash
+# QWEN_API_KEY=...
+# QWEN_MODEL=qwen-plus
+#
+# Safety valves:
+# AI_DISABLED=true              # hard-kill the layer regardless of keys
+# AI_TIMEOUT_MS=15000           # per provider attempt
+# AI_TOTAL_BUDGET_MS=45000      # across all attempts in one request
+# AI_DAILY_TOKEN_BUDGET=2000000 # per instance per UTC day; 0 = unlimited
+```
+
+- [ ] **Step 4: Verify + commit** — `feat: add AI provider layer with Gemini/Qwen fallback`
+
+**Acceptance:** all `tests/ai.test.ts` green; no network calls in CI; `grep -rn "console.log" src/lib/ai.ts` shows no payload logging.
+
+---
+
+### Task 0b: Status route, hook, and feature flag
+
+**Why:** The UI needs a cheap way to ask "is AI configured?" without exposing keys, and the flag needs to exist before any surface can reference it.
+
+**Files:**
+- Create: `src/app/api/ai/status/route.ts`
+- Create: `src/lib/use-ai-enabled.ts` (there is no `src/hooks/` dir in this repo; client-side hooks live in `src/lib` — precedent: `src/lib/swr.tsx`)
+- Modify: `src/lib/ratelimit.ts` (add `aiRateLimit`)
+- Modify: `src/lib/feature-flags.ts` (add `aiInsights`)
+- Modify: `src/app/settings/page.tsx` (flag row)
+
+- [ ] **Step 1: Add `aiRateLimit` to `src/lib/ratelimit.ts`**
+
+```ts
+/**
+ * Token-hash-keyed limiter for authenticated, cost-bearing routes.
+ *
+ * The existing getRateLimitKey() keys on IP, which is wrong for AI routes:
+ * cost follows the *token* (one user behind changing IPs should still be
+ * limited). Callers pass hashKey(token) from src/lib/cache.ts.
+ */
+export function aiRateLimit(
+  tokenHash: string,
+  surface: string,
+  limit: number,
+): { allowed: boolean; retryAfterMs?: number } {
+  return rateLimit(`ai:${surface}:${tokenHash}`, limit, 60_000);
+}
+```
+
+- [ ] **Step 2: Add the `aiInsights` flag**
+
+In `src/lib/feature-flags.ts`, add `aiInsights: boolean;` to `FeatureFlags` and `aiInsights: true` to `DEFAULT_FLAGS`. (Defaulting to `true` is correct — the env-key check is the real gate, so a flag default of `true` means "show it once keys exist.")
+
+In `src/app/settings/page.tsx`, add a row alongside the existing entries (~line 138):
+
+```ts
+{ key: "aiInsights", label: "AI Insights", description: "LLM-generated analysis of your metrics. Requires AI provider keys to be configured on the server.", affects: "Repository Overview, Organization Health, Workflow Detail" },
+```
+
+- [ ] **Step 3: Implement `/api/ai/status`**
+
+```ts
+export const maxDuration = 60;
+
+export async function GET() {
+  const token = await getTokenFromSession();
+  if (!token) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  return NextResponse.json(
+    { enabled: aiEnabled(), providers: configuredProviders() },
+    { headers: { "Cache-Control": "private, max-age=60" } },
+  );
+}
+```
+
+Do **not** add this path to `ALWAYS_PUBLIC` in `src/middleware.ts` — it must stay behind session auth.
+
+- [ ] **Step 4: Implement the `useAiEnabled()` hook**
+
+Thin SWR wrapper over `/api/ai/status` returning `{ enabled: boolean; providers: string[]; isLoading: boolean }`. Use the existing `fetcher` from `@/lib/swr`. Because `SWRProvider` sets `dedupingInterval: 600_000`, all call sites share one request automatically — no extra caching needed.
+
+- [ ] **Step 5: Verify + commit** — `feat: add /api/ai/status, useAiEnabled hook, and aiInsights flag`
+
+**Acceptance:** `/api/ai/status` returns `{enabled:false, providers:[]}` with no keys set, 401 unauthenticated, and never includes key material.
+
+---
+
+### Task 0c: Route-handler test pattern
+
+**Why:** Spec §7.1 — this repo has zero route-handler tests and `vitest.config.ts` scopes coverage to `src/lib/**`. Establish the pattern once, on the simplest route, before four more routes depend on it.
+
+**Files:**
+- Create: `tests/api-ai-status.test.ts`
+
+- [ ] **Step 1: Attempt the direct approach**
+
+Import the route handler and mock its dependencies:
+
+```ts
+vi.mock("@/lib/session", () => ({ getTokenFromSession: vi.fn() }));
+vi.mock("@/lib/ai", () => ({ aiEnabled: vi.fn(), configuredProviders: vi.fn() }));
+
+const { GET } = await import("@/app/api/ai/status/route");
+```
+
+Assert: 401 when `getTokenFromSession` resolves `null`; `{enabled:true, providers:["gemini"]}` when mocked so.
+
+- [ ] **Step 2: If Step 1 is awkward, use the extract-to-lib fallback**
+
+If mocking `next/headers`/iron-session fights back, **stop and refactor instead** — this is the preferred outcome, not a defeat. Extract the logic into a pure function in `src/lib/` taking its dependencies as arguments, unit-test that, and leave the route as a 5-line adapter. Precedent: `computeScorecard` (v4.0.3) and `computeBusFactor` (v4.0.0) were both extracted out of their routes for exactly this reason.
+
+Record which approach won in the test file's header comment, so tasks 1–4 follow it without re-deciding.
+
+- [ ] **Step 3: Verify + commit** — `test: establish route-handler test pattern for AI routes`
+
+**Acceptance:** the chosen pattern is documented in a header comment and is reusable by the remaining four routes.
+
+---
+
+### Task 1a: Insights snapshot builder
+
+**Why:** The snapshot is the privacy enforcement point (spec §3.3) — it must exist and be tested before anything sends data anywhere.
+
+**Files:**
+- Create: `src/lib/ai-snapshots.ts`
+- Create: `tests/ai-snapshots.test.ts`
+
+- [ ] **Step 1: Write the failing tests, including the privacy assertion**
+
+The privacy test is the important one. Write a reusable helper and use it in every snapshot test in this plan:
+
+```ts
+const FORBIDDEN_KEYS = ["token", "pat", "accessToken", "logs", "log", "body",
+  "content", "yaml", "yml", "message", "patch", "diff", "email"];
+
+function assertNoForbiddenKeys(obj: unknown, path = "$") {
+  if (obj === null || typeof obj !== "object") return;
+  for (const [k, v] of Object.entries(obj as Record<string, unknown>)) {
+    expect(FORBIDDEN_KEYS, `forbidden key at ${path}.${k}`).not.toContain(k);
+    assertNoForbiddenKeys(v, `${path}.${k}`);
+  }
+}
+```
+
+Then: build a snapshot from fixtures and assert exact shape + `assertNoForbiddenKeys(snapshot)`.
+
+- [ ] **Step 2: Implement `buildInsightsSnapshot`**
+
+```ts
+export async function buildInsightsSnapshot(
+  token: string,
+  scope: { surface: "repo"; owner: string; repo: string }
+        | { surface: "org"; org: string },
+): Promise<InsightsSnapshot>;
+```
+
+Reuse **only** these (verified symbols, spec §3.3): `getRepoSummary`, `calculateRepoDora` / `calculateDoraMetrics`, `computeBusFactor`, `computeScorecard`, `detectAnomalies`, `listWorkflowFileCommits`.
+
+Build the object field-by-field — **never spread a raw API object into the snapshot.** For `recent_workflow_changes`, map `WorkflowFileCommit` down to `{ date, author_login }` only; the source type has `message`, `sha`, and `html_url`, none of which may be included.
+
+Use `pLimitSettled` from `src/lib/concurrency.ts` for any fan-out, matching how `computeScorecard` does it.
+
+- [ ] **Step 3: Verify + commit** — `feat: add insights snapshot builder with allowlisted fields`
+
+**Acceptance:** `assertNoForbiddenKeys` passes; snapshot contains no field absent from the `InsightsSnapshot` interface.
+
+---
+
+### Task 1b: Prompts module + response validation
+
+**Files:**
+- Create: `src/lib/ai-prompts.ts`
+- Create: `src/lib/ai-schema.ts`
+- Create: `tests/ai-schema.test.ts`
+
+- [ ] **Step 1: `src/lib/ai-prompts.ts`** — export the system prompts from spec §4 as versioned `const` strings (`INSIGHTS_SYSTEM_PROMPT`, later `ANOMALY_SYSTEM_PROMPT`, `DIGEST_SYSTEM_PROMPT`, `ROOT_CAUSE_SYSTEM_PROMPT`). Copy them verbatim from the spec.
+
+- [ ] **Step 2: `src/lib/ai-schema.ts`** — pure validators, no deps:
+
+```ts
+export interface InsightsContent { summary: string; bullets: string[]; actions: string[]; }
+export function parseInsightsContent(raw: string): InsightsContent | null;
+```
+
+Rules: `JSON.parse` in a try/catch (return `null`, never throw); require `summary` string ≤ 400 chars; `bullets` string[] ≤ 6, each ≤ 200 chars; `actions` string[] ≤ 4, each ≤ 200 chars. Trim strings; drop extra keys.
+
+- [ ] **Step 3: Tests** — valid payload; missing key; wrong types; oversize summary; too many bullets; non-JSON garbage; JSON wrapped in ```` ```json ```` fences (models do this — strip fences before parsing).
+
+- [ ] **Step 4: Verify + commit** — `feat: add AI prompt constants and response schema validation`
+
+---
+
+### Task 1c: `/api/ai/insights` route
+
+**Files:**
+- Create: `src/app/api/ai/insights/route.ts`
+- Create: `tests/api-ai-insights.test.ts` (following task 0c's pattern)
+
+- [ ] **Step 1: Implement**, following the handler shape in spec §3.2 exactly. Params: `owner`+`repo` (repo surface) or `org` (org surface); validate with `validateOwner`/`validateRepo`/`validateOrg`. Rate limit 20/min. Cache TTL 900s, key `ai:insights:${tokenHash}:${scope}:${fingerprint}`.
+
+  Support `?refresh=1` to bypass cache (call the factory directly, then write through). Still rate-limited — do not let refresh become an unmetered path.
+
+  On `parseInsightsContent` returning `null`, retry `generateJson` **once**, then map to 503.
+
+- [ ] **Step 2: Tests** — 401 unauthenticated; 503 when `aiEnabled()` false; 429 over rate limit; 503 on `AiFailure`; 200 + `cached:true` on second identical call; `budget_exceeded` → 429.
+
+- [ ] **Step 3: Verify + commit** — `feat: add /api/ai/insights route`
+
+---
+
+### Task 1d: `AiInsightsCard` component + page wiring
+
+**Files:**
+- Create: `src/components/AiInsightsCard.tsx`
+- Modify: `src/app/repos/[owner]/[repo]/page.tsx`
+- Modify: `src/app/org/[orgName]/health/page.tsx`
+
+- [ ] **Step 1: Build the card.** Reuse the collapsible `Section` visual pattern established in v4.0.11 (`src/app/repos/[owner]/[repo]/team/page.tsx` — tone-colored icon badge, title, count badge, description, Show/Hide pill). Use `Sparkles` from lucide, violet tone.
+
+  States, all required:
+  - **Loading** — spinner + "Analysing your metrics…" (follow the v4.0.10 precedent in the health page: a bare skeleton reads as frozen; a spinner + status line reads as working).
+  - **Success** — `summary` paragraph, `bullets` list, `actions` list under an "Actions" subheading.
+  - **Unavailable (503)** — muted one-liner, card stays collapsed. Never an error-red box; this is an optional enhancement, not a failure.
+  - **Rate-limited (429)** — "Try again in a minute."
+  - Always render a small provider/model attribution line and a "Regenerate" button.
+
+- [ ] **Step 2: Wire into both pages.** Render only when `useAiEnabled().enabled && flags.aiInsights`. When either is false, render **nothing** — no placeholder, no "enable this" nag.
+
+- [ ] **Step 3: Verify + commit** — `feat: add AI Insights card to repo overview and org health pages`
+
+**Acceptance:** with no AI keys configured, both pages are byte-identical in behavior to v4.0.11.
+
+---
+
+### Task 1e: 🚢 Release v4.1.0
+
+**Files:** `package.json`, `helm/gitdash/Chart.yaml`, `CHANGELOG.md`, `src/app/docs/page.tsx`, `README.md`, `.env.local.example`
+
+- [ ] **Step 1: Docs — AI transparency section.** New `feat-ai-insights` entry in `NAV` under Features, index card in `Features()` with `since: "4.1.0"`, and a detail component in `SECTION_COMPONENTS`. Must state explicitly:
+  - which providers receive data, and that keys are server-side only;
+  - the exact allowlist of what is sent (metrics, repo/workflow/job/step names, **logins**, dates);
+  - the explicit never-sent list (tokens, logs, code, YAML, PR/commit bodies, emails);
+  - that all surfaces disappear when no keys are configured.
+
+- [ ] **Step 2: API Reference** — add `/api/ai/status` and `/api/ai/insights` rows, then run the parity check (must print nothing).
+
+- [ ] **Step 3: README** — add an "AI Insights" row to the capability table (~line 50).
+
+- [ ] **Step 4: Run the full [Release Checklist](#release-checklist)** — version to `4.1.0`, chart to `0.5.0`.
+
+- [ ] **Step 5: Commit + PR** — `feat: v4.1.0 — AI insight layer and AI Insights panel`.
+  PR body must include the test-plan checklist, the recorded test count, and a one-line note that the feature is inert without env keys. Then flag the four reviewer notes at the bottom of this plan.
+
+---
+
+## Phase 2 → **Release v4.1.1** (chart `0.5.1`) — F4: Anomaly Explanations
+
+**Branch:** `feat/v4.1.1-anomaly-explanations` (off freshly pulled `main`)
+
+### Task 2a: Anomaly snapshot builder
+
+**Files:** Modify `src/lib/ai-snapshots.ts`, `tests/ai-snapshots.test.ts`
+
+- [ ] **Step 1:** Implement `buildAnomalySnapshot(token, { owner, repo, workflow_id, metric })`.
+
+  **Note the server-side rebuild** (spec §F4): call `listWorkflowRuns(token, owner, repo, workflow_id, 50)`, map to `AnomalyInputRun[]`, then run `detectAnomalies` + `computeBaseline` server-side. The client already computed these, but snapshots must be server-assembled. Cap `outliers` at 5, most recent first. Add `listWorkflowFileCommits(token, owner, repo, 10)` for `concurrent_signals`, mapped to `{ date, author_login }` only.
+
+- [ ] **Step 2:** Tests including `assertNoForbiddenKeys`.
+- [ ] **Step 3:** Commit — `feat: add anomaly snapshot builder`
+
+### Task 2b: Route + UI
+
+**Files:** Create `src/app/api/ai/anomaly-explanation/route.ts`, `tests/api-ai-anomaly.test.ts`; modify `src/app/repos/[owner]/[repo]/workflows/[workflow_id]/page.tsx`; add `parseAnomalyContent` to `src/lib/ai-schema.ts`.
+
+- [ ] **Step 1:** Route — params `owner`, `repo`, `workflow_id` (`validateId`), `metric` (must be exactly `"duration"` or `"queue_wait"`; reject anything else with a 400 — do not pass user strings through to a prompt). Rate limit 20/min, TTL 1800s.
+- [ ] **Step 2:** `parseAnomalyContent` → `{ explanation: string; check: string }`, each ≤ 400 chars.
+- [ ] **Step 3:** UI — a "Why?" button under each anomaly badge that lazy-fetches (SWR key `null` until clicked). Inline result, no modal.
+- [ ] **Step 4:** Verify + commit — `feat: add AI anomaly explanations to workflow detail`
+
+### Task 2c: 🚢 Release v4.1.1
+
+- [ ] **Step 1: Docs** — new `feat-ai-anomaly` page (NAV + index card `since: "4.1.1"` + detail component), and add the `/api/ai/anomaly-explanation` API Reference row.
+- [ ] **Step 2: Amend the transparency section** — F4 sends actor logins and trigger names; confirm the allowlist wording still covers it, and widen it if not.
+- [ ] **Step 3: Full [Release Checklist](#release-checklist)** — version `4.1.1`, chart `0.5.1`.
+- [ ] **Step 4: Commit + PR** — `feat: v4.1.1 — AI anomaly explanations`.
+
+---
+
+## Phase 3 → **Release v4.1.2** (chart `0.5.2`) — F2: AI Leadership Digest
+
+> ### ⚠️ Gate — do not start until this is true
+> `RESEND_API_KEY` or `SMTP_HOST` is configured **and** a real weekly digest email has been received. Until then `deliverLeadershipDigestEmail` (`src/lib/notifier.ts:304`) returns `{ok:false, "No email provider configured"}` and this whole phase ships something no one can see.
+>
+> **If still blocked when you reach this point: skip to Phase 4 and revisit.**
+
+### Task 3a: Digest snapshot, escaping, and AI summary
+
+**Files:** Modify `src/lib/notifier.ts`, `src/lib/sync.ts`, `src/lib/ai-snapshots.ts`, `src/lib/ai-prompts.ts`, `tests/notifier.test.ts`
+
+- [ ] **Step 1: Add `escapeHtml()` to `src/lib/notifier.ts`** and apply it to the new `aiSummary` **and** to the existing `summary_line` / `highlights` / `concerns` interpolations. Those are currently un-escaped; same helper, same file, fix them together.
+
+- [ ] **Step 2:** Extend `LeadershipDigestEmailInput` with `aiSummary?: string`. Render it above the existing narrative under an explicit `<h3>AI summary</h3>` heading (transparency requirement, spec §5.7) in the HTML body, and as an `AI summary:` block in the text body.
+
+- [ ] **Step 3:** In `sendWeeklyLeadershipDigests` (`src/lib/sync.ts:178`), after `generateLeadershipNarrative`, call `generateJson` with the digest snapshot. Wrap in try/catch **and** check `result.ok` — on any failure, log and pass `aiSummary: undefined`. The digest must send regardless.
+
+- [ ] **Step 4: Test the failure path explicitly** — mock `generateJson` to return `AiFailure` and assert the email still sends with the rule-based narrative intact. This is the single most important test in this phase.
+
+- [ ] **Step 5:** Verify + commit — `feat: add AI executive summary to weekly leadership digest`
+
+### Task 3b: 🚢 Release v4.1.2
+
+- [ ] **Step 1: Docs** — extend the existing **Leadership Digest** feature page (added in v4.0.6) with an "AI summary" subsection carrying a `VersionBadge` `since: "4.1.2"`. This feature amends an existing page rather than adding a new one — no new NAV entry, no new API Reference row (F2 has no route).
+- [ ] **Step 2: Full [Release Checklist](#release-checklist)** — version `4.1.2`, chart `0.5.2`.
+- [ ] **Step 3: Commit + PR** — `feat: v4.1.2 — AI executive summary in weekly leadership digest`.
+  State in the PR body whether a real digest email was received (the Phase 3 gate).
+
+---
+
+## Phase 4 → **Release v4.1.3** (chart `0.5.3`) — F3: Root-Cause Hypotheses
+
+> If F2 was skipped, **this ships as v4.1.2 / chart `0.5.2`** instead. Adjust every number in this phase accordingly.
+
+**Files:** Modify `src/lib/ai-snapshots.ts`, `src/lib/ai-schema.ts`, `src/lib/ai-prompts.ts`; create `src/app/api/ai/root-cause/route.ts`, `tests/api-ai-root-cause.test.ts`; modify the workflow detail page.
+
+- [ ] **Step 1: Snapshot builder** — `buildRootCauseSnapshot(token, { owner, repo, workflow_id })`.
+
+  **Apply all three fan-out mitigations from spec §F3 — they are required, not optional:**
+  1. Call `getJobStats(token, owner, repo, workflow_id, 30)` — **30, not the default 50**.
+  2. The route only runs when `failure_count >= 3` (enforce server-side too, not just in the UI: return 200 with `content: null` and let the UI hide).
+  3. Wrap the **snapshot build itself** in `withCache` (key `ai:root-cause-snap:${tokenHash}:${owner}/${repo}/${workflow_id}`, TTL 600) — this is the one surface where caching the GitHub fan-out separately from the LLM call is worth the extra key.
+
+  Derive `branch_type` by comparing `head_branch` to the repo default branch: `"main"` if equal, `"pr"` if `event === "pull_request"`, else `"other"`.
+
+- [ ] **Step 2:** `parseRootCauseContent` → `{ hypotheses: Array<{rank, hypothesis, evidence, confidence, next_step}> }`, ≤ 3 entries, `confidence` must be one of `"high"|"medium"|"low"` (reject the payload otherwise).
+
+- [ ] **Step 3:** Route — rate limit **10/min** (half the others; this is the expensive one), TTL 600s.
+
+- [ ] **Step 4:** UI — ranked list under the reliability tab charts, confidence badge per hypothesis (red/amber/slate), evidence line in muted text, `next_step` as the call to action. Shown only when `failure_count >= 3`.
+
+- [ ] **Step 5:** Verify + commit — `feat: add AI failure root-cause hypotheses to workflow detail`
+
+### Task 4b: 🚢 Release v4.1.3
+
+- [ ] **Step 1: Docs** — new `feat-ai-root-cause` page (NAV + index card `since: "4.1.3"` + detail component). Document the confidence levels and state plainly that hypotheses are derived from **metadata only, never run logs** — this is the feature most likely to be misread as log analysis.
+- [ ] **Step 2: API Reference** — add the `/api/ai/root-cause` row; run the parity check.
+- [ ] **Step 3: Amend the transparency section** — F3 sends job and step **names**; confirm the allowlist wording covers them explicitly.
+- [ ] **Step 4: Full [Release Checklist](#release-checklist)** — version `4.1.3`, chart `0.5.3`.
+- [ ] **Step 5: Commit + PR** — `feat: v4.1.3 — AI failure root-cause hypotheses`.
+
+---
+
+## Final state (all four releases merged)
+
+- [ ] `package.json` at `4.1.3`, chart at `0.5.3` / appVersion `4.1.3`
+- [ ] `CHANGELOG.md` has four new sections: 4.1.0, 4.1.1, 4.1.2, 4.1.3
+- [ ] Docs `ReleaseNotes()` has four new entries; only 4.1.3 carries `badge: "latest"`
+- [ ] Docs Features section has 3 new pages (`feat-ai-insights`, `feat-ai-anomaly`, `feat-ai-root-cause`) plus an amended Leadership Digest page
+- [ ] API Reference documents all four `/api/ai/*` routes; parity check clean
+- [ ] Verification baseline still met: 0 tsc errors · tests all green (≥63, will be higher) · 0 lint errors · build succeeds
+- [ ] With every AI env var unset, the app is behaviorally identical to v4.0.11
+
+---
+
+## Release notes for the reviewer
+
+Call these out explicitly in the PR body of **v4.1.0** (and re-flag any that a later release changes) — they are the judgement calls a reviewer should check rather than discover:
+
+1. **`AI_DAILY_TOKEN_BUDGET` is per-instance, not global** (spec §6.2). It limits damage; it does not hard-cap spend across a serverless fleet. A Neon-backed limiter was deliberately deferred to preserve the zero-migration rollback story.
+2. **The AI cache does not protect GitHub rate limits** (spec §6.3) — snapshot-fingerprint keying means a cache hit still pays the GitHub fan-out. F3 is the sharp edge and carries three required mitigations.
+3. **Logins are sent to the AI provider.** This is intentional (accountability statements need names) and is documented on the docs page. Flag it for an explicit sign-off.
+4. **F2 was resequenced** behind an email-provider precondition; if it shipped without one, say so.

--- a/docs/specs/2026-08-14-ai-features-design.md
+++ b/docs/specs/2026-08-14-ai-features-design.md
@@ -1,0 +1,856 @@
+# GitDash AI Features — Design
+
+**Date:** 2026-08-14
+**Status:** Approved for implementation (rev 2 — corrected against codebase at v4.0.11)
+**Target releases:** **v4.1.0 → v4.1.3 — one version and one PR per feature** (env-key-gated; zero behavior change when no AI keys are configured)
+**Implementation plan:** [`docs/plans/2026-08-14-ai-features-plan.md`](../plans/2026-08-14-ai-features-plan.md)
+
+> **Release discipline (non-negotiable).** Every feature in this spec ships as
+> its own version, its own CHANGELOG entry, its own docs page, and its own PR —
+> the same pattern used for v4.0.0–v4.0.3. Never batch two features into one
+> release; each must be independently revertible. See §8 and §10.
+
+> **Rev 2 changelog.** Rev 1 was reviewed against the codebase and three factual
+> errors plus four design gaps were found. Corrections are marked **[R2]**
+> throughout. Summary: `apiRateLimit` and `computeRepoDora` don't exist; the
+> cost-control argument didn't hold on serverless; build order put an invisible
+> feature first. See §11 for the full list.
+
+---
+
+## 1. Why
+
+GitDash v4.x moved from raw CI metrics toward leadership-facing insight (health
+scorecards, burnout radar, 1:1 briefs, weekly digests). The narrative layer is
+currently **rule-based** (`src/lib/leadership-narrative.ts`,
+`src/lib/one-on-one.ts`, `src/lib/optimization.ts`) — accurate but rigid: fixed
+sentence templates, no synthesis across signals.
+
+An LLM layer turns computed metrics into genuine analysis: *what changed, why it
+likely happened, what to do about it* — the question every dashboard visitor
+actually asks.
+
+**Success criteria**
+
+1. Every AI surface degrades gracefully: no API keys → surface hidden; provider
+   error → rule-based fallback or "unavailable" state. Never a broken page.
+2. AI output is grounded: every number in generated text must come from the
+   provided snapshot. No invented metrics.
+3. Privacy standard matches the product's "your PAT is yours" brand: metrics +
+   names only — never code, logs, YAML content, PR bodies, or tokens.
+4. Cost stays bounded **by a mechanism that actually works on the deployment
+   target** (see §6) — not by cache/rate-limit assumptions that don't survive
+   serverless. **[R2]**
+
+---
+
+## 2. Decisions already made
+
+| Decision | Choice | Rationale |
+| --- | --- | --- |
+| Provider integration | **Direct API keys with fallback:** Gemini primary, Qwen fallback | Self-contained for any GitDash user; no dependency on a private gateway |
+| Data sent to LLM | **Metrics + names only** (aggregate numbers, repo/workflow/job/step names, logins, dates). Never source code, PR/commit text, workflow YAML, or run logs | Matches product security brand; keeps prompt-injection surface near zero |
+| Call site | **Server-side only** (`/api/ai/*` + `src/lib/ai.ts`) | Keys never reach the browser; snapshots assembled server-side |
+| Prompt inputs | **Typed snapshots, no free-form user text** | Deterministic, testable, injection-resistant |
+| Feature gating | Env-key presence (authoritative) + client flag `aiInsights` (cosmetic) **[R2]** | Opt-in, invisible otherwise |
+| Spend ceiling | **`AI_DAILY_TOKEN_BUDGET` ships in v4.1.0** — not deferred **[R2]** | The only bound that survives serverless (§6) |
+
+---
+
+## 3. Architecture
+
+```
+Browser (SWR GET)
+   │
+   ▼
+/api/ai/*  ── getTokenFromSession → validate → aiRateLimit → budget check
+   │
+   ▼
+Snapshot builder (pure, allowlisted)  ←── existing libs: dora, anomaly,
+   │                                      org-health-scorecard, github
+   ▼
+src/lib/ai.ts  ── OpenAI-compatible chat completions via fetch
+   │              Gemini primary → Qwen fallback → AiFailure (never throws)
+   ▼
+JSON response ── validated against schema ── cached (withCache, token-scoped)
+```
+
+### 3.1 Provider layer — `src/lib/ai.ts` (new)
+
+Zero new dependencies (raw `fetch` against OpenAI-compatible endpoints — both
+Gemini and DashScope expose them).
+
+**Env vars**
+
+| Variable | Default | Notes |
+| --- | --- | --- |
+| `GEMINI_API_KEY` | — | Primary provider |
+| `GEMINI_BASE_URL` | `https://generativelanguage.googleapis.com/v1beta/openai` | OpenAI-compatible endpoint |
+| `GEMINI_MODEL` | `gemini-2.5-flash` | Flash class is sufficient for all four surfaces |
+| `QWEN_API_KEY` | — | Fallback provider |
+| `QWEN_BASE_URL` | `https://dashscope-intl.aliyuncs.com/compatible-mode/v1` | Use `dashscope.aliyuncs.com` for CN accounts |
+| `QWEN_MODEL` | `qwen-plus` | |
+| `AI_TIMEOUT_MS` | `15000` | **[R2]** Per-attempt (was 30000 — see §3.1.1) |
+| `AI_TOTAL_BUDGET_MS` | `45000` | **[R2]** Hard ceiling across all attempts |
+| `AI_DAILY_TOKEN_BUDGET` | `2000000` | **[R2]** Process-wide daily cap; `0` = unlimited |
+| `AI_DISABLED` | — | `true` hard-kills the layer regardless of keys |
+
+**Interface**
+
+```ts
+export type AiProvider = "gemini" | "qwen";
+
+export interface AiSuccess {
+  ok: true;
+  provider: AiProvider;
+  model: string;
+  content: string;                                   // raw JSON text from the model
+  usage?: { prompt_tokens: number; completion_tokens: number };
+}
+export interface AiFailure {
+  ok: false;
+  /** Machine-readable so routes can distinguish 503 from 429. */
+  reason: "disabled" | "no_keys" | "budget_exceeded" | "timeout" | "provider_error" | "bad_response";
+  error: string;                                     // safe for logs, never for users verbatim
+}
+export type AiResult = AiSuccess | AiFailure;
+
+/** True when AI_DISABLED is unset AND at least one provider key is present. */
+export function aiEnabled(): boolean;
+
+/** Which providers are configured — for /api/ai/status. Never returns key material. */
+export function configuredProviders(): AiProvider[];
+
+export async function generateJson(
+  systemPrompt: string,
+  userPayload: unknown,                              // JSON-serialized snapshot
+  opts?: { temperature?: number; maxOutputTokens?: number; signal?: AbortSignal },
+): Promise<AiResult>;
+```
+
+**Behavior**
+
+- Tries providers in order `[gemini, qwen]`, skipping any without a key.
+- Per attempt: `AbortController` with `AI_TIMEOUT_MS`, request body
+  `{ model, messages, temperature: 0.2, response_format: { type: "json_object" } }`.
+- **Total-budget guard [R2]:** a single wall-clock deadline of
+  `AI_TOTAL_BUDGET_MS` spans *all* attempts. Once exceeded, remaining providers
+  are skipped and `{ reason: "timeout" }` is returned. This is what prevents the
+  rev-1 worst case of 30s × 2 providers × retry ≈ 120s in one request.
+- Non-retryable status (400/401/403) → skip straight to next provider.
+  429/5xx → one retry after 1s, then next provider.
+- **Never throws.** All failures return `AiFailure`.
+- **Token accounting [R2]:** on success, add `usage.prompt_tokens +
+  usage.completion_tokens` to an in-process daily counter (UTC-day keyed). When
+  the counter exceeds `AI_DAILY_TOKEN_BUDGET`, `generateJson` short-circuits to
+  `{ reason: "budget_exceeded" }` without calling any provider. See §6 for why
+  this is per-instance and what that means.
+- Logging: provider, model, latency, HTTP status, token counts, budget
+  remaining. **Never log prompt content or snapshot payloads.**
+
+#### 3.1.1 Why the timeout numbers changed **[R2]**
+
+Rev 1 specified `AI_TIMEOUT_MS=30000` per attempt with 2 providers and a retry —
+a ~120s worst case inside a single request. Only `/api/cron/sync` sets
+`maxDuration` today (`src/app/api/cron/sync/route.ts:35`); every other route
+uses the platform default. Rev 2 lowers the per-attempt timeout to 15s, adds a
+45s total ceiling, and requires each AI route to declare
+`export const maxDuration = 60;`.
+
+### 3.2 Route group — `/api/ai/*` (new)
+
+All GET (matches the SWR fetcher + `Cache-Control` convention of every other
+analytics route).
+
+| Route | Surface | Rate limit | Cache TTL |
+| --- | --- | --- | --- |
+| `/api/ai/status` | `{ enabled, providers }` — no secrets | none (cheap, no LLM call) | none |
+| `/api/ai/insights` | F1 | 20/min | 15 min |
+| `/api/ai/anomaly-explanation` | F4 | 20/min | 30 min |
+| `/api/ai/root-cause` | F3 | 10/min | 10 min |
+
+F2 needs no route — it runs inside the existing cron digest path.
+
+**Rate limiting — corrected [R2].** Rev 1 referenced a non-existent
+`apiRateLimit`. The real module is `src/lib/ratelimit.ts`:
+
+```ts
+rateLimit(key: string, limit: number, windowMs: number): { allowed: boolean; retryAfterMs?: number }
+getRateLimitKey(req: Request, prefix: string): string   // ← IP-based, NOT token-hash
+```
+
+Since the spec calls for per-token limiting, add a small helper to
+`src/lib/ratelimit.ts`:
+
+```ts
+/** Token-hash-keyed limiter for authenticated, cost-bearing routes. */
+export function aiRateLimit(
+  tokenHash: string,
+  surface: string,
+  limit: number,
+): { allowed: boolean; retryAfterMs?: number } {
+  return rateLimit(`ai:${surface}:${tokenHash}`, limit, 60_000);
+}
+```
+
+`tokenHash` comes from the existing `hashKey(token)` in `src/lib/cache.ts:34`.
+
+**Common handler shape** (mirror `src/app/api/github/org-health-scorecard/route.ts`,
+which is the closest existing analogue):
+
+```ts
+export const maxDuration = 60;                       // [R2] required on every AI route
+
+export async function GET(req: NextRequest) {
+  const token = await getTokenFromSession();
+  if (!token) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  if (!aiEnabled()) {
+    return NextResponse.json({ ok: false, error: "AI features are not configured" }, { status: 503 });
+  }
+
+  const ownerResult = validateOwner(searchParams.get("owner"));
+  if (!ownerResult.ok) return ownerResult.response;
+  // …validateRepo / validateOrg / validateId as appropriate
+
+  const tokenHash = hashKey(token);
+  const limit = aiRateLimit(tokenHash, "insights", 20);
+  if (!limit.allowed) {
+    return NextResponse.json(
+      { ok: false, error: "Rate limit exceeded" },
+      { status: 429, headers: { "Retry-After": String(Math.ceil((limit.retryAfterMs ?? 60000) / 1000)) } },
+    );
+  }
+
+  try {
+    const snapshot = await buildInsightsSnapshot(token, { … });
+    const fingerprint = hashKey(JSON.stringify(snapshot));   // [R2] see caching note
+    const result = await withCache(
+      `ai:insights:${tokenHash}:${scope}:${fingerprint}`,
+      900,
+      async () => { /* generateJson + schema validation */ },
+    );
+    return NextResponse.json(result, {
+      headers: { "Cache-Control": "private, max-age=900" },
+    });
+  } catch (e) {
+    return safeError(e, "Failed to generate AI insights");
+  }
+}
+```
+
+**Important caching note [R2].** Fingerprinting by snapshot hash means the
+snapshot must be built *before* the cache lookup — so a cache hit still costs
+the full GitHub fan-out, only saving the LLM call. That is the intended
+trade-off (LLM calls are the metered resource; GitHub calls are already cached
+one layer down by `getRepoSummary`/`withCache`), but it must be understood: **the
+AI cache does not protect GitHub rate limits.** See §6.3.
+
+**Response envelope**
+
+```json
+{
+  "ok": true,
+  "provider": "gemini",
+  "model": "gemini-2.5-flash",
+  "generated_at": "2026-08-14T03:20:00Z",
+  "cached": false,
+  "content": { "summary": "…", "bullets": ["…"], "actions": ["…"] }
+}
+```
+
+Failure mapping **[R2]** — routes translate `AiFailure.reason` to status:
+
+| `reason` | HTTP | Body `error` |
+| --- | --- | --- |
+| `disabled`, `no_keys` | 503 | `"AI features are not configured"` |
+| `budget_exceeded` | 429 | `"AI daily budget reached"` |
+| `timeout`, `provider_error`, `bad_response` | 503 | `"AI insights unavailable"` |
+
+Snapshot-assembly errors → 500 via `safeError` (never leak provider errors
+verbatim).
+
+**Shared model output schema**
+
+```json
+{
+  "summary": "2-3 sentence plain-English synthesis",
+  "bullets": ["finding grounded in provided numbers", "…"],
+  "actions": ["concrete next step", "…"]
+}
+```
+
+Server-side validation: keys present, string arrays, length caps (summary ≤ 400
+chars, ≤ 6 bullets, ≤ 4 actions, each item ≤ 200 chars). Invalid shape → retry
+once → `{ reason: "bad_response" }`.
+
+### 3.3 Snapshot builders — `src/lib/ai-snapshots.ts` (new)
+
+One pure builder per surface. Each builder:
+
+- takes `(token, scopeParams)` and returns a typed snapshot object,
+- is the **enforcement point of the privacy policy** — it allowlists fields;
+  anything not in the type cannot leak,
+- reuses existing fetchers only.
+
+**Corrected symbol table [R2]** — rev 1 named `computeRepoDora`, which does not
+exist. Verified symbols as of v4.0.11:
+
+| Need | Real symbol | Location |
+| --- | --- | --- |
+| Repo DORA | `calculateRepoDora(mergedPrs, releases, detailMap)` → `RepoDoraSummary` | `src/lib/dora.ts:386` (pure) |
+| …its fetching | route handler | `src/app/api/github/repo-dora/route.ts` |
+| CI DORA from runs | `calculateDoraMetrics(runs)` → `DoraMetrics` | `src/lib/dora.ts:173` |
+| Repo summary | `getRepoSummary(token, owner, repo)` | `src/lib/github.ts:243` |
+| Org scorecard | `computeScorecard(token, octokit, org, limit)` | `src/lib/org-health-scorecard.ts:68` |
+| Bus factor | `computeBusFactor(octokit, owner, repo)` | `src/lib/bus-factor.ts` |
+| Anomalies | `detectAnomalies(runs, threshold?)` → `Map<number, RunAnomalies>` | `src/lib/anomaly.ts:153` (pure) |
+| Baseline | `computeBaseline(runs, metric, threshold?)` → `BaselineStats \| null` | `src/lib/anomaly.ts:185` (pure) |
+| Workflow runs | `listWorkflowRuns(token, owner, repo, workflow_id, per_page?)` | `src/lib/github.ts:511` |
+| Job/step stats | `getJobStats(token, owner, repo, workflow_id, per_page?)` → `JobStatsResponse` | `src/lib/github.ts:638` |
+| Workflow file history | `listWorkflowFileCommits(token, owner, repo, limit?)` → `WorkflowFileCommit[]` | `src/lib/github.ts:765` |
+| Token → cache key | `hashKey(secret)` | `src/lib/cache.ts:34` |
+| Cache | `withCache(key, ttlSeconds, factory)` | `src/lib/cache.ts:99` |
+
+Unit tests assert snapshot shape against fixtures **and** assert absence of
+forbidden fields by construction (see §7).
+
+---
+
+## 4. Feature specs
+
+Build order is **F1 → F4 → F2 → F3** — changed in rev 2, see §8.
+
+### F1 — AI Insights Panel  *(flagship, builds first)*
+
+**What:** A card on the repo overview (`/repos/[owner]/[repo]`) and org health
+scorecard (`/org/[orgName]/health`) pages: plain-English synthesis of the metrics
+already on screen.
+
+**Snapshot — `InsightsSnapshot`**
+
+```ts
+export interface InsightsSnapshot {
+  surface: "repo" | "org";
+  scope: string;                      // "owner/repo" or "orgName"
+  period_days: number;                // 30
+  dora: {
+    deployments_per_day: number;
+    lead_time_p50_hours: number;
+    change_failure_rate_pct: number;
+    mttr_p50_hours: number;
+    benchmark: DoraLevel;             // "elite" | "high" | "medium" | "low"
+  } | null;
+  ci: {
+    total_runs: number;
+    success_rate_pct: number;
+    success_rate_prev_period_pct: number | null;
+    duration_p95_ms: number;
+    duration_p95_prev_period_ms: number | null;
+    queue_wait_p95_ms: number;
+  } | null;
+  anomalies: { metric: AnomalyMetric; direction: "high" | "low"; run_number: number }[];
+  bus_factor: { overall: number; critical_modules: number; top_module_share_pct: number } | null;
+  risk_bands: { healthy: number; watch: number; at_risk: number } | null;  // org surface only
+  recent_workflow_changes: { date: string; author_login: string | null }[];  // metadata only
+}
+```
+
+**Prompt** — versioned constant in `src/lib/ai-prompts.ts`:
+
+```
+SYSTEM
+You are a senior DevOps analyst embedded in GitDash, a CI/CD analytics
+dashboard. You receive a JSON snapshot of pre-computed engineering metrics.
+
+Rules:
+- Use ONLY numbers and facts present in the snapshot. Never invent metrics,
+  dates, or causes that the data does not support.
+- If a signal is weak or missing (null fields, small sample sizes), say so
+  explicitly instead of guessing.
+- Be concrete and actionable; no generic advice ("improve testing") — tie
+  every recommendation to a specific snapshot signal.
+- Tone: candid, concise, leadership-friendly. No jargon without a one-clause
+  explanation.
+- Respond with JSON only: {"summary": "...", "bullets": [...], "actions": [...]}
+  summary <= 3 sentences. bullets <= 5, each <= 25 words. actions <= 3, imperative.
+
+USER
+<InsightsSnapshot JSON>
+```
+
+**UI:** New `src/components/AiInsightsCard.tsx` — collapsible card reusing the
+`Section` header pattern introduced in v4.0.11
+(`src/app/repos/[owner]/[repo]/team/page.tsx`), sparkle icon, loading skeleton,
+"Regenerate" button (appends `?refresh=1`, which bypasses cache), and an
+`unavailable` state. Rendered only when the `useAiEnabled()` hook reports
+enabled **and** the `aiInsights` client flag is on.
+
+**Effort:** 1–1.5 days.
+
+---
+
+### F4 — Anomaly Explanations  *(second — cheapest surface once F1's UI pattern exists)*
+
+**What:** `src/lib/anomaly.ts` already flags duration/queue-wait outliers on the
+workflow detail page. Each flag gains a "Why?" button that lazy-fetches a 2–3
+sentence AI explanation.
+
+**Snapshot — `AnomalySnapshot`**
+
+```ts
+export interface AnomalySnapshot {
+  workflow_name: string;
+  repo: string;                       // "owner/repo"
+  metric: AnomalyMetric;              // "duration" | "queue_wait"
+  baseline: { mean_ms: number; stddev_ms: number; sample_size: number };
+  outliers: {                         // cap 5, most recent first
+    run_number: number;
+    date: string;
+    value_ms: number;
+    z_score: number;
+    trigger: string;                  // WorkflowRun.event
+    actor_login: string | null;
+  }[];
+  concurrent_signals: {
+    workflow_file_changes: { date: string; author_login: string | null }[];
+    trigger_mix: Record<string, number>;
+  };
+}
+```
+
+**Server-side rebuild is required [R2].** `detectAnomalies` is currently invoked
+**client-side only** (`src/app/repos/[owner]/[repo]/workflows/[workflow_id]/page.tsx`).
+Because §2 mandates server-side snapshot assembly and GET-only routes, the F4
+route must call `listWorkflowRuns` and re-run `detectAnomalies` +
+`computeBaseline` server-side. This duplicates work the client already did. It is
+accepted (keeps the injection surface at zero and the client can't forge
+snapshot numbers), but it means each cache-miss "Why?" click costs one
+`listWorkflowRuns` call plus one `listWorkflowFileCommits` call. Budget
+accordingly; do not describe this as free.
+
+**Prompt**
+
+```
+SYSTEM
+You explain CI metric anomalies in two or three sentences. Input is JSON:
+baseline stats, the outlier runs, and concurrent signals (workflow-file
+changes, trigger mix). Use only the provided data. Name the most likely cause
+first, note alternatives only if evidence supports them, and end with one
+concrete check the team can perform. You do NOT have run logs and must not
+pretend to. Respond JSON only: {"explanation": "...", "check": "..."}.
+
+USER
+<AnomalySnapshot JSON>
+```
+
+**Response schema differs from the shared envelope:** `content.explanation`,
+`content.check` (both strings, ≤ 400 chars each).
+
+**Effort:** 0.75–1 day (upped from rev 1 to account for the server-side rebuild).
+
+---
+
+### F2 — AI Leadership Digest  *(third — see the blocker below)*
+
+> ### ⚠️ Precondition [R2]
+> **The weekly digest email currently cannot send.** Production has neither
+> `RESEND_API_KEY` nor `SMTP_HOST`, so `deliverLeadershipDigestEmail`
+> (`src/lib/notifier.ts:304`) returns
+> `{ ok: false, error: "No email provider configured…" }` on every call.
+>
+> Rev 1 sequenced F2 first as *"fastest to ship — most visible."* It is
+> currently the **least** visible: an AI summary inside an email nobody
+> receives. **Do not start F2 until an email provider is configured and a test
+> digest has been received.** If that is blocked, skip F2 and go straight to F3.
+
+**What:** The existing weekly digest email gains an LLM-written executive summary
+above the rule-based narrative.
+
+**Integration point:** `sendWeeklyLeadershipDigests` (`src/lib/sync.ts:178`).
+After `computeScorecard` + `generateLeadershipNarrative`, call `generateJson`.
+On any `AiFailure` → send the email with only the rule-based narrative (current
+behavior). **The digest never fails because AI is down.**
+
+**Snapshot — `DigestSnapshot`**
+
+```ts
+export interface DigestSnapshot {
+  org: string;
+  week: string;                       // ISO week, e.g. "2026-W33"
+  scorecard: OrgHealthScorecardResponse;    // existing type, already metrics-only
+  rule_narrative: {                   // anchor: model refines, must not contradict
+    summary_line: string;
+    highlights: string[];
+    concerns: string[];
+  };
+}
+```
+
+**Email rendering — corrected [R2].** Rev 1's prompt said *"email body renders
+plain text."* It does not: `deliverLeadershipDigestEmail` builds **both** an HTML
+body (primary) and a plain-text fallback. Therefore:
+
+- Keep the "no markdown / no emojis" instruction (it keeps the text fallback
+  clean), but
+- **HTML-escape the AI summary before interpolating it into the `html`
+  template.** Add a small `escapeHtml()` helper in `notifier.ts` and apply it to
+  the new `aiSummary` field. (The existing narrative fields are also
+  un-escaped — fixing those is in scope for this task since it's the same
+  helper and the same file.)
+
+**Signature change:**
+
+```ts
+export interface LeadershipDigestEmailInput {
+  subject: string;
+  summary_line: string;
+  highlights: string[];
+  concerns: string[];
+  aiSummary?: string;                 // [R2] new, optional
+}
+```
+
+Rendered in its own section labeled **"AI summary"** (transparency) above the
+existing narrative.
+
+**Effort:** 0.5 day *after* the email precondition is met.
+
+---
+
+### F3 — Failure Root-Cause Hypotheses  *(last — deepest build)*
+
+**What:** On the workflow detail page, when recent failures exist: an "AI
+hypotheses" panel ranking likely causes with supporting evidence. Metadata only —
+never run logs.
+
+**Snapshot — `RootCauseSnapshot`**
+
+```ts
+export interface RootCauseSnapshot {
+  workflow_name: string;
+  repo: string;
+  window_days: number;                // 14
+  run_count: number;
+  failure_count: number;
+  failure_rate_pct: number;
+  first_failure_at: string | null;
+  prior_success_streak: number;
+  failures: {                         // cap 10, most recent first
+    run_number: number;
+    date: string;
+    trigger: string;
+    branch_type: "main" | "pr" | "other";
+    failed_jobs: { job_name: string; failed_step_names: string[]; duration_ms: number }[];
+  }[];
+  step_failure_frequency: { step_name: string; failure_count: number; share_of_failures_pct: number }[];
+  failure_clustering: {
+    same_step_share_pct: number;
+    trigger_distribution: Record<string, number>;
+    branch_distribution: Record<string, number>;
+  };
+  workflow_file_changes: { date: string; author_login: string | null }[];
+  duration_shift: { before_failures_p50_ms: number; during_failures_p50_ms: number } | null;
+}
+```
+
+**GitHub fan-out warning [R2].** This snapshot needs `getJobStats`
+(`src/lib/github.ts:638`), which fetches runs and then jobs for each completed
+run, batched 8 at a time — **on the order of 50 GitHub API calls per cache
+miss.** With a 10/min rate limit, a single user can consume a meaningful slice of
+a 5,000/hr GitHub budget. Mitigations, all required:
+
+1. Call `getJobStats` with `per_page` ≤ 30, not the default 50.
+2. Gate the UI to `failure_count >= 3` (already specified) so the route is not
+   hit on healthy workflows.
+3. Reuse the `withCache` layer *around the snapshot build itself*, not just
+   around the LLM call — this is the one surface where that is worth the extra
+   key.
+
+**Prompt**
+
+```
+SYSTEM
+You are a CI failure analyst. You receive JSON metadata about recent workflow
+failures: which steps failed, how often, triggers, branches, timing, and dates
+when the workflow definition itself changed. You do NOT have logs and must not
+pretend to.
+
+Rules:
+- Produce 1-3 ranked hypotheses. Each must cite the specific evidence from the
+  snapshot that supports it (step names, dates, concentrations).
+- Prefer boring explanations: a workflow-file change right before the first
+  failure, one flaky step, infra/queue signals - in that order of evidence.
+- Mark each hypothesis confidence: "high" | "medium" | "low" based on how
+  strongly the evidence supports it. Low-evidence guesses must say so.
+- Never reference log contents, code, or anything not in the snapshot.
+- Respond JSON only: {"hypotheses": [{"rank": 1, "hypothesis": "...",
+  "evidence": "...", "confidence": "...", "next_step": "..."}]}
+
+USER
+<RootCauseSnapshot JSON>
+```
+
+**Response schema:** `content.hypotheses[]` — array of ≤ 3, each
+`{ rank: number; hypothesis: string; evidence: string; confidence: "high"|"medium"|"low"; next_step: string }`.
+
+**UI placement:** Below the reliability tab charts, shown only when
+`failure_count >= 3` in window.
+
+**Effort:** 1.5–2 days.
+
+---
+
+## 5. Security & privacy
+
+1. **Allowlist enforcement at the type level** — snapshots are the only thing
+   serialized into prompts; builders expose no passthrough of raw API objects.
+2. **Never sent:** PAT/OAuth tokens, run logs, file contents, workflow YAML,
+   PR/commit message bodies, email addresses. **Logins are sent** (needed for
+   accountability statements) — this must be documented on the docs page.
+3. **Keys server-side only.** `/api/ai/status` returns capability, never key
+   material. It is not in `ALWAYS_PUBLIC` (`src/middleware.ts:12`), so it
+   inherits session auth — keep it that way.
+4. **Prompt injection:** no free-form user input enters any prompt anywhere in
+   the v4.1.x series. (The deferred NL-Q&A feature is the one that would change
+   this — it needs its own injection review before it is planned.)
+5. **The client flag is not a security control [R2].** `src/lib/feature-flags.ts`
+   is localStorage-backed and trivially flipped by any user. Every AI route must
+   independently call `aiEnabled()` server-side; the flag only hides UI.
+6. **Rate limiting + budget** — see §6 for what these actually guarantee.
+7. **Transparency:** docs page section "AI features" stating exactly what data
+   leaves the instance and to which providers; AI-generated sections labeled in
+   both UI and email.
+
+---
+
+## 6. Cost control — corrected **[R2]**
+
+Rev 1 claimed *"Rate limits above bound worst case to a few dollars/day even
+under abuse."* That does not follow on this deployment target. Both mechanisms
+are in-process `Map`s:
+
+| Mechanism | File | Scope |
+| --- | --- | --- |
+| `withCache` | `src/lib/cache.ts:1-7` | Self-documented: *"Not shared across serverless instances — treat as a request-coalescing layer, not a distributed cache"* |
+| `rateLimit` | `src/lib/ratelimit.ts:11` | Module-level `Map`, per-instance |
+
+On Vercel, every instance gets a fresh window and a cold cache. So:
+
+### 6.1 What is actually guaranteed
+
+| Claim | Holds? | Notes |
+| --- | --- | --- |
+| Per-call cost is small | **Yes** | Flash-class, ~1.5k in + 200 out ≈ $0.0002–0.0005 |
+| Cache reduces repeat calls | **Partially** | Only within one warm instance |
+| Rate limit bounds a single user | **Partially** | Per instance, not globally |
+| Total spend is bounded | **Only via `AI_DAILY_TOKEN_BUDGET`** | Promoted into v4.1.0 for exactly this reason |
+
+### 6.2 The decision
+
+`AI_DAILY_TOKEN_BUDGET` ships in v4.1.0 (default 2,000,000 tokens/day ≈ a few
+dollars on flash pricing). It is **also per-instance**, so it is a
+damage-limiter, not a hard global cap — that is stated plainly rather than
+papered over. Its job is to make a runaway loop or a hostile authenticated user
+expensive-but-survivable instead of unbounded.
+
+**Deliberately not doing:** a Neon-backed distributed limiter. It would be a
+real fix but requires a schema change, and §10's rollback story ("revert the
+version commit, no migration") is worth more at this stage than a tighter bound.
+Revisit if actual spend justifies it.
+
+### 6.3 GitHub rate limit is a separate budget
+
+The AI cache is keyed on a snapshot fingerprint, so a cache hit still pays the
+GitHub fan-out — it only saves the LLM call. F3 is the sharp edge here (~50 calls
+per snapshot build via `getJobStats`); see its mitigations. Do not conflate "AI
+cached" with "GitHub calls avoided."
+
+---
+
+## 7. Testing strategy
+
+| Layer | Test | Precedent |
+| --- | --- | --- |
+| `ai.ts` | Mocked `fetch`: provider order, fallback on 401/429/5xx, per-attempt timeout, **total-budget abort**, JSON-mode request body, `AI_DISABLED`, key absence, **daily-budget short-circuit** | New file, pure Node ✓ |
+| Snapshot builders | Fixture inputs → exact snapshot shape; **assert forbidden keys absent** (walk the serialized JSON, fail on `logs`/`body`/`content`/`yaml`/`token`) | Matches `tests/dora.test.ts` style ✓ |
+| Prompt builders | Snapshot → messages array snapshot tests (prompts are versioned constants) | New, trivial ✓ |
+| Response validation | Malformed model JSON (missing keys, oversize, wrong types) → rejected; retry-once path exercised | New, pure ✓ |
+| Digest integration | `generateJson` mocked to fail → email still sends with rule-based narrative only | Extends `tests/notifier.test.ts` ✓ |
+| Routes | Handler tests with mocked `generateJson`: 401, 429, 503, cache hit | **⚠️ No precedent — see below [R2]** |
+
+### 7.1 Route-handler tests are new infrastructure **[R2]**
+
+All 7 existing test files test pure `src/lib` functions; `vitest.config.ts`
+scopes coverage to `src/lib/**/*.ts`. There are **zero** route-handler tests
+today. Testing a route requires mocking `NextRequest` and `getTokenFromSession`
+(which reads iron-session cookies via `next/headers`).
+
+**Decision:** treat this as its own task with its own budget (0.5 day, task 0c in
+the plan), not as a free rider on the feature tasks. Establish the pattern once
+against `/api/ai/status` — the simplest possible route — then reuse it.
+
+If the mocking proves awkward, the acceptable fallback is: **extract each route's
+logic into a pure `handleX(deps)` function in `src/lib/`, unit-test that, and
+keep the route file as a thin adapter.** This matches how `computeScorecard` and
+`computeBusFactor` were already extracted from their routes in v4.0.0/v4.0.3, and
+is the preferred outcome if there's any friction.
+
+All tests are pure/Node — **no network in CI.**
+
+---
+
+## 8. Build order & effort — revised **[R2]**
+
+**One feature = one version = one PR.** Each row below is a complete,
+independently revertible release: code + version bump (all 7 locations, §10.1) +
+CHANGELOG entry + docs feature page + API Reference entries + PR.
+
+| Release | Contents | Effort | Gate |
+| --- | --- | --- | --- |
+| **v4.1.0** | Core layer (`ai.ts`, `aiRateLimit`, `/api/ai/status`, `aiInsights` flag, route-test pattern) **+ F1 AI Insights Panel** | 2.25–2.75 d | — |
+| **v4.1.1** | **F4** Anomaly Explanations | 0.75–1 d | v4.1.0 (reuses card pattern) |
+| **v4.1.2** | **F2** AI Leadership Digest | 0.5 d | ⚠️ email provider configured |
+| **v4.1.3** | **F3** Root-Cause Hypotheses | 1.5–2 d | v4.1.0 |
+| | **Total** | **5–6.25 days** | |
+
+**Why the core layer ships with F1 rather than alone.** The provider module,
+status route, and flag produce **no user-visible surface** on their own —
+releasing them as a standalone version would mean a version bump and a
+release-notes entry describing nothing a user can see. Bundling them with F1
+keeps every release meaningful. They are still separate *commits* inside that
+PR, so `git revert` can drop F1 while keeping the layer if that's ever wanted.
+
+**Order rationale (changed from rev 1).** Rev 1 built F2 first on the theory it
+was "most visible." It is currently invisible (§F2 precondition). Rev 2 leads
+with **F1** — the flagship, visible on page load, and the surface that
+establishes the card UI pattern F4 reuses. F4 follows as the cheap add-on. F2
+slots in whenever email is unblocked. F3 is last: biggest snapshot, bespoke
+schema and UI, heaviest GitHub fan-out.
+
+If F2 is still blocked when its turn comes, **skip it and ship F3 as v4.1.2** —
+do not leave a version number reserved for an unshipped feature.
+
+---
+
+## 9. Deferred (not in the v4.1.x series)
+
+- Natural-language metrics Q&A (chat) — biggest build; introduces free-form
+  prompt input → needs an injection review first.
+- Neon-backed distributed rate limit / budget (§6.2).
+- AI cost-optimization tips, AI 1:1 coaching brief, security-finding explainer —
+  same architecture, cheap follow-ups once the layer exists.
+- Embedding-based repo similarity / anomaly clustering.
+- Per-user AI usage metering.
+
+---
+
+## 10. Rollout
+
+All four releases are gated by env-key presence (authoritative) + the
+`aiInsights` client flag (cosmetic). **Zero schema changes across all four** —
+no migration to undo at any point.
+
+### 10.1 Version bump — all 7 locations, every release
+
+A release is not complete until **every** one of these is updated. Verified
+against the tree at v4.0.11:
+
+| # | File | Line (at v4.0.11) | What |
+| --- | --- | --- | --- |
+| 1 | `package.json` | 3 | `"version": "X.Y.Z"` |
+| 2 | `helm/gitdash/Chart.yaml` | 5 | `version:` (chart version — bump independently) |
+| 3 | `helm/gitdash/Chart.yaml` | 6 | `appVersion: "X.Y.Z"` |
+| 4 | `src/app/docs/page.tsx` | 2473 | `ReleaseNotes()` — **new** top entry, `badge: "latest"` |
+| 5 | `src/app/docs/page.tsx` | 2473+ | previous top entry demoted to `badge: null` |
+| 6 | `src/app/docs/page.tsx` | 2916 | `NEXT_PUBLIC_APP_VERSION ?? "X.Y.Z"` (sidebar badge) |
+| 7 | `src/app/docs/page.tsx` | 3165 | `NEXT_PUBLIC_APP_VERSION ?? "X.Y.Z"` (footer) |
+| 8 | `CHANGELOG.md` | 9 | new `## [X.Y.Z] — YYYY-MM-DD` section at the top |
+
+Chart-version mapping for this series: `0.4.11` → **`0.5.0`** (v4.1.0) → `0.5.1`
+(v4.1.1) → `0.5.2` (v4.1.2) → `0.5.3` (v4.1.3).
+
+Self-check — after bumping, this must return only the new version:
+
+```bash
+grep -rn "NEXT_PUBLIC_APP_VERSION ?? \"" src/app/docs/page.tsx
+grep -n '"version"' package.json; grep -n "^version:\|^appVersion:" helm/gitdash/Chart.yaml
+```
+
+### 10.2 Docs — every feature gets its own page
+
+Per spec §4, each feature is a user-facing surface, so each release adds:
+
+1. A `feat-*` entry in the docs `NAV` array under **Features**.
+2. An index card in `Features()` with `since: "X.Y.Z"` (renders the `VersionBadge`).
+3. A dedicated detail component registered in `SECTION_COMPONENTS`.
+4. Its `/api/ai/*` row(s) in the **API Reference** section.
+5. A `ReleaseNotes()` entry (see §10.1 #4/#5).
+
+The transparency section (what data leaves the instance, to which providers,
+what is never sent) ships once with v4.1.0 and is amended if a later feature
+widens the data set — F3 and F4 both do, so both must revisit it.
+
+**API Reference parity is verified every release:**
+
+```bash
+grep -o 'path: "/api/[^"]*"' src/app/docs/page.tsx | sed 's/path: "//;s/"//' | sort -u > /tmp/documented.txt
+find src/app/api -name route.ts | sed 's|src/app||;s|/route.ts||' | sort -u > /tmp/actual.txt
+comm -13 /tmp/documented.txt /tmp/actual.txt   # must print nothing
+```
+
+### 10.3 PR workflow — mandatory
+
+Never commit to `main`. Per release:
+
+1. Branch off an up-to-date `main`: `git checkout main && git pull origin main && git checkout -b feat/vX.Y.Z-<slug>`
+2. Multiple commits within the branch are fine and encouraged (one per task).
+3. Full verification gate green **before** the release commit (§10.4).
+4. `gh pr create` with a test-plan checklist in the body.
+5. **Wait for the owner to merge.** Do not self-merge.
+6. After merge: `git checkout main && git pull origin main` before starting the next release.
+
+> **Known hazard:** a PR merged before a later commit is pushed silently drops
+> that commit (this happened with the v4.0.6 screenshots). Always confirm
+> `git status` is clean and the branch is fully pushed *before* asking for merge.
+
+### 10.4 Verification gate — before every release commit
+
+```bash
+pnpm exec tsc --noEmit           # 0 errors
+pnpm test                         # all green — record the count in the PR
+pnpm exec eslint <changed files>  # 0 errors (pre-existing warnings OK)
+rm -rf .next && pnpm run build    # succeeds
+# + the API Reference parity check from §10.2
+```
+
+Baseline at v4.0.11: **0 tsc errors, 63/63 tests, 0 lint errors (11 pre-existing
+warnings), build succeeds, route parity clean.** Any regression against this
+baseline blocks the release.
+
+### 10.5 Rollback
+
+Three independent levers, in increasing order of cost:
+
+1. **Unset the AI env keys** — every surface hides, no redeploy, no code change.
+2. **Promote the previous Vercel deployment** — instant, no rebuild.
+3. **`git revert` the release commit** — clean, because each feature is its own
+   version and its own PR. Zero schema changes means nothing to migrate back.
+
+---
+
+## 11. Rev 2 correction log
+
+| # | Rev 1 said | Reality | Fix |
+| --- | --- | --- | --- |
+| 1 | Rate limit "via `apiRateLimit`" | No such symbol. `src/lib/ratelimit.ts` exports `rateLimit` + `getRateLimitKey` (IP-keyed) | §3.2 adds `aiRateLimit(tokenHash, surface, limit)` |
+| 2 | Snapshots reuse `computeRepoDora` | No such symbol. Real: `calculateRepoDora` (pure) / `calculateDoraMetrics` | §3.3 symbol table, all verified w/ line refs |
+| 3 | Rate limits bound spend "to a few dollars/day" | Cache + limiter are in-process; per-instance on Vercel | §6 rewritten; `AI_DAILY_TOKEN_BUDGET` promoted into v4.1.0 |
+| 4 | F2 first — "smallest, most visible" | Digest email cannot send (no `RESEND_API_KEY`/`SMTP_HOST`) | F2 gated on a precondition; order → F1, F4, F2, F3 |
+| 5 | F2 prompt: "email body renders plain text" | `deliverLeadershipDigestEmail` renders HTML + text | Keep no-markdown rule; add `escapeHtml()` |
+| 6 | F4 "thin context-builder", 0.5–1 d | `detectAnomalies` runs client-side only; server must re-fetch + recompute | Documented; effort → 0.75–1 d |
+| 7 | F3 composes existing fetchers (implied cheap) | `getJobStats` is ~50 GitHub calls per build | Fan-out warning + 3 required mitigations |
+| 8 | Route tests listed as routine | Zero route-test precedent; coverage scoped to `src/lib/**` | §7.1 — own task (0c) + extract-to-lib fallback |
+| 9 | `AI_TIMEOUT_MS=30000`, no total cap | Worst case ~120s/request; no `maxDuration` on non-cron routes | 15s/attempt, 45s total, `maxDuration = 60` required |
+| 10 | Flag named `ai-insights` | Existing flags are camelCase (`healthScorecard`, `workloadRisk`) | → `aiInsights` |
+| 11 | Client flag implied as gating | localStorage-backed, trivially flipped | §5.5 — routes must check `aiEnabled()` themselves |

--- a/helm/gitdash/Chart.yaml
+++ b/helm/gitdash/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: gitdash
 description: Self-hosted GitHub Actions metrics dashboard (standalone PAT or GitHub OAuth)
 type: application
-version: 0.4.11
-appVersion: "4.0.11"
+version: 0.5.0
+appVersion: "4.1.0"
 keywords:
   - github-actions
   - dashboard

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gitdash",
-  "version": "4.0.11",
+  "version": "4.1.0",
   "private": true,
   "packageManager": "pnpm@10.30.3",
   "scripts": {

--- a/src/app/api/ai/insights/route.ts
+++ b/src/app/api/ai/insights/route.ts
@@ -1,0 +1,159 @@
+/**
+ * GET /api/ai/insights — plain-English synthesis of a repo's or org's metrics.
+ *
+ * Params: owner+repo (repo surface) or org (org surface).
+ * Optional: refresh=1 bypasses the cached generation (still rate-limited —
+ * refresh must not become an unmetered path to the provider).
+ *
+ * Caching note: the key is fingerprinted on the snapshot, so the GitHub
+ * fan-out runs before the cache lookup and a hit only saves the LLM call.
+ * That is deliberate — LLM calls are the metered resource here, and the
+ * underlying fetchers carry their own caches. Do not read a cache hit as
+ * "no GitHub calls were made".
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { getTokenFromSession } from "@/lib/session";
+import { aiEnabled, generateJson, type AiFailureReason } from "@/lib/ai";
+import { buildInsightsSnapshot, type InsightsScope } from "@/lib/ai-snapshots";
+import { INSIGHTS_SYSTEM_PROMPT } from "@/lib/ai-prompts";
+import { parseInsightsContent, type InsightsContent } from "@/lib/ai-schema";
+import { withCache, cacheGet, cacheSet, cacheDelete, hashKey } from "@/lib/cache";
+import { aiRateLimit } from "@/lib/ratelimit";
+import { validateOwner, validateRepo, validateOrg, safeError } from "@/lib/validation";
+
+export const maxDuration = 60;
+
+const CACHE_TTL = 900; // 15 min
+const RATE_LIMIT_PER_MIN = 20;
+
+export interface AiInsightsResponse {
+  ok: true;
+  provider: string;
+  model: string;
+  generated_at: string;
+  cached: boolean;
+  partial: boolean;
+  content: InsightsContent;
+}
+
+/** Map a provider failure onto a client-safe status + message. */
+function failureResponse(reason: AiFailureReason): NextResponse {
+  if (reason === "budget_exceeded") {
+    return NextResponse.json(
+      { ok: false, error: "AI daily budget reached" },
+      { status: 429, headers: { "Retry-After": "3600" } },
+    );
+  }
+  if (reason === "disabled" || reason === "no_keys") {
+    return NextResponse.json(
+      { ok: false, error: "AI features are not configured" },
+      { status: 503 },
+    );
+  }
+  return NextResponse.json({ ok: false, error: "AI insights unavailable" }, { status: 503 });
+}
+
+export async function GET(req: NextRequest) {
+  const token = await getTokenFromSession();
+  if (!token) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  // Checked server-side rather than trusting the client feature flag, which is
+  // localStorage-backed and can be flipped by anyone.
+  if (!aiEnabled()) {
+    return NextResponse.json(
+      { ok: false, error: "AI features are not configured" },
+      { status: 503 },
+    );
+  }
+
+  const { searchParams } = new URL(req.url);
+  const orgParam = searchParams.get("org");
+
+  let scope: InsightsScope;
+  let scopeKey: string;
+
+  if (orgParam) {
+    const orgResult = validateOrg(orgParam);
+    if (!orgResult.ok) return orgResult.response;
+    scope = { surface: "org", org: orgResult.data };
+    scopeKey = `org:${orgResult.data}`;
+  } else {
+    const ownerResult = validateOwner(searchParams.get("owner"));
+    if (!ownerResult.ok) return ownerResult.response;
+    const repoResult = validateRepo(searchParams.get("repo"));
+    if (!repoResult.ok) return repoResult.response;
+    scope = { surface: "repo", owner: ownerResult.data, repo: repoResult.data };
+    scopeKey = `repo:${ownerResult.data}/${repoResult.data}`;
+  }
+
+  const tokenHash = hashKey(token);
+  const limit = aiRateLimit(tokenHash, "insights", RATE_LIMIT_PER_MIN);
+  if (!limit.allowed) {
+    return NextResponse.json(
+      { ok: false, error: "Rate limit exceeded" },
+      {
+        status: 429,
+        headers: { "Retry-After": String(Math.ceil((limit.retryAfterMs ?? 60_000) / 1000)) },
+      },
+    );
+  }
+
+  const refresh = searchParams.get("refresh") === "1";
+
+  try {
+    const snapshot = await buildInsightsSnapshot(token, scope);
+    const fingerprint = hashKey(JSON.stringify(snapshot));
+    const cacheKey = `ai:insights:${tokenHash}:${scopeKey}:${fingerprint}`;
+
+    // Distinguish a served-from-cache response from a fresh generation so the
+    // UI can label it — withCache alone cannot report which happened.
+    const hit = !refresh && cacheGet<AiInsightsResponse>(cacheKey) !== undefined;
+
+    const generate = async (): Promise<AiInsightsResponse | { failed: AiFailureReason }> => {
+      let result = await generateJson(INSIGHTS_SYSTEM_PROMPT, snapshot);
+      if (!result.ok) return { failed: result.reason };
+
+      let content = parseInsightsContent(result.content);
+      if (!content) {
+        // One retry: JSON-mode slips are usually transient.
+        result = await generateJson(INSIGHTS_SYSTEM_PROMPT, snapshot);
+        if (!result.ok) return { failed: result.reason };
+        content = parseInsightsContent(result.content);
+      }
+      if (!content) return { failed: "bad_response" };
+
+      return {
+        ok: true,
+        provider: result.provider,
+        model: result.model,
+        generated_at: new Date().toISOString(),
+        cached: false,
+        partial: snapshot.partial,
+        content,
+      };
+    };
+
+    let payload: AiInsightsResponse | { failed: AiFailureReason };
+
+    if (refresh) {
+      payload = await generate();
+      // Only write through on success — never cache a failure.
+      if ("ok" in payload) cacheSet(cacheKey, payload, CACHE_TTL);
+    } else {
+      payload = await withCache(cacheKey, CACHE_TTL, generate);
+      // A failure that slipped into the cache would poison the key for its
+      // whole TTL, so evict it and let the next request try again.
+      if (!("ok" in payload)) cacheDelete(cacheKey);
+    }
+
+    if (!("ok" in payload)) return failureResponse(payload.failed);
+
+    return NextResponse.json(
+      { ...payload, cached: hit },
+      { headers: { "Cache-Control": `private, max-age=${CACHE_TTL}` } },
+    );
+  } catch (e) {
+    return safeError(e, "Failed to generate AI insights");
+  }
+}

--- a/src/app/api/ai/status/route.ts
+++ b/src/app/api/ai/status/route.ts
@@ -1,0 +1,35 @@
+/**
+ * GET /api/ai/status — capability probe for the AI layer (v4.1.0).
+ *
+ * The UI needs to know whether to render any AI surface at all. This answers
+ * that in one cheap call with no LLM round-trip, so it is not rate-limited.
+ *
+ * Returns capability only — which providers have a key configured, never the
+ * key material itself. Session-authed like every other route (it is
+ * deliberately absent from ALWAYS_PUBLIC in src/middleware.ts).
+ */
+
+import { NextResponse } from "next/server";
+import { getTokenFromSession } from "@/lib/session";
+import { aiEnabled, configuredProviders } from "@/lib/ai";
+
+export const maxDuration = 60;
+
+export interface AiStatusResponse {
+  enabled: boolean;
+  providers: string[];
+}
+
+export async function GET() {
+  const token = await getTokenFromSession();
+  if (!token) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const body: AiStatusResponse = {
+    enabled: aiEnabled(),
+    providers: configuredProviders(),
+  };
+
+  return NextResponse.json(body, {
+    headers: { "Cache-Control": "private, max-age=60" },
+  });
+}

--- a/src/app/docs/page.tsx
+++ b/src/app/docs/page.tsx
@@ -9,7 +9,7 @@ import {
   CheckCircle,
   Activity, FileText, ShieldAlert, User, DollarSign,
   TrendingUp, Bell, Building2, List, BarChart3, Trophy, Sliders,
-  HeartPulse, AlertTriangle, Mail, MessageCircle,
+  HeartPulse, AlertTriangle, Mail, MessageCircle, Sparkles,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { Callout } from "@/components/docs/Callout";
@@ -62,6 +62,7 @@ const NAV: NavSection[] = [
       { id: "feat-workload-risk", label: "Workload Risk Radar", icon: AlertTriangle, sub: true },
       { id: "feat-one-on-one", label: "1:1 Prep Sheet", icon: MessageCircle, sub: true },
       { id: "feat-leadership-digest", label: "Leadership Digest", icon: Mail, sub: true },
+      { id: "feat-ai-insights", label: "AI Insights", icon: Sparkles, sub: true },
     ],
   },
   {
@@ -862,6 +863,15 @@ function Features({ onNavigate }: { onNavigate: (id: string) => void }) {
       chips: ["Weekly email", "Narrative summary", "No threshold to configure"],
       since: "4.0.3",
     },
+    {
+      id: "feat-ai-insights",
+      name: "AI Insights",
+      path: "/repos/[owner]/[repo] · /org/[orgName]/health",
+      screenshot: "22-ai-insights.png",
+      desc: "Plain-English synthesis of the metrics already on the page: what changed, why it matters, and what to do about it. Optional — the card only appears when AI provider keys are configured on the server. Metrics and names are sent to the provider; never code, logs, or commit messages.",
+      chips: ["Gemini + Qwen fallback", "Server-side keys only", "Metrics-only prompts", "Hidden when unconfigured"],
+      since: "4.1.0",
+    },
   ];
 
   return (
@@ -1488,6 +1498,113 @@ function FeatureLeadershipDigest() {
       <Callout type="warning">
         Delivery requires an email provider to be configured in the deployment
         (<Code>RESEND_API_KEY</Code> or SMTP settings) — see Configuration.
+      </Callout>
+    </section>
+  );
+}
+
+function FeatureAiInsights() {
+  return (
+    <section className="space-y-6">
+      <FeaturePageHeader
+        icon={Sparkles} name="AI Insights" path="/repos/[owner]/[repo] · /org/[orgName]/health"
+        chips={["Gemini + Qwen fallback", "Server-side keys only", "Metrics-only prompts", "Hidden when unconfigured"]}
+        since="4.1.0"
+      />
+      <ProseP>
+        An optional layer that turns the metrics already on screen into plain-English analysis —
+        what changed, why it matters, and what to do next. It appears as a collapsible card on the
+        Repository Overview and Team Health Scorecard pages.
+      </ProseP>
+
+      <Callout type="info">
+        <strong>Entirely opt-in.</strong> With no AI provider key configured on the server, every AI
+        surface is hidden and GitDash behaves exactly as it did before v4.1.0. There is no
+        placeholder and no prompt to enable anything.
+      </Callout>
+
+      <ScreenshotSlot file="22-ai-insights.png" alt="AI Insights card" />
+
+      <DocCard>
+        <SubHeading>What data leaves your instance</SubHeading>
+        <ProseP>
+          This is the part worth reading carefully. Prompts are assembled server-side from a typed
+          snapshot that allowlists its fields — anything not in the list cannot be sent, and the
+          test suite fails the build if a forbidden field appears.
+        </ProseP>
+        <DocTable
+          headers={["Sent", "Never sent"]}
+          rows={[
+            ["Aggregate metrics (DORA figures, success rates, run counts, bus factor)", "Your PAT or OAuth token"],
+            ["Repository, workflow, job and step names", "Workflow run logs"],
+            ["GitHub logins of contributors and commit authors", "Source code or file contents"],
+            ["Dates and timestamps", "Workflow YAML contents"],
+            ["Risk bands and composite scores", "PR or commit message bodies"],
+            ["Whether the data was partial", "Email addresses"],
+          ]}
+        />
+        <Callout type="warning">
+          <strong>Logins are sent.</strong> Contributor and author logins are included so the model
+          can attribute observations to people. If that is not acceptable for your organisation,
+          leave the AI keys unset — there is no partial mode.
+        </Callout>
+      </DocCard>
+
+      <DocCard>
+        <SubHeading>Providers and keys</SubHeading>
+        <ProseP>
+          Gemini is tried first, Qwen is the fallback. Both are reached through their
+          OpenAI-compatible endpoints, so no vendor SDK is installed. Keys are read server-side only
+          and are never sent to the browser — <Code>/api/ai/status</Code> reports which providers are
+          configured, never the key material.
+        </ProseP>
+        <DocTable
+          headers={["Variable", "Default", "Purpose"]}
+          rows={[
+            ["GEMINI_API_KEY", "—", "Primary provider. Unset = provider skipped"],
+            ["GEMINI_MODEL", "gemini-2.5-flash", "Flash class is sufficient for this workload"],
+            ["QWEN_API_KEY", "—", "Fallback provider"],
+            ["QWEN_MODEL", "qwen-plus", ""],
+            ["AI_DISABLED", "—", "Set to true to hard-kill the layer regardless of keys"],
+            ["AI_TIMEOUT_MS", "15000", "Per provider attempt"],
+            ["AI_TOTAL_BUDGET_MS", "45000", "Wall-clock ceiling across all attempts in one request"],
+            ["AI_DAILY_TOKEN_BUDGET", "2000000", "Per instance per UTC day. 0 = unlimited"],
+          ]}
+        />
+      </DocCard>
+
+      <DocCard>
+        <SubHeading>Cost and rate limiting</SubHeading>
+        <ProseP>
+          Calls are cached for 15 minutes and fingerprinted on the snapshot, so unchanged metrics
+          reuse the previous generation. Requests are rate-limited to 20/minute per token, and a
+          daily token budget stops runaway usage.
+        </ProseP>
+        <Callout type="warning">
+          Both the cache and the limiters are <strong>in-process</strong>. On a multi-instance
+          deployment each instance keeps its own counters, so these bound cost per instance rather
+          than globally — a damage-limiter, not a hard spend cap.
+        </Callout>
+      </DocCard>
+
+      <DocCard>
+        <SubHeading>How it fails</SubHeading>
+        <DocTable
+          headers={["Situation", "What you see"]}
+          rows={[
+            ["No provider keys configured", "The card is not rendered at all"],
+            ["Feature switched off in Settings", "The card is not rendered at all"],
+            ["Provider is down or returns an error", "A muted \"unavailable\" line — the page's own metrics are unaffected"],
+            ["Rate limit or daily budget reached", "A muted \"try again in a minute\" line"],
+            ["Some metrics could not be fetched", "A \"partial data\" badge, and the model is told to hedge"],
+          ]}
+        />
+      </DocCard>
+
+      <Callout type="warning">
+        Generated text can be wrong. Every figure it cites comes from the snapshot, but the
+        reasoning around those figures is a model&apos;s. Treat it as a starting point for a
+        conversation, not a source of truth — the underlying numbers on the page are.
       </Callout>
     </section>
   );
@@ -2219,6 +2336,23 @@ function APIReference() {
         },
         {
           method: "GET",
+          path: "/api/ai/status",
+          description: "Capability probe for the AI layer. Returns { enabled, providers } — which providers have a key configured, never the key material. Not rate-limited (no LLM call).",
+          params: [],
+        },
+        {
+          method: "GET",
+          path: "/api/ai/insights",
+          description: "LLM synthesis of a repository's or org's metrics. Returns { ok, provider, model, generated_at, cached, partial, content: { summary, bullets, actions } }. 503 when no provider key is configured or the provider is unavailable; 429 when rate-limited (20/min per token) or the daily token budget is spent. Prompts are built from an allowlisted, metrics-only snapshot — never code, logs, or commit messages.",
+          params: [
+            { name: "owner", type: "string", optional: true, desc: "Repository owner (repo surface — pair with repo)" },
+            { name: "repo", type: "string", optional: true, desc: "Repository name (repo surface)" },
+            { name: "org", type: "string", optional: true, desc: "Organisation login (org surface — takes precedence over owner/repo)" },
+            { name: "refresh", type: "1", optional: true, desc: "Bypass the cached generation. Still rate-limited." },
+          ],
+        },
+        {
+          method: "GET",
           path: "/api/health",
           description: "Liveness/readiness probe. Returns {\"status\":\"ok\"} with no authentication. Used by Kubernetes and load balancers.",
           params: [],
@@ -2470,9 +2604,25 @@ pnpm run lint`}
 function ReleaseNotes() {
   const releases = [
     {
+      version: "4.1.0",
+      date: "2026-08-14",
+      badge: "latest",
+      badgeColor: "bg-emerald-500/15 text-emerald-400 border-emerald-500/20",
+      changes: {
+        added: [
+          "AI Insights — an optional card on the Repository Overview and Team Health Scorecard pages that turns the metrics already on screen into plain-English analysis: what changed, why it matters, and what to do next. Gemini primary with Qwen fallback, both via their OpenAI-compatible endpoints, so no vendor SDK is installed",
+          "Entirely opt-in: with no provider key configured on the server, every AI surface is hidden and GitDash behaves exactly as it did in v4.0.11. New \"AI Insights\" toggle in Settings → Feature Flags, and a new /api/ai/status capability probe",
+          "Privacy is enforced at the type level: prompts are built server-side from an allowlisted snapshot, and the test suite walks the serialized output to fail the build if a token, log, commit message, file path or URL ever appears. Metrics, names, logins and dates are sent; code, logs, YAML and message bodies never are",
+          "Cost controls: 15-minute snapshot-fingerprinted caching, 20 requests/minute per token, a per-attempt and total wall-clock timeout, and a daily token budget (AI_DAILY_TOKEN_BUDGET). All in-process, so they bound cost per instance rather than globally — documented as a damage-limiter, not a hard spend cap",
+        ],
+        fixed: [],
+        improved: [],
+      },
+    },
+    {
       version: "4.0.11",
       date: "2026-08-13",
-      badge: "latest",
+      badge: null,
       badgeColor: "bg-emerald-500/15 text-emerald-400 border-emerald-500/20",
       changes: {
         added: [],
@@ -2913,7 +3063,7 @@ function DocSidebar({
           <BookOpen className="w-4 h-4 text-violet-400" />
           <span className="text-sm font-semibold text-white">GitDash Docs</span>
           <span className="text-xs px-1.5 py-0.5 rounded bg-violet-500/15 text-violet-400 border border-violet-500/20 font-mono">
-            v{process.env.NEXT_PUBLIC_APP_VERSION ?? "4.0.11"}
+            v{process.env.NEXT_PUBLIC_APP_VERSION ?? "4.1.0"}
           </span>
         </div>
         {/* Mobile close */}
@@ -3058,6 +3208,7 @@ export default function DocsPage() {
     "feat-workload-risk":    <FeatureWorkloadRisk />,
     "feat-one-on-one":       <FeatureOneOnOne />,
     "feat-leadership-digest": <FeatureLeadershipDigest />,
+    "feat-ai-insights":       <FeatureAiInsights />,
     "metrics-reference":    <MetricsReference onNavigate={setActive} />,
     "metrics-dora":         <MetricsDora />,
     "metrics-pr-cycle":     <MetricsPrCycle />,
@@ -3162,7 +3313,7 @@ export default function DocsPage() {
 
           {/* Footer */}
           <footer className="mt-8 pb-4 text-center text-xs text-slate-600 space-y-1">
-            <p>GitDash v{process.env.NEXT_PUBLIC_APP_VERSION ?? "4.0.11"} — GitHub Actions Dashboard</p>
+            <p>GitDash v{process.env.NEXT_PUBLIC_APP_VERSION ?? "4.1.0"} — GitHub Actions Dashboard</p>
             <p>
               <a href="https://github.com/dinhdobathi1992/gitdash" target="_blank" rel="noreferrer" className="hover:text-slate-400 transition-colors">
                 Open source on GitHub

--- a/src/app/org/[orgName]/health/page.tsx
+++ b/src/app/org/[orgName]/health/page.tsx
@@ -7,6 +7,7 @@ import { fetcher } from "@/lib/swr";
 import { Breadcrumb } from "@/components/Sidebar";
 import { useFeatureFlags } from "@/components/FeatureFlagsProvider";
 import { LEVEL_COLORS, LEVEL_LABELS } from "@/lib/dora";
+import AiInsightsCard from "@/components/AiInsightsCard";
 import type { OrgHealthScorecardResponse, RepoScorecardEntry } from "@/app/api/github/org-health-scorecard/route";
 import {
   Building2, ShieldCheck, TrendingUp, TrendingDown, Minus,
@@ -350,6 +351,9 @@ export default function OrgHealthScorecardPage({
 
           {data && total > 0 && (
             <>
+              {/* AI Insights — renders nothing unless the server has provider keys */}
+              <AiInsightsCard surface="org" org={orgName} />
+
               {/* Stat tiles */}
               <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
                 <StatTile label="At Risk" value={counts.at_risk} note={`${Math.round((counts.at_risk / total) * 100)}% of estate`} tone="at_risk" />

--- a/src/app/repos/[owner]/[repo]/page.tsx
+++ b/src/app/repos/[owner]/[repo]/page.tsx
@@ -12,6 +12,7 @@ import { RepoWorkflowBreadcrumb } from "@/components/Sidebar";
 import { RunHistoryBars, TrendSparkline, StatusBadge, HealthScoreRing } from "@/components/WorkflowMetrics";
 import { DoraKpiCards, DoraKpiSkeleton } from "@/components/DoraKpiCards";
 import PartialDataBadge from "@/components/PartialDataBadge";
+import AiInsightsCard from "@/components/AiInsightsCard";
 import type { OpenPrHealthResponse } from "@/app/api/github/open-pr-health/route";
 import {
   AlertCircle, ExternalLink, GitBranch, FileCode, RefreshCw,
@@ -445,6 +446,9 @@ export default function RepoDetailPage() {
         </div>
       ) : (
         <div className="space-y-6">
+          {/* AI Insights — renders nothing unless the server has provider keys */}
+          <AiInsightsCard surface="repo" owner={owner} repo={repo} />
+
           {/* DORA KPI Cards */}
           {flags.dora ? (
             doraLoading ? (

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -137,6 +137,7 @@ const FLAG_DEFS: FlagDef[] = [
   { key: "reviewBottleneck", label: "Review Bottleneck", description: "Flags overloaded reviewers and stale review requests from PR review data.", affects: "Repository Team" },
   { key: "healthScorecard", label: "Team Health Scorecard", description: "Org-wide ranked view combining DORA tier and bus-factor risk per repo, worst-first.", affects: "Organization Overview" },
   { key: "workloadRisk", label: "Workload Risk Radar", description: "Flags sustained after-hours/weekend work, activity cliffs, and concurrent-PR overload per person.", affects: "Repository Team" },
+  { key: "aiInsights", label: "AI Insights", description: "LLM-generated analysis of the metrics already on screen. Requires AI provider keys configured on the server — the surfaces stay hidden without them.", affects: "Repository Overview, Organization Health" },
 ];
 
 function Toggle({ on, onChange }: { on: boolean; onChange: (v: boolean) => void }) {

--- a/src/components/AiInsightsCard.tsx
+++ b/src/components/AiInsightsCard.tsx
@@ -1,0 +1,161 @@
+"use client";
+
+/**
+ * AI Insights card (v4.1.0).
+ *
+ * Renders the LLM synthesis of whatever metrics are already on the page.
+ * Two gates, both required: the server must have provider keys configured
+ * (useAiEnabled) and the user must not have switched the surface off
+ * (aiInsights flag). When either is false this renders nothing at all — no
+ * placeholder, no "enable this" nag, so a deployment without AI keys looks
+ * exactly as it did before v4.1.0.
+ *
+ * Failure is a non-event by design. This is an enhancement layered over
+ * metrics the user can already read, so an unavailable provider gets a muted
+ * one-liner rather than an error-red box.
+ */
+
+import { useState } from "react";
+import useSWR from "swr";
+import { fetcher, FetchError } from "@/lib/swr";
+import { useAiEnabled } from "@/lib/use-ai-enabled";
+import { useFeatureFlags } from "@/components/FeatureFlagsProvider";
+import type { AiInsightsResponse } from "@/app/api/ai/insights/route";
+import {
+  Sparkles, ChevronRight, RefreshCw, Loader2, AlertTriangle, Lightbulb,
+} from "lucide-react";
+import { cn } from "@/lib/utils";
+
+type Props =
+  | { surface: "repo"; owner: string; repo: string }
+  | { surface: "org"; org: string };
+
+export default function AiInsightsCard(props: Props) {
+  const { enabled } = useAiEnabled();
+  const { flags } = useFeatureFlags();
+  const [open, setOpen] = useState(true);
+  const [refreshKey, setRefreshKey] = useState(0);
+
+  const query =
+    props.surface === "repo"
+      ? `owner=${encodeURIComponent(props.owner)}&repo=${encodeURIComponent(props.repo)}`
+      : `org=${encodeURIComponent(props.org)}`;
+
+  // refreshKey is a cache-buster for SWR only; refresh=1 tells the route to
+  // bypass its own server-side cache and regenerate.
+  const key =
+    enabled && flags.aiInsights
+      ? `/api/ai/insights?${query}${refreshKey > 0 ? `&refresh=1&_=${refreshKey}` : ""}`
+      : null;
+
+  const { data, error, isLoading, isValidating } = useSWR<AiInsightsResponse>(
+    key,
+    fetcher<AiInsightsResponse>,
+    { errorRetryCount: 0 }, // a 503 here means "unavailable", not "try harder"
+  );
+
+  if (!enabled || !flags.aiInsights) return null;
+
+  const status = error instanceof FetchError ? error.status : null;
+  const unavailableText =
+    status === 429
+      ? "Rate limit reached — try again in a minute."
+      : "AI insights are unavailable right now.";
+
+  return (
+    <div className="rounded-2xl border border-violet-500/20 bg-gradient-to-b from-violet-500/[0.04] to-slate-950/40 overflow-hidden">
+      <button
+        onClick={() => setOpen((v) => !v)}
+        className={cn(
+          "w-full relative flex items-center gap-4 px-5 py-4 text-left transition-colors hover:bg-violet-500/[0.06]",
+          open && "border-b border-violet-500/15",
+        )}
+      >
+        <span className="absolute inset-y-0 left-0 w-[2px] bg-gradient-to-b from-violet-400 to-violet-600" />
+        <span className="shrink-0 w-9 h-9 rounded-lg border border-violet-500/30 bg-violet-500/[0.14] flex items-center justify-center">
+          <Sparkles className="w-4 h-4 text-violet-300" />
+        </span>
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-2.5 flex-wrap">
+            <span className="text-[15px] font-semibold text-white">AI Insights</span>
+            {data?.partial && (
+              <span className="inline-flex items-center gap-1 text-[11px] px-2 py-0.5 rounded-full border border-amber-500/25 bg-amber-500/10 text-amber-300">
+                <AlertTriangle className="w-3 h-3" /> partial data
+              </span>
+            )}
+          </div>
+          <p className="text-xs text-slate-500 mt-0.5">
+            Generated analysis of the metrics on this page — always verify against the numbers.
+          </p>
+        </div>
+        <span className="shrink-0 flex items-center gap-1.5 px-3 py-1.5 rounded-lg border border-slate-700 bg-gradient-to-b from-slate-800 to-slate-900 text-xs text-slate-300">
+          {open ? "Hide" : "Show"}
+          <ChevronRight className={cn("w-3 h-3 transition-transform", open && "rotate-90")} />
+        </span>
+      </button>
+
+      {open && (
+        <div className="p-5">
+          {isLoading && (
+            <div className="flex items-center gap-2.5 text-sm text-violet-200">
+              <Loader2 className="w-4 h-4 animate-spin shrink-0" />
+              <span>Analysing your metrics…</span>
+            </div>
+          )}
+
+          {!isLoading && error && (
+            <p className="text-xs text-slate-500 italic">{unavailableText}</p>
+          )}
+
+          {!isLoading && !error && data && (
+            <div className="space-y-4">
+              <p className="text-sm text-slate-200 leading-relaxed">{data.content.summary}</p>
+
+              {data.content.bullets.length > 0 && (
+                <ul className="space-y-1.5">
+                  {data.content.bullets.map((b, i) => (
+                    <li key={i} className="flex gap-2.5 text-xs text-slate-400">
+                      <span className="mt-1.5 w-1 h-1 rounded-full bg-violet-400 shrink-0" />
+                      <span>{b}</span>
+                    </li>
+                  ))}
+                </ul>
+              )}
+
+              {data.content.actions.length > 0 && (
+                <div className="rounded-xl border border-slate-800 bg-slate-900/40 p-4">
+                  <div className="flex items-center gap-1.5 text-[11px] font-semibold uppercase tracking-wide text-violet-300 mb-2">
+                    <Lightbulb className="w-3.5 h-3.5" /> Suggested actions
+                  </div>
+                  <ul className="space-y-1.5">
+                    {data.content.actions.map((a, i) => (
+                      <li key={i} className="flex gap-2.5 text-xs text-slate-300">
+                        <span className="font-mono text-slate-600 shrink-0">{i + 1}.</span>
+                        <span>{a}</span>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              )}
+
+              <div className="flex items-center justify-between gap-3 pt-1 flex-wrap">
+                <span className="text-[11px] text-slate-600">
+                  {data.provider} · {data.model}
+                  {data.cached && " · cached"}
+                </span>
+                <button
+                  onClick={() => setRefreshKey((k) => k + 1)}
+                  disabled={isValidating}
+                  className="inline-flex items-center gap-1.5 px-2.5 py-1 text-[11px] text-slate-400 hover:text-violet-300 border border-slate-700 rounded-lg transition-colors disabled:opacity-40"
+                >
+                  <RefreshCw className={cn("w-3 h-3", isValidating && "animate-spin")} />
+                  Regenerate
+                </button>
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/lib/ai-prompts.ts
+++ b/src/lib/ai-prompts.ts
@@ -1,0 +1,28 @@
+/**
+ * System prompts for the AI layer (v4.1.0).
+ *
+ * Versioned constants, not built at call time. Two reasons: they are the
+ * behavioural contract for each surface and should change deliberately in a
+ * reviewed diff, and keeping them static means the only variable part of a
+ * request is the typed snapshot — nothing user-supplied ever reaches a prompt.
+ *
+ * Every prompt ends by pinning the exact JSON shape, which is then validated
+ * server-side in ai-schema.ts. The model is asked to hedge on weak signals
+ * rather than guess, because a confident wrong number is worse than a stated
+ * uncertainty on a leadership dashboard.
+ */
+
+export const INSIGHTS_SYSTEM_PROMPT = `You are a senior DevOps analyst embedded in GitDash, a CI/CD analytics
+dashboard. You receive a JSON snapshot of pre-computed engineering metrics.
+
+Rules:
+- Use ONLY numbers and facts present in the snapshot. Never invent metrics,
+  dates, or causes that the data does not support.
+- If a signal is weak or missing (null fields, small sample sizes, or
+  "partial": true), say so explicitly instead of guessing.
+- Be concrete and actionable; no generic advice ("improve testing") - tie
+  every recommendation to a specific snapshot signal.
+- Tone: candid, concise, leadership-friendly. No jargon without a one-clause
+  explanation.
+- Respond with JSON only: {"summary": "...", "bullets": [...], "actions": [...]}
+  summary <= 3 sentences. bullets <= 5, each <= 25 words. actions <= 3, imperative.`;

--- a/src/lib/ai-schema.ts
+++ b/src/lib/ai-schema.ts
@@ -1,0 +1,82 @@
+/**
+ * Validation for model-generated JSON (v4.1.0).
+ *
+ * A model's output is untrusted input. Even in JSON mode a provider can
+ * return a fenced block, a wrong shape, or a 4,000-word "summary" — none of
+ * which should reach a React component. Every parser here returns `null`
+ * rather than throwing, so routes can uniformly retry once and then fall
+ * back to an "unavailable" state.
+ *
+ * Caps are enforced by truncation of the *list*, not the text: an overlong
+ * string is rejected outright rather than silently cut mid-sentence, because
+ * a truncated recommendation reads as a bug.
+ */
+
+export interface InsightsContent {
+  summary: string;
+  bullets: string[];
+  actions: string[];
+}
+
+const MAX_SUMMARY_CHARS = 400;
+const MAX_ITEM_CHARS = 200;
+const MAX_BULLETS = 6;
+const MAX_ACTIONS = 4;
+
+/**
+ * Strip markdown code fences. Models in JSON mode still occasionally wrap
+ * their output in ```json ... ```, and that is not worth a retry.
+ */
+function stripFences(raw: string): string {
+  const trimmed = raw.trim();
+  if (!trimmed.startsWith("```")) return trimmed;
+  return trimmed
+    .replace(/^```(?:json)?\s*/i, "")
+    .replace(/\s*```$/, "")
+    .trim();
+}
+
+function asCleanString(v: unknown, maxChars: number): string | null {
+  if (typeof v !== "string") return null;
+  const s = v.trim();
+  if (!s || s.length > maxChars) return null;
+  return s;
+}
+
+function asStringList(v: unknown, maxItems: number): string[] | null {
+  if (!Array.isArray(v)) return null;
+  const out: string[] = [];
+  for (const item of v.slice(0, maxItems)) {
+    const s = asCleanString(item, MAX_ITEM_CHARS);
+    if (s === null) return null; // a malformed entry invalidates the payload
+    out.push(s);
+  }
+  return out;
+}
+
+/**
+ * Parse and validate the shared {summary, bullets, actions} envelope.
+ * Returns null on any structural problem — callers retry once, then degrade.
+ */
+export function parseInsightsContent(raw: string): InsightsContent | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(stripFences(raw));
+  } catch {
+    return null;
+  }
+
+  if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) return null;
+  const obj = parsed as Record<string, unknown>;
+
+  const summary = asCleanString(obj.summary, MAX_SUMMARY_CHARS);
+  if (summary === null) return null;
+
+  const bullets = asStringList(obj.bullets, MAX_BULLETS);
+  if (bullets === null) return null;
+
+  const actions = asStringList(obj.actions, MAX_ACTIONS);
+  if (actions === null) return null;
+
+  return { summary, bullets, actions };
+}

--- a/src/lib/ai-snapshots.ts
+++ b/src/lib/ai-snapshots.ts
@@ -1,0 +1,273 @@
+/**
+ * Snapshot builders for the AI layer (v4.1.0).
+ *
+ * These are the privacy enforcement point. Everything sent to a model goes
+ * through a builder here, and each builder constructs its result field by
+ * field against an explicit interface — never by spreading a GitHub API
+ * object. Anything absent from the type therefore cannot leak, even if an
+ * upstream fetcher starts returning more.
+ *
+ * Allowed: aggregate numbers, repo/workflow/job/step names, logins, dates.
+ * Never: tokens, run logs, file contents, workflow YAML, PR or commit
+ * message bodies, email addresses.
+ *
+ * `tests/ai-snapshots.test.ts` walks the serialized output of every builder
+ * and fails on a forbidden key, so this rule is checked mechanically rather
+ * than by review.
+ *
+ * Builders reuse existing fetchers only — no new GitHub API surface.
+ */
+
+import { getRepoSummary, listWorkflowFileCommits, getOctokit } from "@/lib/github";
+import type { TrendPoint } from "@/lib/github";
+import { getRepoDoraSummary } from "@/lib/github-dora";
+import { computeBusFactor } from "@/lib/bus-factor";
+import { computeScorecard } from "@/lib/org-health-scorecard";
+import type { DoraLevel } from "@/lib/dora";
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+export interface InsightsDora {
+  deployments_per_day: number;
+  lead_time_p50_hours: number;
+  change_failure_rate_pct: number;
+  /** Null when no recovery events were observed in the window. */
+  mttr_mean_hours: number | null;
+  benchmark: DoraLevel;
+}
+
+export interface InsightsCi {
+  total_runs: number;
+  success_rate_pct: number;
+  success_rate_prev_period_pct: number | null;
+  runs_last_30d: number;
+  failures_last_30d: number;
+}
+
+export interface InsightsBusFactor {
+  overall: number;
+  critical_modules: number;
+  total_contributors: number;
+}
+
+export interface InsightsRiskBands {
+  healthy: number;
+  watch: number;
+  at_risk: number;
+  median_score: number;
+}
+
+export interface InsightsSnapshot {
+  surface: "repo" | "org";
+  /** "owner/repo" or the org login. */
+  scope: string;
+  period_days: number;
+  dora: InsightsDora | null;
+  ci: InsightsCi | null;
+  bus_factor: InsightsBusFactor | null;
+  /** Org surface only — distribution across the health scorecard's bands. */
+  risk_bands: InsightsRiskBands | null;
+  /** Org surface only — the worst-scoring repos, names and scores only. */
+  worst_repos: { repo: string; score: number; band: string; dora_level: DoraLevel }[];
+  /** Metadata only: when the workflow definitions changed, and by whom. */
+  recent_workflow_changes: { date: string; author_login: string | null }[];
+  /** True when any sub-fetch returned partial data — the model is told to hedge. */
+  partial: boolean;
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+const msToHours = (ms: number): number => Math.round((ms / 3_600_000) * 10) / 10;
+
+function median(nums: number[]): number {
+  if (nums.length === 0) return 0;
+  const sorted = [...nums].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  return sorted.length % 2 !== 0
+    ? sorted[mid]
+    : Math.round((sorted[mid - 1] + sorted[mid]) / 2);
+}
+
+/**
+ * Map workflow-file commits down to date + author.
+ *
+ * The source WorkflowFileCommit carries `message`, `sha`, `html_url` and
+ * `file_path`; none of those may reach a prompt. Commit messages in
+ * particular are free text, which is exactly the injection vector this
+ * layer avoids by construction.
+ */
+function toWorkflowChanges(
+  commits: { date: string; author_login: string | null }[],
+  limit: number,
+): { date: string; author_login: string | null }[] {
+  return commits.slice(0, limit).map((c) => ({
+    date: c.date,
+    author_login: c.author_login,
+  }));
+}
+
+/**
+ * Split the 30-day trend into halves so the model can see direction, not just
+ * level. TrendPoint is {date, success, total} — failures are derived.
+ */
+function splitTrend(trend: TrendPoint[]): {
+  total: number;
+  failures: number;
+  ratePct: number;
+  prevRatePct: number | null;
+} {
+  const total = trend.reduce((s, d) => s + d.total, 0);
+  const failures = trend.reduce((s, d) => s + (d.total - d.success), 0);
+  const ratePct = total > 0 ? Math.round(((total - failures) / total) * 100) : 0;
+
+  if (trend.length < 4) return { total, failures, ratePct, prevRatePct: null };
+
+  const half = Math.floor(trend.length / 2);
+  const prior = trend.slice(0, half);
+  const priorTotal = prior.reduce((s, d) => s + d.total, 0);
+  const priorSuccess = prior.reduce((s, d) => s + d.success, 0);
+  const prevRatePct =
+    priorTotal > 0 ? Math.round((priorSuccess / priorTotal) * 100) : null;
+
+  return { total, failures, ratePct, prevRatePct };
+}
+
+// ── Repo surface ──────────────────────────────────────────────────────────────
+
+async function buildRepoInsights(
+  token: string,
+  owner: string,
+  repo: string,
+): Promise<InsightsSnapshot> {
+  const octokit = getOctokit(token);
+
+  // Every sub-fetch is allowed to fail independently — a snapshot with a null
+  // section is still useful, and the prompt tells the model to say so rather
+  // than guess. A hard failure here would take out the whole card.
+  const [summaryRes, doraRes, busRes, commitsRes] = await Promise.allSettled([
+    getRepoSummary(token, owner, repo),
+    getRepoDoraSummary(token, owner, repo),
+    computeBusFactor(octokit, owner, repo),
+    listWorkflowFileCommits(token, owner, repo, 10),
+  ]);
+
+  let partial = false;
+
+  let ci: InsightsCi | null = null;
+  if (summaryRes.status === "fulfilled") {
+    const s = summaryRes.value;
+    const t = splitTrend(s.trend_30d);
+    ci = {
+      total_runs: t.total,
+      success_rate_pct: s.success_rate,
+      success_rate_prev_period_pct: t.prevRatePct,
+      runs_last_30d: t.total,
+      failures_last_30d: t.failures,
+    };
+  } else {
+    partial = true;
+  }
+
+  let dora: InsightsDora | null = null;
+  if (doraRes.status === "fulfilled") {
+    const d = doraRes.value;
+    if (d.partial) partial = true;
+    dora = {
+      deployments_per_day: d.deployment_frequency.per_day,
+      lead_time_p50_hours: msToHours(d.lead_time.median_ms),
+      change_failure_rate_pct: d.change_failure_rate.rate,
+      mttr_mean_hours: d.mttr.mean_ms === null ? null : msToHours(d.mttr.mean_ms),
+      benchmark: d.deployment_frequency.level,
+    };
+  } else {
+    partial = true;
+  }
+
+  let bus_factor: InsightsBusFactor | null = null;
+  if (busRes.status === "fulfilled") {
+    const b = busRes.value;
+    if (b.partial) partial = true;
+    bus_factor = {
+      overall: b.overall_bus_factor,
+      critical_modules: b.critical_modules,
+      total_contributors: b.total_contributors,
+    };
+  } else {
+    partial = true;
+  }
+
+  const recent_workflow_changes =
+    commitsRes.status === "fulfilled" ? toWorkflowChanges(commitsRes.value, 10) : [];
+  if (commitsRes.status === "rejected") partial = true;
+
+  return {
+    surface: "repo",
+    scope: `${owner}/${repo}`,
+    period_days: 30,
+    dora,
+    ci,
+    bus_factor,
+    risk_bands: null,
+    worst_repos: [],
+    recent_workflow_changes,
+    partial,
+  };
+}
+
+// ── Org surface ───────────────────────────────────────────────────────────────
+
+async function buildOrgInsights(token: string, org: string): Promise<InsightsSnapshot> {
+  const octokit = getOctokit(token);
+  const scorecard = await computeScorecard(token, octokit, org, 10);
+
+  const bands = { healthy: 0, watch: 0, at_risk: 0 };
+  for (const r of scorecard.repos) bands[r.risk_band]++;
+
+  const worst = [...scorecard.repos]
+    .sort((a, b) => a.composite_score - b.composite_score)
+    .slice(0, 5)
+    .map((r) => ({
+      repo: r.repo,
+      score: r.composite_score,
+      band: r.risk_band,
+      dora_level: r.dora_level,
+    }));
+
+  const criticalModules = scorecard.repos.reduce((s, r) => s + r.critical_modules, 0);
+  const worstBusFactor = scorecard.repos.length
+    ? Math.min(...scorecard.repos.map((r) => r.overall_bus_factor))
+    : 0;
+
+  return {
+    surface: "org",
+    scope: org,
+    period_days: 30,
+    dora: null,
+    ci: null,
+    bus_factor: scorecard.repos.length
+      ? { overall: worstBusFactor, critical_modules: criticalModules, total_contributors: 0 }
+      : null,
+    risk_bands: {
+      ...bands,
+      median_score: median(scorecard.repos.map((r) => r.composite_score)),
+    },
+    worst_repos: worst,
+    recent_workflow_changes: [],
+    partial: scorecard.repos_analysed < scorecard.repos_attempted,
+  };
+}
+
+// ── Public entry point ────────────────────────────────────────────────────────
+
+export type InsightsScope =
+  | { surface: "repo"; owner: string; repo: string }
+  | { surface: "org"; org: string };
+
+export async function buildInsightsSnapshot(
+  token: string,
+  scope: InsightsScope,
+): Promise<InsightsSnapshot> {
+  return scope.surface === "repo"
+    ? buildRepoInsights(token, scope.owner, scope.repo)
+    : buildOrgInsights(token, scope.org);
+}

--- a/src/lib/ai.ts
+++ b/src/lib/ai.ts
@@ -1,0 +1,323 @@
+/**
+ * AI provider layer (v4.1.0) — Gemini primary, Qwen fallback.
+ *
+ * Zero new dependencies: both providers expose OpenAI-compatible
+ * chat-completions endpoints, so a raw `fetch` is enough.
+ *
+ * Three contracts the rest of the app depends on:
+ *
+ *   1. `generateJson` NEVER throws. Every failure — no keys, disabled,
+ *      timeout, HTTP error, unparseable body — comes back as an `AiFailure`
+ *      with a machine-readable `reason`, so callers can pick their own
+ *      fallback UX instead of wrapping everything in try/catch.
+ *   2. Nothing here logs prompt content or snapshot payloads. Provider,
+ *      model, latency, status and token counts only.
+ *   3. Env is read inside the functions, never at module scope, so a
+ *      deployment can flip AI_DISABLED without a rebuild (and so tests can
+ *      vary it between cases).
+ *
+ * Cost note: the daily token budget below is an in-process counter, which
+ * means it is PER INSTANCE, not global. On a serverless platform each
+ * instance carries its own budget, so this is a damage-limiter — it turns a
+ * runaway loop into a bounded-per-instance cost — not a hard spend cap. A
+ * shared limiter would need the database; that was deliberately deferred to
+ * keep this release free of schema changes (see docs/specs, §6.2).
+ */
+
+export type AiProvider = "gemini" | "qwen";
+
+export interface AiSuccess {
+  ok: true;
+  provider: AiProvider;
+  model: string;
+  /** Raw text returned by the model — expected to be a JSON document. */
+  content: string;
+  usage?: { prompt_tokens: number; completion_tokens: number };
+}
+
+export type AiFailureReason =
+  | "disabled"
+  | "no_keys"
+  | "budget_exceeded"
+  | "timeout"
+  | "provider_error"
+  | "bad_response";
+
+export interface AiFailure {
+  ok: false;
+  reason: AiFailureReason;
+  /** Safe for server logs. Never surface verbatim to a client. */
+  error: string;
+}
+
+export type AiResult = AiSuccess | AiFailure;
+
+interface ProviderConfig {
+  name: AiProvider;
+  keyEnv: string;
+  baseEnv: string;
+  modelEnv: string;
+  defaultBase: string;
+  defaultModel: string;
+}
+
+/** Attempt order is significant: index 0 is primary. */
+const PROVIDERS: ProviderConfig[] = [
+  {
+    name: "gemini",
+    keyEnv: "GEMINI_API_KEY",
+    baseEnv: "GEMINI_BASE_URL",
+    modelEnv: "GEMINI_MODEL",
+    defaultBase: "https://generativelanguage.googleapis.com/v1beta/openai",
+    defaultModel: "gemini-2.5-flash",
+  },
+  {
+    name: "qwen",
+    keyEnv: "QWEN_API_KEY",
+    baseEnv: "QWEN_BASE_URL",
+    modelEnv: "QWEN_MODEL",
+    defaultBase: "https://dashscope-intl.aliyuncs.com/compatible-mode/v1",
+    defaultModel: "qwen-plus",
+  },
+];
+
+const DEFAULT_TIMEOUT_MS = 15_000;
+const DEFAULT_TOTAL_BUDGET_MS = 45_000;
+const DEFAULT_DAILY_TOKEN_BUDGET = 2_000_000;
+
+function envInt(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (!raw) return fallback;
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : fallback;
+}
+
+function isDisabled(): boolean {
+  return process.env.AI_DISABLED === "true";
+}
+
+/** Providers with a key present, in attempt order. Never returns key material. */
+export function configuredProviders(): AiProvider[] {
+  return PROVIDERS.filter((p) => Boolean(process.env[p.keyEnv])).map((p) => p.name);
+}
+
+/** True when the layer is not hard-disabled and at least one provider has a key. */
+export function aiEnabled(): boolean {
+  if (isDisabled()) return false;
+  return configuredProviders().length > 0;
+}
+
+// ── Daily token budget ────────────────────────────────────────────────────────
+// Per-instance, UTC-day keyed. See the cost note in the file header.
+
+let budgetState = { day: "", tokens: 0 };
+
+function utcDay(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+function budgetLimit(): number {
+  return envInt("AI_DAILY_TOKEN_BUDGET", DEFAULT_DAILY_TOKEN_BUDGET);
+}
+
+function budgetExhausted(): boolean {
+  const limit = budgetLimit();
+  if (limit === 0) return false; // 0 = unlimited
+  if (budgetState.day !== utcDay()) return false; // new day resets on next record
+  return budgetState.tokens >= limit;
+}
+
+function recordTokens(used: number): void {
+  const today = utcDay();
+  if (budgetState.day !== today) budgetState = { day: today, tokens: 0 };
+  budgetState.tokens += used;
+}
+
+/** Exposed for tests and future observability. Never includes key material. */
+export function budgetSnapshot(): { day: string; tokens: number; limit: number } {
+  return { day: budgetState.day, tokens: budgetState.tokens, limit: budgetLimit() };
+}
+
+/** Test-only: clear the in-process daily counter. */
+export function __resetBudgetForTests(): void {
+  budgetState = { day: "", tokens: 0 };
+}
+
+// ── Provider call ─────────────────────────────────────────────────────────────
+
+interface AttemptOutcome {
+  kind: "success" | "retryable" | "fatal";
+  result?: AiSuccess;
+  error: string;
+}
+
+async function callProvider(
+  cfg: ProviderConfig,
+  systemPrompt: string,
+  userPayload: unknown,
+  opts: { temperature: number; maxOutputTokens: number; timeoutMs: number },
+): Promise<AttemptOutcome> {
+  const key = process.env[cfg.keyEnv]!;
+  const baseUrl = (process.env[cfg.baseEnv] || cfg.defaultBase).replace(/\/+$/, "");
+  const model = process.env[cfg.modelEnv] || cfg.defaultModel;
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), opts.timeoutMs);
+  const startedAt = Date.now();
+
+  try {
+    const res = await fetch(`${baseUrl}/chat/completions`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${key}`,
+      },
+      body: JSON.stringify({
+        model,
+        messages: [
+          { role: "system", content: systemPrompt },
+          { role: "user", content: JSON.stringify(userPayload) },
+        ],
+        temperature: opts.temperature,
+        max_tokens: opts.maxOutputTokens,
+        response_format: { type: "json_object" },
+      }),
+      signal: controller.signal,
+    });
+
+    const latency = Date.now() - startedAt;
+
+    if (!res.ok) {
+      // 400/401/403 are configuration problems — retrying the same provider
+      // cannot help, so fall straight through to the next one.
+      const retryable = res.status === 429 || res.status >= 500;
+      console.error(
+        `[ai] ${cfg.name}/${model} HTTP ${res.status} in ${latency}ms (${retryable ? "retryable" : "fatal"})`,
+      );
+      return {
+        kind: retryable ? "retryable" : "fatal",
+        error: `${cfg.name} returned HTTP ${res.status}`,
+      };
+    }
+
+    const json = (await res.json()) as {
+      choices?: { message?: { content?: string } }[];
+      usage?: { prompt_tokens?: number; completion_tokens?: number };
+    };
+    const content = json.choices?.[0]?.message?.content;
+
+    if (!content || !content.trim()) {
+      console.error(`[ai] ${cfg.name}/${model} returned an empty completion in ${latency}ms`);
+      return { kind: "retryable", error: `${cfg.name} returned an empty completion` };
+    }
+
+    const usage =
+      json.usage && typeof json.usage.prompt_tokens === "number"
+        ? {
+            prompt_tokens: json.usage.prompt_tokens ?? 0,
+            completion_tokens: json.usage.completion_tokens ?? 0,
+          }
+        : undefined;
+
+    if (usage) recordTokens(usage.prompt_tokens + usage.completion_tokens);
+
+    console.info(
+      `[ai] ${cfg.name}/${model} ok in ${latency}ms` +
+        (usage ? ` (${usage.prompt_tokens}+${usage.completion_tokens} tokens)` : ""),
+    );
+
+    return {
+      kind: "success",
+      result: { ok: true, provider: cfg.name, model, content, usage },
+      error: "",
+    };
+  } catch (e) {
+    const latency = Date.now() - startedAt;
+    const aborted = e instanceof Error && e.name === "AbortError";
+    console.error(
+      `[ai] ${cfg.name}/${model} ${aborted ? "timed out" : "failed"} after ${latency}ms`,
+    );
+    // A timeout is retryable in principle, but the caller's total budget is the
+    // real guard — the loop below re-checks the deadline before every attempt.
+    return {
+      kind: "retryable",
+      error: aborted ? `${cfg.name} timed out` : `${cfg.name} request failed`,
+    };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+/**
+ * Ask a provider for a JSON document, trying Gemini then Qwen.
+ *
+ * `userPayload` is JSON-serialized as the user message — it must be a typed
+ * snapshot from src/lib/ai-snapshots.ts, never free-form user input.
+ */
+export async function generateJson(
+  systemPrompt: string,
+  userPayload: unknown,
+  opts?: { temperature?: number; maxOutputTokens?: number },
+): Promise<AiResult> {
+  if (isDisabled()) {
+    return { ok: false, reason: "disabled", error: "AI layer is disabled by AI_DISABLED" };
+  }
+
+  const available = PROVIDERS.filter((p) => Boolean(process.env[p.keyEnv]));
+  if (available.length === 0) {
+    return { ok: false, reason: "no_keys", error: "No AI provider key is configured" };
+  }
+
+  if (budgetExhausted()) {
+    const { tokens, limit } = budgetSnapshot();
+    console.warn(`[ai] daily token budget exhausted (${tokens}/${limit}) — skipping call`);
+    return { ok: false, reason: "budget_exceeded", error: "Daily AI token budget exhausted" };
+  }
+
+  const perAttemptMs = envInt("AI_TIMEOUT_MS", DEFAULT_TIMEOUT_MS);
+  const deadline = Date.now() + envInt("AI_TOTAL_BUDGET_MS", DEFAULT_TOTAL_BUDGET_MS);
+  const temperature = opts?.temperature ?? 0.2;
+  const maxOutputTokens = opts?.maxOutputTokens ?? 900;
+
+  let lastError = "All AI providers failed";
+
+  for (const cfg of available) {
+    // One wall-clock deadline spans every attempt, so a slow primary can never
+    // push a single request past the route's maxDuration.
+    const remaining = deadline - Date.now();
+    if (remaining <= 0) {
+      return { ok: false, reason: "timeout", error: "AI total time budget exhausted" };
+    }
+
+    const attempt = await callProvider(cfg, systemPrompt, userPayload, {
+      temperature,
+      maxOutputTokens,
+      timeoutMs: Math.min(perAttemptMs, remaining),
+    });
+
+    if (attempt.kind === "success") return attempt.result!;
+    lastError = attempt.error;
+
+    if (attempt.kind === "retryable") {
+      const left = deadline - Date.now();
+      if (left > 1_000) {
+        await sleep(1_000);
+        const retry = await callProvider(cfg, systemPrompt, userPayload, {
+          temperature,
+          maxOutputTokens,
+          timeoutMs: Math.min(perAttemptMs, deadline - Date.now()),
+        });
+        if (retry.kind === "success") return retry.result!;
+        lastError = retry.error;
+      }
+    }
+    // fatal → fall through to the next provider without retrying this one
+  }
+
+  if (Date.now() >= deadline) {
+    return { ok: false, reason: "timeout", error: "AI total time budget exhausted" };
+  }
+  return { ok: false, reason: "provider_error", error: lastError };
+}

--- a/src/lib/feature-flags.ts
+++ b/src/lib/feature-flags.ts
@@ -11,6 +11,7 @@ export type FeatureFlags = {
   reviewBottleneck: boolean;
   healthScorecard: boolean;
   workloadRisk: boolean;
+  aiInsights: boolean;
 };
 
 export const DEFAULT_FLAGS: FeatureFlags = {
@@ -26,6 +27,7 @@ export const DEFAULT_FLAGS: FeatureFlags = {
   reviewBottleneck: true,
   healthScorecard: true,
   workloadRisk: true,
+  aiInsights: true,
 };
 
 export const STORAGE_KEY = "gitdash:feature-flags";

--- a/src/lib/ratelimit.ts
+++ b/src/lib/ratelimit.ts
@@ -41,6 +41,26 @@ export function rateLimit(
   return { allowed: true };
 }
 
+/**
+ * Token-hash-keyed limiter for authenticated, cost-bearing routes (v4.1.0).
+ *
+ * getRateLimitKey() below keys on IP, which is the wrong axis for AI routes:
+ * the cost follows the *token*, so one user moving between networks should
+ * still be limited. Callers pass hashKey(token) from src/lib/cache.ts —
+ * never the raw token.
+ *
+ * Like the underlying limiter this is in-process, so on a multi-instance
+ * deployment it bounds per instance rather than globally. It is one of two
+ * guards; the other is the daily token budget in src/lib/ai.ts.
+ */
+export function aiRateLimit(
+  tokenHash: string,
+  surface: string,
+  limit: number,
+): { allowed: boolean; retryAfterMs?: number } {
+  return rateLimit(`ai:${surface}:${tokenHash}`, limit, 60_000);
+}
+
 /** Derive a rate-limit key from the request — prefer real IP, fallback to "unknown". */
 export function getRateLimitKey(req: Request, prefix: string): string {
   const forwarded = (req.headers as Headers).get("x-forwarded-for");

--- a/src/lib/use-ai-enabled.ts
+++ b/src/lib/use-ai-enabled.ts
@@ -1,0 +1,35 @@
+"use client";
+
+/**
+ * useAiEnabled — is the server's AI layer configured? (v4.1.0)
+ *
+ * Every AI surface is gated on this. It is deliberately a server probe rather
+ * than a client flag: the feature flag in feature-flags.ts is localStorage-
+ * backed and can be flipped by anyone, so it controls visibility only. This
+ * hook reports what the server can actually do.
+ *
+ * SWRProvider sets dedupingInterval to 10 minutes, so every call site shares a
+ * single request — no extra caching needed here.
+ */
+
+import useSWR from "swr";
+import { fetcher } from "@/lib/swr";
+import type { AiStatusResponse } from "@/app/api/ai/status/route";
+
+export function useAiEnabled(): {
+  enabled: boolean;
+  providers: string[];
+  isLoading: boolean;
+} {
+  const { data, isLoading } = useSWR<AiStatusResponse>(
+    "/api/ai/status",
+    fetcher<AiStatusResponse>,
+  );
+
+  return {
+    // Default to false while loading so a surface never flashes in and out.
+    enabled: data?.enabled ?? false,
+    providers: data?.providers ?? [],
+    isLoading,
+  };
+}

--- a/tests/ai-schema.test.ts
+++ b/tests/ai-schema.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect } from "vitest";
+import { parseInsightsContent } from "@/lib/ai-schema";
+
+const valid = {
+  summary: "Deployment frequency is healthy but change failure rate is rising.",
+  bullets: ["CFR rose from 8% to 12%", "Bus factor is 1 on src/app"],
+  actions: ["Pair on src/app to raise its bus factor"],
+};
+
+describe("parseInsightsContent", () => {
+  it("accepts a well-formed payload", () => {
+    expect(parseInsightsContent(JSON.stringify(valid))).toEqual(valid);
+  });
+
+  it("trims surrounding whitespace on every string", () => {
+    const parsed = parseInsightsContent(
+      JSON.stringify({ summary: "  s  ", bullets: ["  b  "], actions: ["  a  "] }),
+    );
+    expect(parsed).toEqual({ summary: "s", bullets: ["b"], actions: ["a"] });
+  });
+
+  it("accepts empty bullet and action lists", () => {
+    const parsed = parseInsightsContent(
+      JSON.stringify({ summary: "Nothing notable this period.", bullets: [], actions: [] }),
+    );
+    expect(parsed).toEqual({ summary: "Nothing notable this period.", bullets: [], actions: [] });
+  });
+
+  it("strips ```json fences that models add even in JSON mode", () => {
+    const fenced = "```json\n" + JSON.stringify(valid) + "\n```";
+    expect(parseInsightsContent(fenced)).toEqual(valid);
+  });
+
+  it("strips bare ``` fences", () => {
+    expect(parseInsightsContent("```\n" + JSON.stringify(valid) + "\n```")).toEqual(valid);
+  });
+
+  it("truncates an over-long bullet list to the cap", () => {
+    const parsed = parseInsightsContent(
+      JSON.stringify({ ...valid, bullets: Array.from({ length: 20 }, (_, i) => `b${i}`) }),
+    );
+    expect(parsed?.bullets).toHaveLength(6);
+  });
+
+  it("truncates an over-long action list to the cap", () => {
+    const parsed = parseInsightsContent(
+      JSON.stringify({ ...valid, actions: Array.from({ length: 20 }, (_, i) => `a${i}`) }),
+    );
+    expect(parsed?.actions).toHaveLength(4);
+  });
+
+  // ── Rejections ──────────────────────────────────────────────────────────────
+
+  it("rejects non-JSON garbage", () => {
+    expect(parseInsightsContent("I'm sorry, I can't help with that.")).toBeNull();
+  });
+
+  it("rejects an empty string", () => {
+    expect(parseInsightsContent("")).toBeNull();
+  });
+
+  it("rejects a JSON array at the top level", () => {
+    expect(parseInsightsContent("[1,2,3]")).toBeNull();
+  });
+
+  it("rejects JSON null", () => {
+    expect(parseInsightsContent("null")).toBeNull();
+  });
+
+  it("rejects a missing summary", () => {
+    expect(parseInsightsContent(JSON.stringify({ bullets: [], actions: [] }))).toBeNull();
+  });
+
+  it("rejects a missing bullets key", () => {
+    expect(parseInsightsContent(JSON.stringify({ summary: "s", actions: [] }))).toBeNull();
+  });
+
+  it("rejects a missing actions key", () => {
+    expect(parseInsightsContent(JSON.stringify({ summary: "s", bullets: [] }))).toBeNull();
+  });
+
+  it("rejects a non-string summary", () => {
+    expect(parseInsightsContent(JSON.stringify({ ...valid, summary: 42 }))).toBeNull();
+  });
+
+  it("rejects an empty summary", () => {
+    expect(parseInsightsContent(JSON.stringify({ ...valid, summary: "   " }))).toBeNull();
+  });
+
+  it("rejects a summary over the character cap", () => {
+    expect(parseInsightsContent(JSON.stringify({ ...valid, summary: "x".repeat(401) }))).toBeNull();
+  });
+
+  it("rejects bullets that are not an array", () => {
+    expect(parseInsightsContent(JSON.stringify({ ...valid, bullets: "not a list" }))).toBeNull();
+  });
+
+  it("rejects a bullet list containing a non-string", () => {
+    expect(parseInsightsContent(JSON.stringify({ ...valid, bullets: ["ok", 7] }))).toBeNull();
+  });
+
+  it("rejects an individual item over the character cap", () => {
+    expect(
+      parseInsightsContent(JSON.stringify({ ...valid, bullets: ["x".repeat(201)] })),
+    ).toBeNull();
+  });
+
+  it("never throws on hostile input", () => {
+    const hostile = ['{"summary":', "{", "[}", '{"summary":{"a":1},"bullets":[],"actions":[]}'];
+    for (const h of hostile) {
+      expect(() => parseInsightsContent(h)).not.toThrow();
+    }
+  });
+});

--- a/tests/ai-snapshots.test.ts
+++ b/tests/ai-snapshots.test.ts
@@ -1,0 +1,283 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+/**
+ * Snapshot-builder tests, with the privacy allowlist checked mechanically.
+ *
+ * The point of the builders is that a field absent from the interface cannot
+ * leak into a prompt. `assertNoForbiddenKeys` enforces that by walking the
+ * serialized snapshot, so an upstream fetcher that starts returning commit
+ * messages or file contents fails a test rather than quietly shipping them
+ * to a model.
+ *
+ * Every AI snapshot builder added later must reuse this helper.
+ */
+
+/** Keys that must never appear anywhere in a snapshot, at any depth. */
+const FORBIDDEN_KEYS = [
+  "token", "pat", "accessToken", "access_token", "apiKey", "api_key",
+  "logs", "log", "body", "content", "yaml", "yml",
+  "message", "commit_message", "patch", "diff",
+  "email", "html_url", "sha",
+];
+
+export function assertNoForbiddenKeys(obj: unknown, path = "$"): void {
+  if (obj === null || typeof obj !== "object") return;
+  if (Array.isArray(obj)) {
+    obj.forEach((v, i) => assertNoForbiddenKeys(v, `${path}[${i}]`));
+    return;
+  }
+  for (const [k, v] of Object.entries(obj as Record<string, unknown>)) {
+    expect(
+      FORBIDDEN_KEYS,
+      `forbidden key "${k}" found at ${path}.${k} — snapshots must not carry it`,
+    ).not.toContain(k);
+    assertNoForbiddenKeys(v, `${path}.${k}`);
+  }
+}
+
+// ── Mocks for every fetcher a builder reuses ─────────────────────────────────
+
+const getRepoSummary = vi.fn();
+const listWorkflowFileCommits = vi.fn();
+const getRepoDoraSummary = vi.fn();
+const computeBusFactor = vi.fn();
+const computeScorecard = vi.fn();
+
+vi.mock("@/lib/github", () => ({
+  getRepoSummary: (...a: unknown[]) => getRepoSummary(...a),
+  listWorkflowFileCommits: (...a: unknown[]) => listWorkflowFileCommits(...a),
+  getOctokit: () => ({}),
+}));
+vi.mock("@/lib/github-dora", () => ({
+  getRepoDoraSummary: (...a: unknown[]) => getRepoDoraSummary(...a),
+}));
+vi.mock("@/lib/bus-factor", () => ({
+  computeBusFactor: (...a: unknown[]) => computeBusFactor(...a),
+}));
+vi.mock("@/lib/org-health-scorecard", () => ({
+  computeScorecard: (...a: unknown[]) => computeScorecard(...a),
+}));
+
+// ── Fixtures — deliberately carrying forbidden fields ────────────────────────
+// Each fixture mimics the *real* upstream shape, including the sensitive
+// fields the builder is responsible for dropping.
+
+const repoSummaryFixture = {
+  latest_conclusion: "success",
+  latest_status: "completed",
+  latest_run_at: "2026-08-13T10:00:00Z",
+  latest_actor: "octocat",
+  latest_sha: "deadbeef",
+  latest_message: "fix: do not leak this commit message",
+  recent_runs: [],
+  trend_30d: Array.from({ length: 30 }, (_, i) => ({
+    date: `2026-07-${String(i + 1).padStart(2, "0")}`,
+    success: 8,
+    total: 10,
+  })),
+  success_rate: 80,
+};
+
+const doraFixture = {
+  deployment_frequency: { per_day: 1.5, total: 45, period_days: 30, level: "high", label: "High" },
+  lead_time: { median_ms: 7_200_000, p95_ms: 20_000_000, sample_size: 20, level: "high", label: "High" },
+  change_failure_rate: { rate: 12, failures: 5, total: 42, level: "medium", label: "Medium" },
+  mttr: { mean_ms: 3_600_000, recoveries: 4, level: "high", label: "High" },
+  overall_level: "high",
+  cycle_breakdown: {},
+  pr_scatter: [],
+  throughput_by_week: [],
+  prs_analysed: 42,
+  releases_analysed: 3,
+  partial: false,
+  fetched_prs: 42,
+  total_prs_attempted: 42,
+};
+
+const busFactorFixture = {
+  modules: [{ path: "src/app", bus_factor: 1 }],
+  overall_bus_factor: 2,
+  total_commits: 120,
+  critical_modules: 3,
+  total_contributors: 4,
+  partial: false,
+};
+
+const workflowCommitsFixture = [
+  {
+    sha: "abc123",
+    message: "ci: bump node — this message must not reach a prompt",
+    author_login: "octocat",
+    author_avatar: "https://example.test/a.png",
+    author_name: "Octo Cat",
+    date: "2026-08-10T09:00:00Z",
+    html_url: "https://github.com/o/r/commit/abc123",
+    file_path: ".github/workflows/ci.yml",
+  },
+];
+
+const scorecardFixture = {
+  org: "acme",
+  repos: [
+    { owner: "acme", repo: "alpha", dora_level: "low", overall_bus_factor: 1, critical_modules: 5, composite_score: 25, risk_band: "at_risk", trend: "flat", partial: false },
+    { owner: "acme", repo: "beta", dora_level: "medium", overall_bus_factor: 2, critical_modules: 1, composite_score: 54, risk_band: "watch", trend: "up", partial: false },
+    { owner: "acme", repo: "gamma", dora_level: "high", overall_bus_factor: 3, critical_modules: 0, composite_score: 85, risk_band: "healthy", trend: "up", partial: false },
+  ],
+  repos_analysed: 3,
+  repos_attempted: 3,
+};
+
+beforeEach(() => {
+  getRepoSummary.mockReset().mockResolvedValue(repoSummaryFixture);
+  getRepoDoraSummary.mockReset().mockResolvedValue(doraFixture);
+  computeBusFactor.mockReset().mockResolvedValue(busFactorFixture);
+  listWorkflowFileCommits.mockReset().mockResolvedValue(workflowCommitsFixture);
+  computeScorecard.mockReset().mockResolvedValue(scorecardFixture);
+});
+
+// ── Repo surface ──────────────────────────────────────────────────────────────
+
+describe("buildInsightsSnapshot — repo surface", () => {
+  it("produces the expected shape from healthy fixtures", async () => {
+    const { buildInsightsSnapshot } = await import("@/lib/ai-snapshots");
+    const snap = await buildInsightsSnapshot("tok", { surface: "repo", owner: "o", repo: "r" });
+
+    expect(snap.surface).toBe("repo");
+    expect(snap.scope).toBe("o/r");
+    expect(snap.period_days).toBe(30);
+    expect(snap.dora).toEqual({
+      deployments_per_day: 1.5,
+      lead_time_p50_hours: 2,
+      change_failure_rate_pct: 12,
+      mttr_mean_hours: 1,
+      benchmark: "high",
+    });
+    expect(snap.ci).toMatchObject({ total_runs: 300, success_rate_pct: 80 });
+    expect(snap.bus_factor).toEqual({ overall: 2, critical_modules: 3, total_contributors: 4 });
+    expect(snap.partial).toBe(false);
+  });
+
+  it("carries no forbidden keys", async () => {
+    const { buildInsightsSnapshot } = await import("@/lib/ai-snapshots");
+    const snap = await buildInsightsSnapshot("tok", { surface: "repo", owner: "o", repo: "r" });
+    assertNoForbiddenKeys(snap);
+  });
+
+  it("drops commit messages, shas and urls from workflow-change metadata", async () => {
+    const { buildInsightsSnapshot } = await import("@/lib/ai-snapshots");
+    const snap = await buildInsightsSnapshot("tok", { surface: "repo", owner: "o", repo: "r" });
+
+    expect(snap.recent_workflow_changes).toEqual([
+      { date: "2026-08-10T09:00:00Z", author_login: "octocat" },
+    ]);
+    const serialized = JSON.stringify(snap);
+    expect(serialized).not.toContain("must not reach a prompt");
+    expect(serialized).not.toContain("abc123");
+    expect(serialized).not.toContain("github.com");
+  });
+
+  it("never serializes the latest commit message from the repo summary", async () => {
+    const { buildInsightsSnapshot } = await import("@/lib/ai-snapshots");
+    const snap = await buildInsightsSnapshot("tok", { surface: "repo", owner: "o", repo: "r" });
+    expect(JSON.stringify(snap)).not.toContain("do not leak this commit message");
+  });
+
+  it("degrades to a partial snapshot when a sub-fetch fails instead of throwing", async () => {
+    getRepoDoraSummary.mockRejectedValue(new Error("rate limited"));
+    computeBusFactor.mockRejectedValue(new Error("rate limited"));
+
+    const { buildInsightsSnapshot } = await import("@/lib/ai-snapshots");
+    const snap = await buildInsightsSnapshot("tok", { surface: "repo", owner: "o", repo: "r" });
+
+    expect(snap.dora).toBeNull();
+    expect(snap.bus_factor).toBeNull();
+    expect(snap.ci).not.toBeNull();
+    expect(snap.partial).toBe(true);
+  });
+
+  it("flags partial when an upstream fetcher reports partial data", async () => {
+    getRepoDoraSummary.mockResolvedValue({ ...doraFixture, partial: true });
+
+    const { buildInsightsSnapshot } = await import("@/lib/ai-snapshots");
+    const snap = await buildInsightsSnapshot("tok", { surface: "repo", owner: "o", repo: "r" });
+    expect(snap.partial).toBe(true);
+  });
+
+  it("reports a null MTTR rather than inventing a zero", async () => {
+    getRepoDoraSummary.mockResolvedValue({
+      ...doraFixture,
+      mttr: { mean_ms: null, recoveries: 0, level: "high", label: "High" },
+    });
+
+    const { buildInsightsSnapshot } = await import("@/lib/ai-snapshots");
+    const snap = await buildInsightsSnapshot("tok", { surface: "repo", owner: "o", repo: "r" });
+    expect(snap.dora?.mttr_mean_hours).toBeNull();
+  });
+});
+
+// ── Org surface ───────────────────────────────────────────────────────────────
+
+describe("buildInsightsSnapshot — org surface", () => {
+  it("summarises the scorecard into bands and worst repos", async () => {
+    const { buildInsightsSnapshot } = await import("@/lib/ai-snapshots");
+    const snap = await buildInsightsSnapshot("tok", { surface: "org", org: "acme" });
+
+    expect(snap.surface).toBe("org");
+    expect(snap.scope).toBe("acme");
+    expect(snap.risk_bands).toEqual({ healthy: 1, watch: 1, at_risk: 1, median_score: 54 });
+    expect(snap.worst_repos[0]).toEqual({
+      repo: "alpha",
+      score: 25,
+      band: "at_risk",
+      dora_level: "low",
+    });
+    expect(snap.bus_factor).toEqual({
+      overall: 1,
+      critical_modules: 6,
+      total_contributors: 0,
+    });
+  });
+
+  it("carries no forbidden keys", async () => {
+    const { buildInsightsSnapshot } = await import("@/lib/ai-snapshots");
+    const snap = await buildInsightsSnapshot("tok", { surface: "org", org: "acme" });
+    assertNoForbiddenKeys(snap);
+  });
+
+  it("caps worst_repos at five entries", async () => {
+    computeScorecard.mockResolvedValue({
+      ...scorecardFixture,
+      repos: Array.from({ length: 12 }, (_, i) => ({
+        ...scorecardFixture.repos[0],
+        repo: `r${i}`,
+        composite_score: i * 5,
+      })),
+      repos_analysed: 12,
+      repos_attempted: 12,
+    });
+
+    const { buildInsightsSnapshot } = await import("@/lib/ai-snapshots");
+    const snap = await buildInsightsSnapshot("tok", { surface: "org", org: "acme" });
+    expect(snap.worst_repos).toHaveLength(5);
+    expect(snap.worst_repos[0].score).toBe(0);
+  });
+
+  it("marks partial when the scorecard could not score every repo", async () => {
+    computeScorecard.mockResolvedValue({ ...scorecardFixture, repos_analysed: 2, repos_attempted: 3 });
+
+    const { buildInsightsSnapshot } = await import("@/lib/ai-snapshots");
+    const snap = await buildInsightsSnapshot("tok", { surface: "org", org: "acme" });
+    expect(snap.partial).toBe(true);
+  });
+
+  it("handles an org with no scoreable repos", async () => {
+    computeScorecard.mockResolvedValue({ org: "acme", repos: [], repos_analysed: 0, repos_attempted: 0 });
+
+    const { buildInsightsSnapshot } = await import("@/lib/ai-snapshots");
+    const snap = await buildInsightsSnapshot("tok", { surface: "org", org: "acme" });
+
+    expect(snap.bus_factor).toBeNull();
+    expect(snap.worst_repos).toEqual([]);
+    expect(snap.risk_bands).toEqual({ healthy: 0, watch: 0, at_risk: 0, median_score: 0 });
+  });
+});

--- a/tests/ai.test.ts
+++ b/tests/ai.test.ts
@@ -1,0 +1,344 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+/**
+ * The AI layer reads process.env inside its functions, so each test can set
+ * env directly. `fetch` is stubbed globally — no test in this file touches
+ * the network.
+ */
+
+const AI_ENV = [
+  "AI_DISABLED",
+  "AI_TIMEOUT_MS",
+  "AI_TOTAL_BUDGET_MS",
+  "AI_DAILY_TOKEN_BUDGET",
+  "GEMINI_API_KEY",
+  "GEMINI_BASE_URL",
+  "GEMINI_MODEL",
+  "QWEN_API_KEY",
+  "QWEN_BASE_URL",
+  "QWEN_MODEL",
+];
+
+function clearAiEnv() {
+  for (const k of AI_ENV) delete process.env[k];
+}
+
+/** Minimal OpenAI-compatible success body. */
+function okBody(content = '{"summary":"ok"}', usage = { prompt_tokens: 100, completion_tokens: 20 }) {
+  return {
+    ok: true,
+    status: 200,
+    json: async () => ({ choices: [{ message: { content } }], usage }),
+  } as unknown as Response;
+}
+
+function errBody(status: number) {
+  return { ok: false, status, json: async () => ({}) } as unknown as Response;
+}
+
+let fetchMock: ReturnType<typeof vi.fn>;
+
+beforeEach(async () => {
+  clearAiEnv();
+  fetchMock = vi.fn();
+  vi.stubGlobal("fetch", fetchMock);
+  // Silence the layer's structured logging during tests.
+  vi.spyOn(console, "info").mockImplementation(() => {});
+  vi.spyOn(console, "warn").mockImplementation(() => {});
+  vi.spyOn(console, "error").mockImplementation(() => {});
+  const { __resetBudgetForTests } = await import("@/lib/ai");
+  __resetBudgetForTests();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+  clearAiEnv();
+});
+
+describe("aiEnabled", () => {
+  it("is false when no provider key is set", async () => {
+    const { aiEnabled } = await import("@/lib/ai");
+    expect(aiEnabled()).toBe(false);
+  });
+
+  it("is true when GEMINI_API_KEY is set", async () => {
+    process.env.GEMINI_API_KEY = "k";
+    const { aiEnabled } = await import("@/lib/ai");
+    expect(aiEnabled()).toBe(true);
+  });
+
+  it("is true when only QWEN_API_KEY is set", async () => {
+    process.env.QWEN_API_KEY = "k";
+    const { aiEnabled } = await import("@/lib/ai");
+    expect(aiEnabled()).toBe(true);
+  });
+
+  it("is false when AI_DISABLED=true even with keys present", async () => {
+    process.env.GEMINI_API_KEY = "k";
+    process.env.QWEN_API_KEY = "k";
+    process.env.AI_DISABLED = "true";
+    const { aiEnabled } = await import("@/lib/ai");
+    expect(aiEnabled()).toBe(false);
+  });
+});
+
+describe("configuredProviders", () => {
+  it("returns an empty list with no keys", async () => {
+    const { configuredProviders } = await import("@/lib/ai");
+    expect(configuredProviders()).toEqual([]);
+  });
+
+  it("returns gemini before qwen when both are configured", async () => {
+    process.env.GEMINI_API_KEY = "k";
+    process.env.QWEN_API_KEY = "k";
+    const { configuredProviders } = await import("@/lib/ai");
+    expect(configuredProviders()).toEqual(["gemini", "qwen"]);
+  });
+
+  it("never leaks key material", async () => {
+    process.env.GEMINI_API_KEY = "super-secret-value";
+    const { configuredProviders } = await import("@/lib/ai");
+    expect(JSON.stringify(configuredProviders())).not.toContain("super-secret-value");
+  });
+});
+
+describe("generateJson — gating", () => {
+  it("returns no_keys and does not call fetch when unconfigured", async () => {
+    const { generateJson } = await import("@/lib/ai");
+    const r = await generateJson("sys", { a: 1 });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toBe("no_keys");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("returns disabled when AI_DISABLED=true", async () => {
+    process.env.GEMINI_API_KEY = "k";
+    process.env.AI_DISABLED = "true";
+    const { generateJson } = await import("@/lib/ai");
+    const r = await generateJson("sys", {});
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toBe("disabled");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("generateJson — request shape", () => {
+  it("posts to <base>/chat/completions with json_object mode and temperature 0.2", async () => {
+    process.env.GEMINI_API_KEY = "secret-key";
+    process.env.GEMINI_BASE_URL = "https://example.test/v1";
+    process.env.GEMINI_MODEL = "test-model";
+    fetchMock.mockResolvedValueOnce(okBody());
+
+    const { generateJson } = await import("@/lib/ai");
+    await generateJson("SYSTEM PROMPT", { scope: "o/r" });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe("https://example.test/v1/chat/completions");
+    expect((init.headers as Record<string, string>).Authorization).toBe("Bearer secret-key");
+
+    const body = JSON.parse(init.body as string);
+    expect(body.model).toBe("test-model");
+    expect(body.temperature).toBe(0.2);
+    expect(body.response_format).toEqual({ type: "json_object" });
+    expect(body.messages[0]).toEqual({ role: "system", content: "SYSTEM PROMPT" });
+    expect(body.messages[1].role).toBe("user");
+    expect(JSON.parse(body.messages[1].content)).toEqual({ scope: "o/r" });
+  });
+
+  it("strips a trailing slash from the configured base URL", async () => {
+    process.env.GEMINI_API_KEY = "k";
+    process.env.GEMINI_BASE_URL = "https://example.test/v1/";
+    fetchMock.mockResolvedValueOnce(okBody());
+
+    const { generateJson } = await import("@/lib/ai");
+    await generateJson("sys", {});
+    expect(fetchMock.mock.calls[0][0]).toBe("https://example.test/v1/chat/completions");
+  });
+
+  it("returns ok with provider and content on a 200", async () => {
+    process.env.GEMINI_API_KEY = "k";
+    fetchMock.mockResolvedValueOnce(okBody('{"summary":"hello"}'));
+
+    const { generateJson } = await import("@/lib/ai");
+    const r = await generateJson("sys", {});
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.provider).toBe("gemini");
+      expect(r.content).toBe('{"summary":"hello"}');
+      expect(r.usage).toEqual({ prompt_tokens: 100, completion_tokens: 20 });
+    }
+  });
+});
+
+describe("generateJson — fallback behaviour", () => {
+  it("falls back to qwen on a 401 without retrying gemini", async () => {
+    process.env.GEMINI_API_KEY = "k";
+    process.env.QWEN_API_KEY = "k";
+    fetchMock.mockResolvedValueOnce(errBody(401)).mockResolvedValueOnce(okBody());
+
+    const { generateJson } = await import("@/lib/ai");
+    const r = await generateJson("sys", {});
+
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.provider).toBe("qwen");
+    expect(fetchMock).toHaveBeenCalledTimes(2); // no retry of the 401
+  });
+
+  it("retries once after a 429 before falling back", async () => {
+    process.env.GEMINI_API_KEY = "k";
+    fetchMock.mockResolvedValueOnce(errBody(429)).mockResolvedValueOnce(okBody());
+
+    const { generateJson } = await import("@/lib/ai");
+    const r = await generateJson("sys", {});
+
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.provider).toBe("gemini");
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("falls back to qwen when gemini 500s twice", async () => {
+    process.env.GEMINI_API_KEY = "k";
+    process.env.QWEN_API_KEY = "k";
+    fetchMock
+      .mockResolvedValueOnce(errBody(500))
+      .mockResolvedValueOnce(errBody(500))
+      .mockResolvedValueOnce(okBody());
+
+    const { generateJson } = await import("@/lib/ai");
+    const r = await generateJson("sys", {});
+
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.provider).toBe("qwen");
+  });
+
+  it("treats an empty completion as retryable", async () => {
+    process.env.GEMINI_API_KEY = "k";
+    fetchMock.mockResolvedValueOnce(okBody("   ")).mockResolvedValueOnce(okBody('{"a":1}'));
+
+    const { generateJson } = await import("@/lib/ai");
+    const r = await generateJson("sys", {});
+    expect(r.ok).toBe(true);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("returns provider_error when every provider fails", async () => {
+    process.env.GEMINI_API_KEY = "k";
+    process.env.QWEN_API_KEY = "k";
+    fetchMock.mockResolvedValue(errBody(403)); // fatal for both, no retries
+
+    const { generateJson } = await import("@/lib/ai");
+    const r = await generateJson("sys", {});
+
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toBe("provider_error");
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("never throws when fetch itself rejects", async () => {
+    process.env.GEMINI_API_KEY = "k";
+    fetchMock.mockRejectedValue(new Error("network down"));
+
+    const { generateJson } = await import("@/lib/ai");
+    const r = await generateJson("sys", {});
+    expect(r.ok).toBe(false);
+  });
+});
+
+describe("generateJson — time budget", () => {
+  it("returns timeout when a provider exceeds the per-attempt timeout", async () => {
+    process.env.GEMINI_API_KEY = "k";
+    process.env.AI_TIMEOUT_MS = "10";
+    process.env.AI_TOTAL_BUDGET_MS = "40";
+
+    // Reject with an AbortError once the signal fires, like real fetch does.
+    fetchMock.mockImplementation(
+      (_url: string, init: RequestInit) =>
+        new Promise((_resolve, reject) => {
+          init.signal?.addEventListener("abort", () => {
+            const err = new Error("aborted");
+            err.name = "AbortError";
+            reject(err);
+          });
+        }),
+    );
+
+    const { generateJson } = await import("@/lib/ai");
+    const r = await generateJson("sys", {});
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(["timeout", "provider_error"]).toContain(r.reason);
+  });
+
+  it("does not attempt the fallback provider once the total budget is spent", async () => {
+    process.env.GEMINI_API_KEY = "k";
+    process.env.QWEN_API_KEY = "k";
+    // The primary alone can consume the whole wall-clock budget: its attempt is
+    // capped at min(30, remaining) = 25ms, leaving nothing for qwen.
+    process.env.AI_TIMEOUT_MS = "30";
+    process.env.AI_TOTAL_BUDGET_MS = "25";
+
+    fetchMock.mockImplementation(
+      (_url: string, init: RequestInit) =>
+        new Promise((_resolve, reject) => {
+          init.signal?.addEventListener("abort", () => {
+            const err = new Error("aborted");
+            err.name = "AbortError";
+            reject(err);
+          });
+        }),
+    );
+
+    const { generateJson } = await import("@/lib/ai");
+    const r = await generateJson("sys", {});
+
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toBe("timeout");
+    // Only the primary was tried — the deadline check skipped qwen entirely.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("generateJson — daily token budget", () => {
+  it("short-circuits without calling fetch once the budget is spent", async () => {
+    process.env.GEMINI_API_KEY = "k";
+    process.env.AI_DAILY_TOKEN_BUDGET = "100";
+    fetchMock.mockResolvedValueOnce(okBody('{"a":1}', { prompt_tokens: 90, completion_tokens: 30 }));
+
+    const { generateJson } = await import("@/lib/ai");
+
+    const first = await generateJson("sys", {});
+    expect(first.ok).toBe(true); // 120 tokens recorded, over the 100 limit
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    const second = await generateJson("sys", {});
+    expect(second.ok).toBe(false);
+    if (!second.ok) expect(second.reason).toBe("budget_exceeded");
+    expect(fetchMock).toHaveBeenCalledTimes(1); // no second network call
+  });
+
+  it("treats a budget of 0 as unlimited", async () => {
+    process.env.GEMINI_API_KEY = "k";
+    process.env.AI_DAILY_TOKEN_BUDGET = "0";
+    fetchMock.mockResolvedValue(okBody('{"a":1}', { prompt_tokens: 10_000, completion_tokens: 10_000 }));
+
+    const { generateJson } = await import("@/lib/ai");
+    await generateJson("sys", {});
+    const second = await generateJson("sys", {});
+    expect(second.ok).toBe(true);
+  });
+
+  it("budgetSnapshot reports usage without exposing keys", async () => {
+    process.env.GEMINI_API_KEY = "super-secret-value";
+    process.env.AI_DAILY_TOKEN_BUDGET = "5000";
+    fetchMock.mockResolvedValueOnce(okBody('{"a":1}', { prompt_tokens: 7, completion_tokens: 3 }));
+
+    const { generateJson, budgetSnapshot } = await import("@/lib/ai");
+    await generateJson("sys", {});
+
+    const snap = budgetSnapshot();
+    expect(snap.tokens).toBe(10);
+    expect(snap.limit).toBe(5000);
+    expect(JSON.stringify(snap)).not.toContain("super-secret-value");
+  });
+});

--- a/tests/api-ai-insights.test.ts
+++ b/tests/api-ai-insights.test.ts
@@ -1,0 +1,248 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+/**
+ * Follows the route-handler pattern established in tests/api-ai-status.test.ts.
+ * The cache is real (in-process, cheap) so cache-hit behaviour is exercised
+ * end-to-end; only the session, provider and snapshot layers are mocked.
+ */
+
+const getTokenFromSession = vi.fn();
+const aiEnabled = vi.fn();
+const generateJson = vi.fn();
+const buildInsightsSnapshot = vi.fn();
+
+vi.mock("@/lib/session", () => ({
+  getTokenFromSession: () => getTokenFromSession(),
+}));
+vi.mock("@/lib/ai", () => ({
+  aiEnabled: () => aiEnabled(),
+  generateJson: (...a: unknown[]) => generateJson(...a),
+}));
+vi.mock("@/lib/ai-snapshots", () => ({
+  buildInsightsSnapshot: (...a: unknown[]) => buildInsightsSnapshot(...a),
+}));
+
+const GOOD_CONTENT = JSON.stringify({
+  summary: "Delivery is steady.",
+  bullets: ["CFR is 12%"],
+  actions: ["Raise the bus factor on src/app"],
+});
+
+function okProvider(content = GOOD_CONTENT) {
+  return { ok: true, provider: "gemini", model: "gemini-2.5-flash", content };
+}
+
+/** Unique scope per test keeps the shared in-process cache from bleeding across cases. */
+let seq = 0;
+function reqFor(params: string): NextRequest {
+  return new NextRequest(`https://x.test/api/ai/insights?${params}`);
+}
+function uniqueRepoReq(): NextRequest {
+  seq++;
+  return reqFor(`owner=o${seq}&repo=r${seq}`);
+}
+
+beforeEach(async () => {
+  // A distinct token per test: aiRateLimit() keys on the token hash and the
+  // limiter is module-level state, so a shared token would leak consumed
+  // slots between tests and eventually 429 an unrelated case.
+  seq++;
+  getTokenFromSession.mockReset().mockResolvedValue(`tok-${seq}`);
+  aiEnabled.mockReset().mockReturnValue(true);
+  generateJson.mockReset().mockResolvedValue(okProvider());
+  // A distinct snapshot per test — the cache key is fingerprinted on it.
+  buildInsightsSnapshot.mockReset().mockImplementation(async () => ({
+    surface: "repo",
+    scope: `o${seq}/r${seq}`,
+    partial: false,
+  }));
+  const { cacheDeleteByPrefix } = await import("@/lib/cache");
+  cacheDeleteByPrefix("ai:insights:");
+});
+
+describe("GET /api/ai/insights — auth and gating", () => {
+  it("returns 401 without a session", async () => {
+    getTokenFromSession.mockResolvedValue(null);
+    const { GET } = await import("@/app/api/ai/insights/route");
+    const res = await GET(uniqueRepoReq());
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 503 when the AI layer is unconfigured, without building a snapshot", async () => {
+    aiEnabled.mockReturnValue(false);
+    const { GET } = await import("@/app/api/ai/insights/route");
+    const res = await GET(uniqueRepoReq());
+
+    expect(res.status).toBe(503);
+    await expect(res.json()).resolves.toEqual({
+      ok: false,
+      error: "AI features are not configured",
+    });
+    expect(buildInsightsSnapshot).not.toHaveBeenCalled();
+  });
+
+  it("rejects a missing owner/repo with a validation error", async () => {
+    const { GET } = await import("@/app/api/ai/insights/route");
+    const res = await GET(reqFor(""));
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects an invalid org name", async () => {
+    const { GET } = await import("@/app/api/ai/insights/route");
+    const res = await GET(reqFor("org=" + encodeURIComponent("../etc/passwd")));
+    expect(res.status).toBe(400);
+  });
+});
+
+describe("GET /api/ai/insights — success path", () => {
+  it("returns the validated content with provider attribution", async () => {
+    const { GET } = await import("@/app/api/ai/insights/route");
+    const res = await GET(uniqueRepoReq());
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.provider).toBe("gemini");
+    expect(body.model).toBe("gemini-2.5-flash");
+    expect(body.cached).toBe(false);
+    expect(body.content).toEqual({
+      summary: "Delivery is steady.",
+      bullets: ["CFR is 12%"],
+      actions: ["Raise the bus factor on src/app"],
+    });
+  });
+
+  it("marks the response private so a shared cache cannot serve it across users", async () => {
+    const { GET } = await import("@/app/api/ai/insights/route");
+    const res = await GET(uniqueRepoReq());
+    expect(res.headers.get("Cache-Control")).toContain("private");
+  });
+
+  it("routes an org param to the org surface", async () => {
+    buildInsightsSnapshot.mockResolvedValue({ surface: "org", scope: "acme", partial: false });
+    const { GET } = await import("@/app/api/ai/insights/route");
+    await GET(reqFor("org=acme"));
+
+    expect(buildInsightsSnapshot).toHaveBeenCalledWith(`tok-${seq}`, {
+      surface: "org",
+      org: "acme",
+    });
+  });
+
+  it("propagates the snapshot's partial flag to the client", async () => {
+    seq++;
+    buildInsightsSnapshot.mockResolvedValue({ surface: "repo", scope: "p/q", partial: true });
+    const { GET } = await import("@/app/api/ai/insights/route");
+    const body = await (await GET(reqFor("owner=p&repo=q"))).json();
+    expect(body.partial).toBe(true);
+  });
+
+  it("serves the second identical request from cache without a second provider call", async () => {
+    const { GET } = await import("@/app/api/ai/insights/route");
+    const req = uniqueRepoReq();
+
+    const first = await (await GET(req)).json();
+    expect(first.cached).toBe(false);
+
+    const second = await (await GET(req)).json();
+    expect(second.cached).toBe(true);
+    expect(generateJson).toHaveBeenCalledTimes(1);
+  });
+
+  it("refresh=1 bypasses the cache and calls the provider again", async () => {
+    const { GET } = await import("@/app/api/ai/insights/route");
+    seq++;
+    await GET(reqFor(`owner=o${seq}&repo=r${seq}`));
+    await GET(reqFor(`owner=o${seq}&repo=r${seq}&refresh=1`));
+    expect(generateJson).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("GET /api/ai/insights — failure handling", () => {
+  it("maps a provider error to 503", async () => {
+    generateJson.mockResolvedValue({ ok: false, reason: "provider_error", error: "boom" });
+    const { GET } = await import("@/app/api/ai/insights/route");
+    const res = await GET(uniqueRepoReq());
+
+    expect(res.status).toBe(503);
+    await expect(res.json()).resolves.toEqual({ ok: false, error: "AI insights unavailable" });
+  });
+
+  it("maps an exhausted token budget to 429 with Retry-After", async () => {
+    generateJson.mockResolvedValue({ ok: false, reason: "budget_exceeded", error: "spent" });
+    const { GET } = await import("@/app/api/ai/insights/route");
+    const res = await GET(uniqueRepoReq());
+
+    expect(res.status).toBe(429);
+    expect(res.headers.get("Retry-After")).toBeTruthy();
+  });
+
+  it("never leaks the provider's raw error text to the client", async () => {
+    generateJson.mockResolvedValue({
+      ok: false,
+      reason: "provider_error",
+      error: "gemini returned HTTP 401 for key sk-secret",
+    });
+    const { GET } = await import("@/app/api/ai/insights/route");
+    const body = await (await GET(uniqueRepoReq())).json();
+    expect(JSON.stringify(body)).not.toContain("sk-secret");
+  });
+
+  it("retries once when the model returns unparseable JSON", async () => {
+    generateJson
+      .mockResolvedValueOnce(okProvider("not json at all"))
+      .mockResolvedValueOnce(okProvider());
+
+    const { GET } = await import("@/app/api/ai/insights/route");
+    const res = await GET(uniqueRepoReq());
+
+    expect(res.status).toBe(200);
+    expect(generateJson).toHaveBeenCalledTimes(2);
+  });
+
+  it("returns 503 when both attempts return unparseable JSON", async () => {
+    generateJson.mockResolvedValue(okProvider("still not json"));
+    const { GET } = await import("@/app/api/ai/insights/route");
+    const res = await GET(uniqueRepoReq());
+
+    expect(res.status).toBe(503);
+    expect(generateJson).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not cache a failure — a later request retries rather than being stuck", async () => {
+    const req = uniqueRepoReq();
+    generateJson.mockResolvedValueOnce({ ok: false, reason: "provider_error", error: "boom" });
+
+    const { GET } = await import("@/app/api/ai/insights/route");
+    expect((await GET(req)).status).toBe(503);
+
+    generateJson.mockResolvedValue(okProvider());
+    expect((await GET(req)).status).toBe(200);
+  });
+
+  it("returns 500 when snapshot assembly itself throws", async () => {
+    buildInsightsSnapshot.mockRejectedValue(new Error("github exploded"));
+    const { GET } = await import("@/app/api/ai/insights/route");
+    const res = await GET(uniqueRepoReq());
+
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(JSON.stringify(body)).not.toContain("github exploded");
+  });
+});
+
+describe("GET /api/ai/insights — rate limiting", () => {
+  it("returns 429 with Retry-After once the per-minute limit is exceeded", async () => {
+    const { GET } = await import("@/app/api/ai/insights/route");
+
+    // beforeEach gave this test its own token, so all 21 calls share one
+    // fresh limiter bucket: 20 are allowed, the 21st must be rejected.
+    let last: Response | undefined;
+    for (let i = 0; i < 21; i++) last = await GET(uniqueRepoReq());
+
+    expect(last!.status).toBe(429);
+    expect(last!.headers.get("Retry-After")).toBeTruthy();
+    await expect(last!.json()).resolves.toEqual({ ok: false, error: "Rate limit exceeded" });
+  });
+});

--- a/tests/api-ai-status.test.ts
+++ b/tests/api-ai-status.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+/**
+ * Route-handler test pattern for the AI routes (v4.1.0).
+ *
+ * This is the first route-handler test in the repo — everything else under
+ * tests/ covers pure src/lib functions. Established here on the simplest
+ * possible route so the remaining AI routes can copy it.
+ *
+ * The pattern: vi.mock() the route's own imports (session + the AI layer),
+ * then import the handler dynamically so the mocks are in place first. Route
+ * handlers that take no arguments (like this one) need no NextRequest at all;
+ * routes that read query params construct `new NextRequest(url)` directly,
+ * which works under the node environment without extra setup.
+ *
+ * Verdict: the direct approach works — the extract-to-lib fallback described
+ * in the plan was not needed. Later AI routes should follow this file.
+ */
+
+const getTokenFromSession = vi.fn();
+const aiEnabled = vi.fn();
+const configuredProviders = vi.fn();
+
+vi.mock("@/lib/session", () => ({
+  getTokenFromSession: () => getTokenFromSession(),
+}));
+
+vi.mock("@/lib/ai", () => ({
+  aiEnabled: () => aiEnabled(),
+  configuredProviders: () => configuredProviders(),
+}));
+
+beforeEach(() => {
+  getTokenFromSession.mockReset();
+  aiEnabled.mockReset();
+  configuredProviders.mockReset();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("GET /api/ai/status", () => {
+  it("returns 401 when there is no session token", async () => {
+    getTokenFromSession.mockResolvedValue(null);
+
+    const { GET } = await import("@/app/api/ai/status/route");
+    const res = await GET();
+
+    expect(res.status).toBe(401);
+    await expect(res.json()).resolves.toEqual({ error: "Unauthorized" });
+  });
+
+  it("reports disabled with no providers when the layer is unconfigured", async () => {
+    getTokenFromSession.mockResolvedValue("tok");
+    aiEnabled.mockReturnValue(false);
+    configuredProviders.mockReturnValue([]);
+
+    const { GET } = await import("@/app/api/ai/status/route");
+    const res = await GET();
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({ enabled: false, providers: [] });
+  });
+
+  it("reports the configured providers in priority order", async () => {
+    getTokenFromSession.mockResolvedValue("tok");
+    aiEnabled.mockReturnValue(true);
+    configuredProviders.mockReturnValue(["gemini", "qwen"]);
+
+    const { GET } = await import("@/app/api/ai/status/route");
+    const res = await GET();
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({
+      enabled: true,
+      providers: ["gemini", "qwen"],
+    });
+  });
+
+  it("marks the response private so a shared cache never serves it across users", async () => {
+    getTokenFromSession.mockResolvedValue("tok");
+    aiEnabled.mockReturnValue(true);
+    configuredProviders.mockReturnValue(["gemini"]);
+
+    const { GET } = await import("@/app/api/ai/status/route");
+    const res = await GET();
+
+    expect(res.headers.get("Cache-Control")).toContain("private");
+  });
+
+  it("never includes key material in the response body", async () => {
+    getTokenFromSession.mockResolvedValue("tok");
+    aiEnabled.mockReturnValue(true);
+    configuredProviders.mockReturnValue(["gemini"]);
+
+    const { GET } = await import("@/app/api/ai/status/route");
+    const body = await (await GET()).json();
+
+    const serialized = JSON.stringify(body);
+    expect(serialized).not.toMatch(/api[_-]?key/i);
+    expect(serialized).not.toContain("tok");
+  });
+});


### PR DESCRIPTION
First of four planned AI releases (v4.1.0 → v4.1.3, one feature per version per PR).
Design: `docs/specs/2026-08-14-ai-features-design.md` · Plan: `docs/plans/2026-08-14-ai-features-plan.md`

## Summary

**Entirely opt-in — with no AI provider key configured, every surface is hidden and the app behaves exactly as v4.0.11 does today.**

- **Provider layer** (`src/lib/ai.ts`) — Gemini primary, Qwen fallback via OpenAI-compatible endpoints. **Zero new dependencies.** `generateJson()` never throws; every failure returns a typed `AiFailure` so callers own their fallback UX.
- **AI Insights panel** on Repository Overview and Team Health Scorecard — summary, findings, up to 3 suggested actions.
- **New routes:** `GET /api/ai/status` (capability probe, no key material) and `GET /api/ai/insights`.
- **New `aiInsights` feature flag** in Settings. Double-gated: server keys **and** flag.
- **Docs:** new AI Insights feature page carrying the full transparency contract, both API Reference entries, README capability row.

## Reviewer notes — the judgement calls

1. **`AI_DAILY_TOKEN_BUDGET` is per-instance, not global.** Both it and the rate limiter are in-process counters, so on a multi-instance deploy they bound cost per instance. This is documented in-code, in-app, and in the CHANGELOG as a damage-limiter rather than a hard spend cap. A Neon-backed limiter was deliberately deferred to keep the zero-migration rollback story.
2. **The AI cache does not protect GitHub rate limits.** Keys are fingerprinted on the snapshot, so the GitHub fan-out runs before the cache lookup — a hit only saves the LLM call.
3. **Contributor logins ARE sent to the provider.** Intentional (attribution needs names), documented prominently on the docs page with an explicit callout. Worth your explicit sign-off.
4. **Privacy is enforced mechanically, not by review.** `tests/ai-snapshots.test.ts` walks each snapshot's serialized output and fails on a forbidden key; fixtures deliberately carry commit messages, SHAs and URLs to prove they're dropped.

## Test plan

- [x] `pnpm exec tsc --noEmit` — **0 errors**
- [x] `pnpm test` — **142/142 passing** (63 → 142, +79)
- [x] `pnpm run lint` — **0 errors** (11 pre-existing warnings, unchanged from baseline)
- [x] `rm -rf .next && pnpm run build` — succeeds, both `/api/ai/*` routes emit
- [x] API Reference parity — `comm -13` clean, no undocumented routes
- [x] Version bumped in all locations: `package.json`, Helm `version` + `appVersion`, both docs fallbacks, release-notes entry (previous demoted to `badge: null`), CHANGELOG

## Rollback

1. Unset the AI env keys — every surface hides, no redeploy
2. Promote the v4.0.11 Vercel deployment — instant
3. `git revert` — **no migration to undo, zero schema changes**