### PR TITLE
feat: v4.1.2 — AI failure root-cause hypotheses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,47 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ---
 
+## [4.1.2] — 2026-08-14
+
+### Overview
+Final AI feature of the v4.1.x series: ranked root-cause hypotheses for failing workflows. **F2 (AI Leadership Digest) was skipped** — the weekly digest email still cannot send (no `RESEND_API_KEY`/`SMTP_HOST` configured), and per the plan a version is never reserved for an unshipped feature. F2 can ship later once an email provider exists.
+
+### Added
+
+#### AI Failure Hypotheses
+- When a workflow has **3+ recent failures**, the Workflow Detail **Reliability** tab offers *"Suggest why this is failing"* — up to three ranked causes, each with the specific evidence behind it, a confidence level, and a next step the team can run in minutes.
+- Signals used: workflow-file change dates versus the first failure, step-level failure concentration, trigger/branch clustering, run-duration shifts, and the length of the success streak that ended.
+- **Metadata only — never run logs.** GitDash does not fetch log content for any feature, and the prompt states explicitly that the model has no logs and must not write as though it does.
+- New `GET /api/ai/root-cause`.
+
+### Changed
+
+#### Cost proportional to the problem, not the window
+- The original design called for `getJobStats()`, which fans out across every completed run (~30–50 GitHub calls). Job detail is only needed for runs that **failed**, so the builder fetches jobs for at most 10 failed runs instead — roughly 10 calls, bounded by the number of failures rather than the window size.
+- The GitHub fan-out is cached **separately** from the LLM call on this route (10 min each). Every other AI route fingerprints its cache on the snapshot, so a cache hit still pays the fan-out; here the fan-out is the expensive part and earns its own key.
+- Rate-limited to **10/min per token** — half the other AI surfaces.
+- The minimum-failure floor is enforced server-side (returns `content: null`), so a UI bug cannot turn into provider spend.
+
+#### Schema validation, corrected against real output
+- Confidence is validated against a literal allowlist (`high`/`medium`/`low`) rather than coerced — the UI colours a badge from it, and an invented `"very high"` would render an uncoloured chip.
+- Rank is re-derived from array position: models routinely emit duplicate or out-of-order ranks, and display order is what matters.
+- **Per-field length caps, sized from measured output.** An initial shared 300-character cap rejected otherwise-good answers, because the prompt asks for cited dates and counts and `evidence` measured 211–292 characters in practice. Caps are now per-field (hypothesis 400, evidence 500, next_step 300) and the prompt asks for brevity — which cut typical output from ~600 to ~220 tokens *and* improved readability.
+
+### Verified
+- End-to-end against the live provider through the real code path, three consecutive generations: **3/3 schema pass**, ~2–3s latency, ~640 in / ~220 out tokens per call.
+
+### Rollback
+1. **Unset the AI keys** — every surface hides, no redeploy.
+2. **Promote the v4.1.1 Vercel deployment** — instant.
+3. **`git revert`** — no migration to undo, zero schema changes.
+
+### Changed (infra)
+- Bumped app version from 4.1.1 to 4.1.2
+- Bumped Helm chart version from 0.5.1 to 0.5.2
+- Test count 177 → 212
+
+---
+
 ## [4.1.1] — 2026-08-14
 
 ### Overview

--- a/helm/gitdash/Chart.yaml
+++ b/helm/gitdash/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: gitdash
 description: Self-hosted GitHub Actions metrics dashboard (standalone PAT or GitHub OAuth)
 type: application
-version: 0.5.1
-appVersion: "4.1.1"
+version: 0.5.2
+appVersion: "4.1.2"
 keywords:
   - github-actions
   - dashboard

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gitdash",
-  "version": "4.1.1",
+  "version": "4.1.2",
   "private": true,
   "packageManager": "pnpm@10.30.3",
   "scripts": {

--- a/src/app/api/ai/root-cause/route.ts
+++ b/src/app/api/ai/root-cause/route.ts
@@ -1,0 +1,172 @@
+/**
+ * GET /api/ai/root-cause — ranked hypotheses for why a workflow is failing.
+ *
+ * Params: owner, repo, workflow_id.
+ *
+ * This is the most expensive AI surface, so it carries three guards the other
+ * routes do not need:
+ *
+ *   1. The snapshot build is cached SEPARATELY from the generation. Every other
+ *      AI route fingerprints its cache on the snapshot, which means a cache hit
+ *      still pays the GitHub fan-out. Here the fan-out is the expensive part
+ *      (per-run job fetches), so it gets its own key and TTL.
+ *   2. A minimum failure count — below it the route returns content: null and
+ *      never calls a provider. Speculating about one flaky run is noise.
+ *   3. Half the rate limit of the other surfaces.
+ *
+ * Metadata only: job and step NAMES, dates, counts. Never log content.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { getTokenFromSession } from "@/lib/session";
+import { aiEnabled, generateJson, type AiFailureReason } from "@/lib/ai";
+import { buildRootCauseSnapshot } from "@/lib/ai-snapshots";
+import { ROOT_CAUSE_SYSTEM_PROMPT } from "@/lib/ai-prompts";
+import { parseRootCauseContent, type RootCauseContent } from "@/lib/ai-schema";
+import { withCache, cacheGet, cacheDelete, hashKey } from "@/lib/cache";
+import { aiRateLimit } from "@/lib/ratelimit";
+import { validateOwner, validateRepo, validateId, safeError } from "@/lib/validation";
+
+export const maxDuration = 60;
+
+const SNAPSHOT_TTL = 600; // 10 min — guards the GitHub fan-out
+const CACHE_TTL = 600; // 10 min — guards the LLM call
+const RATE_LIMIT_PER_MIN = 10; // half the other surfaces: this one fans out
+
+/** Below this, there is no pattern to explain — only noise. */
+const MIN_FAILURES = 3;
+
+export interface AiRootCauseResponse {
+  ok: true;
+  provider: string;
+  model: string;
+  generated_at: string;
+  cached: boolean;
+  failure_count: number;
+  partial: boolean;
+  /** Null when there are too few failures to analyse. */
+  content: RootCauseContent | null;
+}
+
+function failureResponse(reason: AiFailureReason): NextResponse {
+  if (reason === "budget_exceeded") {
+    return NextResponse.json(
+      { ok: false, error: "AI daily budget reached" },
+      { status: 429, headers: { "Retry-After": "3600" } },
+    );
+  }
+  if (reason === "disabled" || reason === "no_keys") {
+    return NextResponse.json(
+      { ok: false, error: "AI features are not configured" },
+      { status: 503 },
+    );
+  }
+  return NextResponse.json({ ok: false, error: "AI hypotheses unavailable" }, { status: 503 });
+}
+
+export async function GET(req: NextRequest) {
+  const token = await getTokenFromSession();
+  if (!token) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  if (!aiEnabled()) {
+    return NextResponse.json(
+      { ok: false, error: "AI features are not configured" },
+      { status: 503 },
+    );
+  }
+
+  const { searchParams } = new URL(req.url);
+  const ownerResult = validateOwner(searchParams.get("owner"));
+  if (!ownerResult.ok) return ownerResult.response;
+  const repoResult = validateRepo(searchParams.get("repo"));
+  if (!repoResult.ok) return repoResult.response;
+  const idResult = validateId(searchParams.get("workflow_id"), "workflow_id");
+  if (!idResult.ok) return idResult.response;
+
+  const owner = ownerResult.data;
+  const repo = repoResult.data;
+  const workflowId = idResult.data;
+
+  const tokenHash = hashKey(token);
+  const limit = aiRateLimit(tokenHash, "root-cause", RATE_LIMIT_PER_MIN);
+  if (!limit.allowed) {
+    return NextResponse.json(
+      { ok: false, error: "Rate limit exceeded" },
+      {
+        status: 429,
+        headers: { "Retry-After": String(Math.ceil((limit.retryAfterMs ?? 60_000) / 1000)) },
+      },
+    );
+  }
+
+  try {
+    const scopeKey = `${owner}/${repo}/${workflowId}`;
+
+    // Guard 1: the fan-out gets its own cache, independent of the generation.
+    const snapshot = await withCache(
+      `ai:root-cause-snap:${tokenHash}:${scopeKey}`,
+      SNAPSHOT_TTL,
+      () => buildRootCauseSnapshot(token, { owner, repo, workflowId }),
+    );
+
+    // Guard 2: enforced server-side, not just hidden in the UI.
+    if (snapshot.failure_count < MIN_FAILURES) {
+      return NextResponse.json(
+        {
+          ok: true,
+          provider: "",
+          model: "",
+          generated_at: new Date().toISOString(),
+          cached: false,
+          failure_count: snapshot.failure_count,
+          partial: snapshot.partial,
+          content: null,
+        } satisfies AiRootCauseResponse,
+        { headers: { "Cache-Control": `private, max-age=${CACHE_TTL}` } },
+      );
+    }
+
+    const fingerprint = hashKey(JSON.stringify(snapshot));
+    const cacheKey = `ai:root-cause:${tokenHash}:${scopeKey}:${fingerprint}`;
+    const hit = cacheGet<AiRootCauseResponse>(cacheKey) !== undefined;
+
+    const generate = async (): Promise<AiRootCauseResponse | { failed: AiFailureReason }> => {
+      let result = await generateJson(ROOT_CAUSE_SYSTEM_PROMPT, snapshot, {
+        maxOutputTokens: 1200,
+      });
+      if (!result.ok) return { failed: result.reason };
+
+      let content = parseRootCauseContent(result.content);
+      if (!content) {
+        result = await generateJson(ROOT_CAUSE_SYSTEM_PROMPT, snapshot, { maxOutputTokens: 1200 });
+        if (!result.ok) return { failed: result.reason };
+        content = parseRootCauseContent(result.content);
+      }
+      if (!content) return { failed: "bad_response" };
+
+      return {
+        ok: true,
+        provider: result.provider,
+        model: result.model,
+        generated_at: new Date().toISOString(),
+        cached: false,
+        failure_count: snapshot.failure_count,
+        partial: snapshot.partial,
+        content,
+      };
+    };
+
+    const payload = await withCache(cacheKey, CACHE_TTL, generate);
+    if (!("ok" in payload)) {
+      cacheDelete(cacheKey);
+      return failureResponse(payload.failed);
+    }
+
+    return NextResponse.json(
+      { ...payload, cached: hit },
+      { headers: { "Cache-Control": `private, max-age=${CACHE_TTL}` } },
+    );
+  } catch (e) {
+    return safeError(e, "Failed to generate root-cause hypotheses");
+  }
+}

--- a/src/app/docs/page.tsx
+++ b/src/app/docs/page.tsx
@@ -1540,6 +1540,41 @@ function FeatureAiInsights() {
         </ProseP>
       </DocCard>
 
+      <DocCard>
+        <div className="flex items-center gap-2 mb-2">
+          <SubHeading>Failure hypotheses</SubHeading>
+          <VersionBadge v="4.1.2" />
+        </div>
+        <ProseP>
+          When a workflow has <strong>3 or more recent failures</strong>, the Reliability tab offers{" "}
+          <strong>&ldquo;Suggest why this is failing&rdquo;</strong> — up to three ranked likely
+          causes, each with the evidence behind it and a confidence level. Below that threshold the
+          feature stays quiet: speculating about one flaky run is noise, and the floor is enforced
+          server-side, not just hidden in the UI.
+        </ProseP>
+        <DocTable
+          headers={["Signal used", "What it suggests"]}
+          rows={[
+            ["A workflow-file change dated just before the first failure", "Someone changed the pipeline — usually the answer"],
+            ["One step failing far more than the rest", "A flaky or newly-broken step, rather than the environment"],
+            ["Failures clustered on one trigger or branch type", "A context-specific problem (PR-only, main-only)"],
+            ["A shift in run duration", "Timeouts, early exits, or infrastructure pressure"],
+            ["A long success streak ending abruptly", "Something changed at a knowable point in time"],
+          ]}
+        />
+        <Callout type="warning">
+          <strong>Confidence is meant literally.</strong> &ldquo;Low&rdquo; means the model is mostly
+          guessing, and it is told that one honest low-confidence hypothesis beats three invented
+          ones. Treat every hypothesis as a lead to check — the evidence line tells you exactly which
+          numbers it came from, so you can verify it in seconds.
+        </Callout>
+        <ProseP>
+          Cost is kept proportional to the problem: job detail is fetched only for runs that actually
+          failed, capped at 10, and the GitHub fan-out is cached separately from the generation.
+          This surface is rate-limited to 10 requests/minute — half the others.
+        </ProseP>
+      </DocCard>
+
       <Callout type="info">
         <strong>Entirely opt-in.</strong> With no AI provider key configured on the server, every AI
         surface is hidden and GitDash behaves exactly as it did before v4.1.0. There is no
@@ -2405,6 +2440,16 @@ function APIReference() {
         },
         {
           method: "GET",
+          path: "/api/ai/root-cause",
+          description: "Ranked hypotheses for why a workflow is failing, inferred from failed job/step names, timing shifts, trigger and branch clustering, and workflow-file change dates. Returns { ok, provider, model, failure_count, partial, content: { hypotheses[] } } where each hypothesis carries rank, evidence, confidence (high|medium|low) and next_step. Returns content: null below 3 recent failures — enforced server-side, no provider call. Rate-limited to 10/min per token, half the other AI surfaces. Never reads run logs.",
+          params: [
+            { name: "owner", type: "string", optional: false, desc: "Repository owner" },
+            { name: "repo", type: "string", optional: false, desc: "Repository name" },
+            { name: "workflow_id", type: "number", optional: false, desc: "Workflow ID" },
+          ],
+        },
+        {
+          method: "GET",
           path: "/api/health",
           description: "Liveness/readiness probe. Returns {\"status\":\"ok\"} with no authentication. Used by Kubernetes and load balancers.",
           params: [],
@@ -2656,9 +2701,26 @@ pnpm run lint`}
 function ReleaseNotes() {
   const releases = [
     {
-      version: "4.1.1",
+      version: "4.1.2",
       date: "2026-08-14",
       badge: "latest",
+      badgeColor: "bg-emerald-500/15 text-emerald-400 border-emerald-500/20",
+      changes: {
+        added: [
+          "AI Failure Hypotheses — when a workflow has 3+ recent failures, the Reliability tab offers ranked likely causes with the specific evidence behind each and a confidence level. Inferred from failed job and step names, timing shifts, trigger/branch clustering and workflow-file change dates — never from run logs, which GitDash does not fetch for any feature",
+          "Confidence is validated against a literal allowlist (high/medium/low) rather than coerced, and rank is re-derived from position because models routinely emit duplicate or out-of-order ranks",
+        ],
+        fixed: [],
+        improved: [
+          "Job detail is fetched only for runs that actually failed (capped at 10) instead of every run in the window — roughly 10 GitHub calls rather than 30-50, keeping the expensive part proportional to the problem rather than the window size",
+          "The GitHub fan-out is cached separately from the LLM call on this route. Elsewhere the cache is fingerprinted on the snapshot, so a hit still pays the fan-out; here the fan-out is the expensive part and gets its own key",
+        ],
+      },
+    },
+    {
+      version: "4.1.1",
+      date: "2026-08-14",
+      badge: null,
       badgeColor: "bg-emerald-500/15 text-emerald-400 border-emerald-500/20",
       changes: {
         added: [
@@ -3131,7 +3193,7 @@ function DocSidebar({
           <BookOpen className="w-4 h-4 text-violet-400" />
           <span className="text-sm font-semibold text-white">GitDash Docs</span>
           <span className="text-xs px-1.5 py-0.5 rounded bg-violet-500/15 text-violet-400 border border-violet-500/20 font-mono">
-            v{process.env.NEXT_PUBLIC_APP_VERSION ?? "4.1.1"}
+            v{process.env.NEXT_PUBLIC_APP_VERSION ?? "4.1.2"}
           </span>
         </div>
         {/* Mobile close */}
@@ -3381,7 +3443,7 @@ export default function DocsPage() {
 
           {/* Footer */}
           <footer className="mt-8 pb-4 text-center text-xs text-slate-600 space-y-1">
-            <p>GitDash v{process.env.NEXT_PUBLIC_APP_VERSION ?? "4.1.1"} — GitHub Actions Dashboard</p>
+            <p>GitDash v{process.env.NEXT_PUBLIC_APP_VERSION ?? "4.1.2"} — GitHub Actions Dashboard</p>
             <p>
               <a href="https://github.com/dinhdobathi1992/gitdash" target="_blank" rel="noreferrer" className="hover:text-slate-400 transition-colors">
                 Open source on GitHub

--- a/src/app/repos/[owner]/[repo]/workflows/[workflow_id]/page.tsx
+++ b/src/app/repos/[owner]/[repo]/workflows/[workflow_id]/page.tsx
@@ -11,6 +11,7 @@ import StatCard from "@/components/StatCard";
 import { ConclusionBadge } from "@/components/Badge";
 import { formatDuration, cn } from "@/lib/utils";
 import AnomalyExplanation from "@/components/AnomalyExplanation";
+import RootCauseHypotheses from "@/components/RootCauseHypotheses";
 import { estimateRunCost } from "@/lib/cost";
 import { format, getHours, getDay } from "date-fns";
 import {
@@ -1034,6 +1035,23 @@ function ReliabilityTab({ runs, completed, anomalyMap, owner, repo, workflowId }
                   metric={m}
                 />
               ))}
+          </div>
+        </ChartCard>
+      )}
+
+      {/*
+        Root-cause hypotheses. Gated on recent failures existing at all — the
+        route enforces its own minimum server-side and returns content: null
+        below it, so this only avoids rendering a button that would say
+        "not enough failures".
+      */}
+      {completed.filter((r) => r.conclusion === "failure").length >= 3 && (
+        <ChartCard
+          title="AI Failure Hypotheses"
+          sub="Ranked likely causes, inferred from failed job and step names, timing, and workflow-file changes — never from run logs"
+        >
+          <div className="mt-2">
+            <RootCauseHypotheses owner={owner} repo={repo} workflowId={workflowId} />
           </div>
         </ChartCard>
       )}

--- a/src/components/RootCauseHypotheses.tsx
+++ b/src/components/RootCauseHypotheses.tsx
@@ -1,0 +1,144 @@
+"use client";
+
+/**
+ * AI root-cause hypotheses (v4.1.2).
+ *
+ * Lazy like the anomaly explainer: this is the most expensive AI surface
+ * (per-run job fetches plus a larger generation), so nothing happens until
+ * the user asks. Renders nothing without server keys or with the flag off.
+ *
+ * Confidence is displayed prominently and honestly. A low-confidence
+ * hypothesis presented as certainty is worse than no hypothesis at all —
+ * these are leads to check, not diagnoses.
+ */
+
+import { useState } from "react";
+import useSWR from "swr";
+import { fetcher, FetchError } from "@/lib/swr";
+import { useAiEnabled } from "@/lib/use-ai-enabled";
+import { useFeatureFlags } from "@/components/FeatureFlagsProvider";
+import type { AiRootCauseResponse } from "@/app/api/ai/root-cause/route";
+import type { Confidence } from "@/lib/ai-schema";
+import { Sparkles, Loader2, Search, ArrowRight } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+const CONFIDENCE_STYLE: Record<Confidence, string> = {
+  high: "bg-red-500/10 text-red-300 border-red-500/25",
+  medium: "bg-amber-500/10 text-amber-300 border-amber-500/25",
+  low: "bg-slate-700/40 text-slate-400 border-slate-600/40",
+};
+
+export default function RootCauseHypotheses({
+  owner,
+  repo,
+  workflowId,
+}: {
+  owner: string;
+  repo: string;
+  workflowId: number;
+}) {
+  const { enabled } = useAiEnabled();
+  const { flags } = useFeatureFlags();
+  const [asked, setAsked] = useState(false);
+
+  const key = asked
+    ? `/api/ai/root-cause?owner=${encodeURIComponent(owner)}&repo=${encodeURIComponent(repo)}&workflow_id=${workflowId}`
+    : null;
+
+  const { data, error, isLoading } = useSWR<AiRootCauseResponse>(key, fetcher<AiRootCauseResponse>, {
+    errorRetryCount: 0,
+  });
+
+  if (!enabled || !flags.aiInsights) return null;
+
+  if (!asked) {
+    return (
+      <button
+        onClick={() => setAsked(true)}
+        className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs text-violet-300 bg-violet-500/10 border border-violet-500/25 rounded-lg hover:bg-violet-500/20 transition-colors"
+      >
+        <Sparkles className="w-3.5 h-3.5" />
+        Suggest why this is failing
+      </button>
+    );
+  }
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center gap-2.5 text-xs text-violet-200">
+        <Loader2 className="w-4 h-4 animate-spin shrink-0" />
+        Reading failed jobs and step names — this one takes a few seconds…
+      </div>
+    );
+  }
+
+  if (error) {
+    const status = error instanceof FetchError ? error.status : null;
+    return (
+      <p className="text-xs text-slate-500 italic">
+        {status === 429
+          ? "Rate limit reached — try again in a minute."
+          : "Hypotheses unavailable right now."}
+      </p>
+    );
+  }
+
+  if (!data) return null;
+
+  // Server-side floor: too few failures to say anything useful.
+  if (!data.content) {
+    return (
+      <p className="text-xs text-slate-500 italic">
+        Only {data.failure_count} recent failure{data.failure_count === 1 ? "" : "s"} — not enough of
+        a pattern to analyse yet.
+      </p>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      {data.partial && (
+        <p className="text-[11px] text-amber-300/80">
+          Some job details could not be fetched, so this is based on an incomplete sample.
+        </p>
+      )}
+
+      {data.content.hypotheses.map((h) => (
+        <div
+          key={h.rank}
+          className="rounded-xl border border-slate-800 bg-slate-900/50 p-4 space-y-2.5"
+        >
+          <div className="flex items-start gap-3">
+            <span className="shrink-0 w-5 h-5 rounded-full bg-slate-800 border border-slate-700 flex items-center justify-center text-[10px] font-bold text-slate-400">
+              {h.rank}
+            </span>
+            <p className="text-sm text-slate-100 leading-relaxed flex-1">{h.hypothesis}</p>
+            <span
+              className={cn(
+                "shrink-0 text-[10px] font-semibold uppercase tracking-wide px-2 py-0.5 rounded-full border",
+                CONFIDENCE_STYLE[h.confidence],
+              )}
+            >
+              {h.confidence}
+            </span>
+          </div>
+
+          <div className="flex gap-2 pl-8 text-xs text-slate-400">
+            <Search className="w-3 h-3 mt-0.5 shrink-0 text-slate-600" />
+            <span>{h.evidence}</span>
+          </div>
+
+          <div className="flex gap-2 pl-8 text-xs text-violet-300">
+            <ArrowRight className="w-3 h-3 mt-0.5 shrink-0" />
+            <span>{h.next_step}</span>
+          </div>
+        </div>
+      ))}
+
+      <p className="text-[10px] text-slate-600">
+        {data.provider} · {data.model}
+        {data.cached && " · cached"} · inferred from job and step metadata, not run logs
+      </p>
+    </div>
+  );
+}

--- a/src/lib/ai-prompts.ts
+++ b/src/lib/ai-prompts.ts
@@ -43,3 +43,32 @@ Rules:
   concurrent signals - say so plainly rather than inventing a cause.
 - End with one concrete check the team can perform themselves.
 - Respond JSON only: {"explanation": "...", "check": "..."}`;
+
+export const ROOT_CAUSE_SYSTEM_PROMPT = `You are a CI failure analyst. You receive JSON metadata about recent workflow
+failures: which jobs and steps failed, how often, the triggers and branches
+involved, timing shifts, and the dates when the workflow definition itself
+changed.
+
+You do NOT have run logs, job output, error messages, or source code, and you
+must not write as though you do.
+
+Rules:
+- Produce 1-3 ranked hypotheses, most likely first. Each must cite the specific
+  evidence from the snapshot that supports it: step names, dates, counts, or
+  concentration percentages.
+- Prefer boring explanations, in this order of evidence: a workflow-file change
+  dated just before the first failure; one step failing far more often than the
+  rest (see step_failure_frequency and same_step_share_pct); failures clustered
+  on one trigger or branch type; a duration shift suggesting infrastructure or
+  timeout pressure.
+- Set confidence honestly: "high" only when the evidence is direct and
+  concentrated, "medium" when suggestive, "low" when you are mostly guessing.
+  A single low-confidence hypothesis is a better answer than three invented
+  ones.
+- If "partial" is true, some job detail could not be fetched — say so rather
+  than treating the sample as complete.
+- next_step must be something the team can do themselves in minutes.
+- Keep every field tight: hypothesis and next_step under 40 words each,
+  evidence under 60 words. Cite the numbers, do not narrate them.
+- Respond JSON only: {"hypotheses": [{"rank": 1, "hypothesis": "...",
+  "evidence": "...", "confidence": "high", "next_step": "..."}]}`;

--- a/src/lib/ai-schema.ts
+++ b/src/lib/ai-schema.ts
@@ -110,3 +110,85 @@ export function parseAnomalyContent(raw: string): AnomalyExplanationContent | nu
 
   return { explanation, check };
 }
+
+// ── Root-cause hypotheses (v4.1.2) ────────────────────────────────────────────
+
+export type Confidence = "high" | "medium" | "low";
+
+export interface RootCauseHypothesis {
+  rank: number;
+  hypothesis: string;
+  evidence: string;
+  confidence: Confidence;
+  next_step: string;
+}
+
+export interface RootCauseContent {
+  hypotheses: RootCauseHypothesis[];
+}
+
+const MAX_HYPOTHESES = 3;
+
+/**
+ * Per-field caps, sized from observed output rather than guessed.
+ *
+ * The prompt asks the model to cite dates, counts and percentages, which
+ * makes `evidence` naturally the longest field — measured at 211-292 chars
+ * across real generations. An earlier shared 300-char cap rejected otherwise
+ * good answers that ran a few characters over, burning a retry and sometimes
+ * failing the request outright. These leave headroom without allowing essays;
+ * the prompt also asks for brevity so the model aims well below them.
+ */
+const MAX_HYPOTHESIS_CHARS = 400;
+const MAX_EVIDENCE_CHARS = 500;
+const MAX_NEXT_STEP_CHARS = 300;
+
+const CONFIDENCES: Confidence[] = ["high", "medium", "low"];
+
+/**
+ * Parse and validate the ranked-hypotheses payload.
+ *
+ * Confidence is checked against a literal allowlist rather than coerced: the
+ * UI colours a badge from it, and a model inventing "very high" would either
+ * crash the badge lookup or silently render an uncoloured chip.
+ */
+export function parseRootCauseContent(raw: string): RootCauseContent | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(stripFences(raw));
+  } catch {
+    return null;
+  }
+
+  if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) return null;
+  const list = (parsed as Record<string, unknown>).hypotheses;
+  if (!Array.isArray(list) || list.length === 0) return null;
+
+  const hypotheses: RootCauseHypothesis[] = [];
+  for (const [i, item] of list.slice(0, MAX_HYPOTHESES).entries()) {
+    if (item === null || typeof item !== "object" || Array.isArray(item)) return null;
+    const o = item as Record<string, unknown>;
+
+    const hypothesis = asCleanString(o.hypothesis, MAX_HYPOTHESIS_CHARS);
+    const evidence = asCleanString(o.evidence, MAX_EVIDENCE_CHARS);
+    const next_step = asCleanString(o.next_step, MAX_NEXT_STEP_CHARS);
+    if (hypothesis === null || evidence === null || next_step === null) return null;
+
+    const confidence = o.confidence;
+    if (typeof confidence !== "string" || !CONFIDENCES.includes(confidence as Confidence)) {
+      return null;
+    }
+
+    // Re-derive rank from position: models frequently emit duplicate or
+    // out-of-order ranks, and the display order is what actually matters.
+    hypotheses.push({
+      rank: i + 1,
+      hypothesis,
+      evidence,
+      confidence: confidence as Confidence,
+      next_step,
+    });
+  }
+
+  return { hypotheses };
+}

--- a/src/lib/ai-snapshots.ts
+++ b/src/lib/ai-snapshots.ts
@@ -22,9 +22,11 @@ import {
   getRepoSummary,
   listWorkflowFileCommits,
   listWorkflowRuns,
+  listRunJobs,
   getOctokit,
 } from "@/lib/github";
-import type { TrendPoint, WorkflowRun } from "@/lib/github";
+import type { TrendPoint, WorkflowRun, WorkflowJob } from "@/lib/github";
+import { pLimitSettled } from "@/lib/concurrency";
 import { getRepoDoraSummary } from "@/lib/github-dora";
 import { computeBusFactor } from "@/lib/bus-factor";
 import { computeScorecard } from "@/lib/org-health-scorecard";
@@ -388,5 +390,185 @@ export async function buildAnomalySnapshot(
       trigger_mix,
     },
     total_runs_analysed: completed.length,
+  };
+}
+
+// ── Root-cause hypotheses (v4.1.2) ────────────────────────────────────────────
+
+export interface RootCauseFailure {
+  run_number: number;
+  date: string;
+  trigger: string;
+  branch_type: "main" | "pr" | "other";
+  failed_jobs: { job_name: string; failed_step_names: string[]; duration_ms: number | null }[];
+}
+
+export interface RootCauseSnapshot {
+  workflow_name: string;
+  repo: string;
+  window_runs: number;
+  run_count: number;
+  failure_count: number;
+  failure_rate_pct: number;
+  first_failure_at: string | null;
+  prior_success_streak: number;
+  /** Most recent first, capped at 10 — the runs we fetched job detail for. */
+  failures: RootCauseFailure[];
+  step_failure_frequency: { step_name: string; failure_count: number; share_of_failures_pct: number }[];
+  failure_clustering: {
+    same_step_share_pct: number;
+    trigger_distribution: Record<string, number>;
+    branch_distribution: Record<string, number>;
+  };
+  workflow_file_changes: { date: string; author_login: string | null }[];
+  duration_shift: { before_failures_p50_ms: number; during_failures_p50_ms: number } | null;
+  /** True when some per-run job fetches failed — the model is told to hedge. */
+  partial: boolean;
+}
+
+const MAX_FAILURES_INSPECTED = 10;
+
+function branchType(run: WorkflowRun): "main" | "pr" | "other" {
+  if (run.event === "pull_request") return "pr";
+  if (run.head_branch === "main" || run.head_branch === "master") return "main";
+  return "other";
+}
+
+function p50(values: number[]): number {
+  if (values.length === 0) return 0;
+  const sorted = [...values].sort((a, b) => a - b);
+  return Math.round(sorted[Math.floor(sorted.length / 2)]);
+}
+
+function runDurationMs(run: WorkflowRun): number | null {
+  if (!run.run_started_at || !run.updated_at) return null;
+  const ms = new Date(run.updated_at).getTime() - new Date(run.run_started_at).getTime();
+  return ms > 0 ? ms : null;
+}
+
+/**
+ * Build failure context for AI root-cause hypotheses.
+ *
+ * Cost note — this deviates from the original spec deliberately. The spec
+ * called for getJobStats(), which fans out over every completed run (~30-50
+ * GitHub calls). Job detail is only needed for runs that actually failed, so
+ * this fetches jobs for at most MAX_FAILURES_INSPECTED failed runs instead:
+ * strictly fewer calls, and it keeps the expensive part proportional to the
+ * problem rather than to the window.
+ *
+ * Metadata only. Job and step NAMES are sent; no logs, no step output.
+ */
+export async function buildRootCauseSnapshot(
+  token: string,
+  params: { owner: string; repo: string; workflowId: number },
+): Promise<RootCauseSnapshot> {
+  const { owner, repo, workflowId } = params;
+
+  const [runsRes, commitsRes] = await Promise.allSettled([
+    listWorkflowRuns(token, owner, repo, workflowId, 50),
+    listWorkflowFileCommits(token, owner, repo, 10),
+  ]);
+
+  const runs: WorkflowRun[] = runsRes.status === "fulfilled" ? runsRes.value : [];
+  const completed = runs.filter((r) => r.status === "completed");
+  const failed = completed.filter((r) => r.conclusion === "failure");
+
+  // Runs arrive newest-first. The streak is how many successes precede the
+  // most recent failure — a long streak followed by a cluster is the single
+  // strongest "something changed" signal available without logs.
+  let priorSuccessStreak = 0;
+  for (const r of completed) {
+    if (r.conclusion === "failure") break;
+    if (r.conclusion === "success") priorSuccessStreak++;
+  }
+
+  const inspect = failed.slice(0, MAX_FAILURES_INSPECTED);
+  const jobResults = await pLimitSettled(
+    inspect.map((r) => async () => ({ run: r, jobs: await listRunJobs(token, owner, repo, r.id) })),
+    { concurrency: 5 },
+  );
+
+  let partial = runsRes.status === "rejected";
+  const failures: RootCauseFailure[] = [];
+  const stepCounts = new Map<string, number>();
+
+  for (const res of jobResults) {
+    if (res.status === "rejected") {
+      partial = true;
+      continue;
+    }
+    const { run, jobs } = res.value as { run: WorkflowRun; jobs: WorkflowJob[] };
+    const failedJobs = jobs
+      .filter((j) => j.conclusion === "failure")
+      .map((j) => {
+        const failedSteps = (j.steps ?? [])
+          .filter((s) => s.conclusion === "failure")
+          .map((s) => s.name);
+        for (const name of failedSteps) {
+          stepCounts.set(name, (stepCounts.get(name) ?? 0) + 1);
+        }
+        return { job_name: j.name, failed_step_names: failedSteps, duration_ms: j.duration_ms };
+      });
+
+    failures.push({
+      run_number: run.run_number,
+      date: run.created_at,
+      trigger: run.event,
+      branch_type: branchType(run),
+      failed_jobs: failedJobs,
+    });
+  }
+
+  const totalStepFailures = [...stepCounts.values()].reduce((s, n) => s + n, 0);
+  const step_failure_frequency = [...stepCounts.entries()]
+    .map(([step_name, failure_count]) => ({
+      step_name,
+      failure_count,
+      share_of_failures_pct:
+        totalStepFailures > 0 ? Math.round((failure_count / totalStepFailures) * 100) : 0,
+    }))
+    .sort((a, b) => b.failure_count - a.failure_count);
+
+  const trigger_distribution: Record<string, number> = {};
+  const branch_distribution: Record<string, number> = {};
+  for (const f of failures) {
+    trigger_distribution[f.trigger] = (trigger_distribution[f.trigger] ?? 0) + 1;
+    branch_distribution[f.branch_type] = (branch_distribution[f.branch_type] ?? 0) + 1;
+  }
+
+  // Are failures concentrated on one step, or scattered? Concentration points
+  // at a flaky or newly-broken step; scatter points at infrastructure.
+  const same_step_share_pct = step_failure_frequency[0]?.share_of_failures_pct ?? 0;
+
+  const failedDurations = failed.map(runDurationMs).filter((v): v is number => v !== null);
+  const successDurations = completed
+    .filter((r) => r.conclusion === "success")
+    .map(runDurationMs)
+    .filter((v): v is number => v !== null);
+  const duration_shift =
+    failedDurations.length > 0 && successDurations.length > 0
+      ? {
+          before_failures_p50_ms: p50(successDurations),
+          during_failures_p50_ms: p50(failedDurations),
+        }
+      : null;
+
+  return {
+    workflow_name: completed[0]?.name ?? runs[0]?.name ?? "workflow",
+    repo: `${owner}/${repo}`,
+    window_runs: completed.length,
+    run_count: completed.length,
+    failure_count: failed.length,
+    failure_rate_pct:
+      completed.length > 0 ? Math.round((failed.length / completed.length) * 100) : 0,
+    first_failure_at: failed.length ? failed[failed.length - 1].created_at : null,
+    prior_success_streak: priorSuccessStreak,
+    failures,
+    step_failure_frequency,
+    failure_clustering: { same_step_share_pct, trigger_distribution, branch_distribution },
+    workflow_file_changes:
+      commitsRes.status === "fulfilled" ? toWorkflowChanges(commitsRes.value, 10) : [],
+    duration_shift,
+    partial,
   };
 }

--- a/tests/ai-schema.test.ts
+++ b/tests/ai-schema.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { parseInsightsContent, parseAnomalyContent } from "@/lib/ai-schema";
+import { parseInsightsContent, parseAnomalyContent, parseRootCauseContent } from "@/lib/ai-schema";
 
 const valid = {
   summary: "Deployment frequency is healthy but change failure rate is rising.",
@@ -161,5 +161,96 @@ describe("parseAnomalyContent", () => {
   it("rejects garbage without throwing", () => {
     expect(() => parseAnomalyContent("nope")).not.toThrow();
     expect(parseAnomalyContent("nope")).toBeNull();
+  });
+});
+
+// ── Root-cause hypotheses (v4.1.2) ────────────────────────────────────────────
+
+describe("parseRootCauseContent", () => {
+  const h = (over = {}) => ({
+    rank: 1,
+    hypothesis: "The ci.yml change on 2026-08-09 broke the build step.",
+    evidence: "All 7 failures name the same step, and none precede that commit.",
+    confidence: "high",
+    next_step: "Diff .github/workflows/ci.yml at that commit.",
+    ...over,
+  });
+
+  it("accepts a well-formed payload", () => {
+    const parsed = parseRootCauseContent(JSON.stringify({ hypotheses: [h()] }));
+    expect(parsed?.hypotheses).toHaveLength(1);
+    expect(parsed?.hypotheses[0].confidence).toBe("high");
+  });
+
+  it("accepts all three confidence levels", () => {
+    for (const c of ["high", "medium", "low"]) {
+      const parsed = parseRootCauseContent(JSON.stringify({ hypotheses: [h({ confidence: c })] }));
+      expect(parsed?.hypotheses[0].confidence).toBe(c);
+    }
+  });
+
+  it("caps at three hypotheses", () => {
+    const parsed = parseRootCauseContent(
+      JSON.stringify({ hypotheses: [h(), h(), h(), h(), h()] }),
+    );
+    expect(parsed?.hypotheses).toHaveLength(3);
+  });
+
+  it("re-derives rank from position, ignoring what the model claimed", () => {
+    const parsed = parseRootCauseContent(
+      JSON.stringify({ hypotheses: [h({ rank: 7 }), h({ rank: 7 }), h({ rank: 2 })] }),
+    );
+    expect(parsed?.hypotheses.map((x) => x.rank)).toEqual([1, 2, 3]);
+  });
+
+  it("strips code fences", () => {
+    const parsed = parseRootCauseContent("```json\n" + JSON.stringify({ hypotheses: [h()] }) + "\n```");
+    expect(parsed?.hypotheses).toHaveLength(1);
+  });
+
+  // ── Rejections ──────────────────────────────────────────────────────────────
+
+  it("rejects an invented confidence level", () => {
+    expect(parseRootCauseContent(JSON.stringify({ hypotheses: [h({ confidence: "very high" })] }))).toBeNull();
+  });
+
+  it("rejects a numeric confidence", () => {
+    expect(parseRootCauseContent(JSON.stringify({ hypotheses: [h({ confidence: 0.9 })] }))).toBeNull();
+  });
+
+  it("rejects an empty hypotheses list", () => {
+    expect(parseRootCauseContent(JSON.stringify({ hypotheses: [] }))).toBeNull();
+  });
+
+  it("rejects a missing hypotheses key", () => {
+    expect(parseRootCauseContent(JSON.stringify({ items: [h()] }))).toBeNull();
+  });
+
+  it("rejects an entry missing evidence", () => {
+    const bad = h(); delete (bad as Record<string, unknown>).evidence;
+    expect(parseRootCauseContent(JSON.stringify({ hypotheses: [bad] }))).toBeNull();
+  });
+
+  it("rejects an entry missing next_step", () => {
+    const bad = h(); delete (bad as Record<string, unknown>).next_step;
+    expect(parseRootCauseContent(JSON.stringify({ hypotheses: [bad] }))).toBeNull();
+  });
+
+  it("rejects an over-long hypothesis", () => {
+    expect(parseRootCauseContent(JSON.stringify({ hypotheses: [h({ hypothesis: "x".repeat(401) })] }))).toBeNull();
+  });
+
+  it("accepts evidence at the length real generations produce (~290 chars)", () => {
+    const parsed = parseRootCauseContent(JSON.stringify({ hypotheses: [h({ evidence: "x".repeat(290) })] }));
+    expect(parsed?.hypotheses).toHaveLength(1);
+  });
+
+  it("rejects evidence beyond its own cap", () => {
+    expect(parseRootCauseContent(JSON.stringify({ hypotheses: [h({ evidence: "x".repeat(501) })] }))).toBeNull();
+  });
+
+  it("rejects garbage without throwing", () => {
+    expect(() => parseRootCauseContent("not json")).not.toThrow();
+    expect(parseRootCauseContent("not json")).toBeNull();
   });
 });

--- a/tests/ai-snapshots.test.ts
+++ b/tests/ai-snapshots.test.ts
@@ -43,11 +43,13 @@ const getRepoDoraSummary = vi.fn();
 const computeBusFactor = vi.fn();
 const computeScorecard = vi.fn();
 const listWorkflowRuns = vi.fn();
+const listRunJobs = vi.fn();
 
 vi.mock("@/lib/github", () => ({
   getRepoSummary: (...a: unknown[]) => getRepoSummary(...a),
   listWorkflowFileCommits: (...a: unknown[]) => listWorkflowFileCommits(...a),
   listWorkflowRuns: (...a: unknown[]) => listWorkflowRuns(...a),
+  listRunJobs: (...a: unknown[]) => listRunJobs(...a),
   getOctokit: () => ({}),
 }));
 vi.mock("@/lib/github-dora", () => ({
@@ -427,5 +429,139 @@ describe("buildAnomalySnapshot", () => {
     expect(snap.outliers).toEqual([]);
     expect(snap.total_runs_analysed).toBe(0);
     expect(snap.workflow_name).toBe("workflow");
+  });
+});
+
+// ── Root-cause snapshot (v4.1.2) ──────────────────────────────────────────────
+
+describe("buildRootCauseSnapshot", () => {
+  /** 5 failures (newest) then 10 successes, so there is a clear pattern. */
+  function failingRuns() {
+    const failures = Array.from({ length: 5 }, (_, i) =>
+      makeRun({
+        id: 500 + i,
+        run_number: 500 + i,
+        conclusion: "failure",
+        created_at: `2026-08-${String(10 + i).padStart(2, "0")}T10:00:00Z`,
+        updated_at: "2026-08-10T10:05:00Z",
+      }),
+    );
+    const successes = Array.from({ length: 10 }, (_, i) =>
+      makeRun({ id: i + 1, run_number: i + 1, conclusion: "success" }),
+    );
+    return [...failures, ...successes];
+  }
+
+  const jobsFixture = [
+    {
+      id: 1,
+      name: "build",
+      status: "completed",
+      conclusion: "failure",
+      duration_ms: 45_000,
+      steps: [
+        { name: "Checkout", status: "completed", conclusion: "success" },
+        { name: "Run tests", status: "completed", conclusion: "failure" },
+      ],
+    },
+    {
+      id: 2,
+      name: "lint",
+      status: "completed",
+      conclusion: "success",
+      duration_ms: 9_000,
+      steps: [{ name: "ESLint", status: "completed", conclusion: "success" }],
+    },
+  ];
+
+  beforeEach(() => {
+    listWorkflowRuns.mockReset().mockResolvedValue(failingRuns());
+    listRunJobs.mockReset().mockResolvedValue(jobsFixture);
+  });
+
+  it("summarises failures, steps and clustering", async () => {
+    const { buildRootCauseSnapshot } = await import("@/lib/ai-snapshots");
+    const snap = await buildRootCauseSnapshot("tok", { owner: "o", repo: "r", workflowId: 7 });
+
+    expect(snap.repo).toBe("o/r");
+    expect(snap.failure_count).toBe(5);
+    expect(snap.run_count).toBe(15);
+    expect(snap.failure_rate_pct).toBe(33);
+    expect(snap.failures).toHaveLength(5);
+    // Only the failed job is reported, and only its failed step.
+    expect(snap.failures[0].failed_jobs).toEqual([
+      { job_name: "build", failed_step_names: ["Run tests"], duration_ms: 45_000 },
+    ]);
+    expect(snap.step_failure_frequency[0]).toEqual({
+      step_name: "Run tests",
+      failure_count: 5,
+      share_of_failures_pct: 100,
+    });
+    expect(snap.failure_clustering.same_step_share_pct).toBe(100);
+  });
+
+  it("carries no forbidden keys", async () => {
+    const { buildRootCauseSnapshot } = await import("@/lib/ai-snapshots");
+    const snap = await buildRootCauseSnapshot("tok", { owner: "o", repo: "r", workflowId: 7 });
+    assertNoForbiddenKeys(snap);
+  });
+
+  it("counts the success streak preceding the newest failure", async () => {
+    // Newest-first: 2 successes, then failures.
+    const runs = [
+      makeRun({ id: 1, run_number: 1, conclusion: "success" }),
+      makeRun({ id: 2, run_number: 2, conclusion: "success" }),
+      ...Array.from({ length: 4 }, (_, i) =>
+        makeRun({ id: 10 + i, run_number: 10 + i, conclusion: "failure" }),
+      ),
+    ];
+    listWorkflowRuns.mockResolvedValue(runs);
+
+    const { buildRootCauseSnapshot } = await import("@/lib/ai-snapshots");
+    const snap = await buildRootCauseSnapshot("tok", { owner: "o", repo: "r", workflowId: 7 });
+    expect(snap.prior_success_streak).toBe(2);
+  });
+
+  it("inspects at most ten failed runs", async () => {
+    listWorkflowRuns.mockResolvedValue(
+      Array.from({ length: 25 }, (_, i) =>
+        makeRun({ id: i + 1, run_number: i + 1, conclusion: "failure" }),
+      ),
+    );
+
+    const { buildRootCauseSnapshot } = await import("@/lib/ai-snapshots");
+    const snap = await buildRootCauseSnapshot("tok", { owner: "o", repo: "r", workflowId: 7 });
+
+    expect(snap.failure_count).toBe(25);        // all counted
+    expect(snap.failures).toHaveLength(10);     // but only ten fetched
+    expect(listRunJobs).toHaveBeenCalledTimes(10);
+  });
+
+  it("flags partial when a job fetch fails, without dropping the snapshot", async () => {
+    listRunJobs.mockRejectedValueOnce(new Error("rate limited"));
+
+    const { buildRootCauseSnapshot } = await import("@/lib/ai-snapshots");
+    const snap = await buildRootCauseSnapshot("tok", { owner: "o", repo: "r", workflowId: 7 });
+
+    expect(snap.partial).toBe(true);
+    expect(snap.failures.length).toBe(4); // the other four still made it
+  });
+
+  it("computes a duration shift between passing and failing runs", async () => {
+    const { buildRootCauseSnapshot } = await import("@/lib/ai-snapshots");
+    const snap = await buildRootCauseSnapshot("tok", { owner: "o", repo: "r", workflowId: 7 });
+    expect(snap.duration_shift).not.toBeNull();
+    expect(snap.duration_shift!.during_failures_p50_ms).toBeGreaterThan(0);
+  });
+
+  it("returns an empty snapshot rather than throwing when runs cannot be fetched", async () => {
+    listWorkflowRuns.mockRejectedValue(new Error("boom"));
+
+    const { buildRootCauseSnapshot } = await import("@/lib/ai-snapshots");
+    const snap = await buildRootCauseSnapshot("tok", { owner: "o", repo: "r", workflowId: 7 });
+
+    expect(snap.failure_count).toBe(0);
+    expect(snap.failures).toEqual([]);
+    expect(snap.partial).toBe(true);
   });
 });

--- a/tests/api-ai-root-cause.test.ts
+++ b/tests/api-ai-root-cause.test.ts
@@ -1,0 +1,196 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+/** Follows the route-handler pattern from tests/api-ai-status.test.ts. */
+
+const getTokenFromSession = vi.fn();
+const aiEnabled = vi.fn();
+const generateJson = vi.fn();
+const buildRootCauseSnapshot = vi.fn();
+
+vi.mock("@/lib/session", () => ({ getTokenFromSession: () => getTokenFromSession() }));
+vi.mock("@/lib/ai", () => ({
+  aiEnabled: () => aiEnabled(),
+  generateJson: (...a: unknown[]) => generateJson(...a),
+}));
+vi.mock("@/lib/ai-snapshots", () => ({
+  buildRootCauseSnapshot: (...a: unknown[]) => buildRootCauseSnapshot(...a),
+}));
+
+const GOOD_CONTENT = JSON.stringify({
+  hypotheses: [
+    {
+      rank: 1,
+      hypothesis: "The ci.yml change broke the test step.",
+      evidence: "All 5 failures name 'Run tests' and none precede 2026-08-09.",
+      confidence: "high",
+      next_step: "Diff .github/workflows/ci.yml at that commit.",
+    },
+  ],
+});
+
+function okProvider(content = GOOD_CONTENT) {
+  return { ok: true, provider: "bailian", model: "qwen3.6-flash", content };
+}
+
+let seq = 0;
+function req(params: string) {
+  return new NextRequest(`https://x.test/api/ai/root-cause?${params}`);
+}
+function validReq() {
+  seq++;
+  return req(`owner=o&repo=r${seq}&workflow_id=7`);
+}
+
+function snapshot(over = {}) {
+  return {
+    workflow_name: "CI",
+    repo: "o/r",
+    window_runs: 15,
+    run_count: 15,
+    failure_count: 5,
+    failure_rate_pct: 33,
+    first_failure_at: "2026-08-10T10:00:00Z",
+    prior_success_streak: 10,
+    failures: [],
+    step_failure_frequency: [{ step_name: "Run tests", failure_count: 5, share_of_failures_pct: 100 }],
+    failure_clustering: { same_step_share_pct: 100, trigger_distribution: { push: 5 }, branch_distribution: { main: 5 } },
+    workflow_file_changes: [],
+    duration_shift: null,
+    partial: false,
+    ...over,
+  };
+}
+
+beforeEach(async () => {
+  seq++;
+  getTokenFromSession.mockReset().mockResolvedValue(`tok-${seq}`);
+  aiEnabled.mockReset().mockReturnValue(true);
+  generateJson.mockReset().mockResolvedValue(okProvider());
+  buildRootCauseSnapshot.mockReset().mockImplementation(async () => snapshot({ repo: `o/r${seq}` }));
+  const { cacheDeleteByPrefix } = await import("@/lib/cache");
+  cacheDeleteByPrefix("ai:root-cause");
+});
+
+describe("GET /api/ai/root-cause — auth and validation", () => {
+  it("returns 401 without a session", async () => {
+    getTokenFromSession.mockResolvedValue(null);
+    const { GET } = await import("@/app/api/ai/root-cause/route");
+    expect((await GET(validReq())).status).toBe(401);
+  });
+
+  it("returns 503 when unconfigured, without building the expensive snapshot", async () => {
+    aiEnabled.mockReturnValue(false);
+    const { GET } = await import("@/app/api/ai/root-cause/route");
+    expect((await GET(validReq())).status).toBe(503);
+    expect(buildRootCauseSnapshot).not.toHaveBeenCalled();
+  });
+
+  it("rejects a missing workflow_id", async () => {
+    const { GET } = await import("@/app/api/ai/root-cause/route");
+    expect((await GET(req("owner=o&repo=r"))).status).toBe(400);
+  });
+});
+
+describe("GET /api/ai/root-cause — minimum-failures floor", () => {
+  it("returns content: null and calls no provider below the threshold", async () => {
+    buildRootCauseSnapshot.mockResolvedValue(snapshot({ failure_count: 2 }));
+    const { GET } = await import("@/app/api/ai/root-cause/route");
+    const res = await GET(validReq());
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.ok).toBe(true);
+    expect(body.content).toBeNull();
+    expect(body.failure_count).toBe(2);
+    expect(generateJson).not.toHaveBeenCalled();
+  });
+
+  it("generates once the threshold is met", async () => {
+    const { GET } = await import("@/app/api/ai/root-cause/route");
+    const body = await (await GET(validReq())).json();
+
+    expect(body.content).not.toBeNull();
+    expect(body.content.hypotheses).toHaveLength(1);
+    expect(generateJson).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("GET /api/ai/root-cause — behaviour", () => {
+  it("returns ranked hypotheses with provider attribution", async () => {
+    const { GET } = await import("@/app/api/ai/root-cause/route");
+    const body = await (await GET(validReq())).json();
+
+    expect(body.provider).toBe("bailian");
+    expect(body.failure_count).toBe(5);
+    expect(body.content.hypotheses[0].confidence).toBe("high");
+    expect(body.content.hypotheses[0].rank).toBe(1);
+  });
+
+  it("caches the snapshot build separately, so a repeat request refetches nothing", async () => {
+    const { GET } = await import("@/app/api/ai/root-cause/route");
+    const r = validReq();
+
+    await GET(r);
+    await GET(r);
+
+    // The GitHub fan-out is the expensive part — it must run only once.
+    expect(buildRootCauseSnapshot).toHaveBeenCalledTimes(1);
+    expect(generateJson).toHaveBeenCalledTimes(1);
+  });
+
+  it("propagates the partial flag", async () => {
+    buildRootCauseSnapshot.mockResolvedValue(snapshot({ partial: true }));
+    const { GET } = await import("@/app/api/ai/root-cause/route");
+    expect((await (await GET(validReq())).json()).partial).toBe(true);
+  });
+
+  it("maps a provider failure to 503", async () => {
+    generateJson.mockResolvedValue({ ok: false, reason: "provider_error", error: "boom" });
+    const { GET } = await import("@/app/api/ai/root-cause/route");
+    const res = await GET(validReq());
+
+    expect(res.status).toBe(503);
+    await expect(res.json()).resolves.toEqual({ ok: false, error: "AI hypotheses unavailable" });
+  });
+
+  it("retries once on an invented confidence level, then succeeds", async () => {
+    const badConfidence = JSON.stringify({
+      hypotheses: [{ rank: 1, hypothesis: "h", evidence: "e", confidence: "extremely high", next_step: "n" }],
+    });
+    generateJson.mockResolvedValueOnce(okProvider(badConfidence)).mockResolvedValueOnce(okProvider());
+
+    const { GET } = await import("@/app/api/ai/root-cause/route");
+    expect((await GET(validReq())).status).toBe(200);
+    expect(generateJson).toHaveBeenCalledTimes(2);
+  });
+
+  it("returns 503 when both attempts fail validation", async () => {
+    generateJson.mockResolvedValue(okProvider("not json"));
+    const { GET } = await import("@/app/api/ai/root-cause/route");
+
+    expect((await GET(validReq())).status).toBe(503);
+    expect(generateJson).toHaveBeenCalledTimes(2);
+  });
+
+  it("returns 500 when snapshot assembly throws, without leaking the cause", async () => {
+    buildRootCauseSnapshot.mockRejectedValue(new Error("github exploded"));
+    const { GET } = await import("@/app/api/ai/root-cause/route");
+    const res = await GET(validReq());
+
+    expect(res.status).toBe(500);
+    expect(JSON.stringify(await res.json())).not.toContain("github exploded");
+  });
+});
+
+describe("GET /api/ai/root-cause — rate limiting", () => {
+  it("allows 10 per minute, then 429s — half the other AI surfaces", async () => {
+    const { GET } = await import("@/app/api/ai/root-cause/route");
+
+    let last: Response | undefined;
+    for (let i = 0; i < 11; i++) last = await GET(validReq());
+
+    expect(last!.status).toBe(429);
+    expect(last!.headers.get("Retry-After")).toBeTruthy();
+  });
+});


### PR DESCRIPTION
Final AI feature of the v4.1.x series. Design: `docs/specs/2026-08-14-ai-features-design.md`

## Summary

**AI Failure Hypotheses (F3)** — when a workflow has 3+ recent failures, the Reliability tab offers "Suggest why this is failing": up to three ranked causes, each with cited evidence, a confidence level, and a next step runnable in minutes.

Signals: workflow-file change dates vs. first failure · step-level failure concentration · trigger/branch clustering · run-duration shifts · length of the success streak that ended.

**Metadata only — never run logs.** GitDash doesn't fetch log content for any feature, and the prompt says so explicitly.

## ⚠️ F2 was skipped

The weekly digest email still can't send — no `RESEND_API_KEY`/`SMTP_HOST` on production (re-verified). Per the plan, a version is never reserved for an unshipped feature, so **F3 took v4.1.2**. F2 can ship whenever an email provider is configured.

## Two things I changed from the original design

**1. Cost is now bounded by failures, not window size.** The spec called for `getJobStats()`, which fans out over every completed run (~30–50 GitHub calls). Job detail is only needed for runs that *failed*, so this fetches jobs for at most 10 failed runs — ~10 calls. Strictly cheaper, and it scales with the problem instead of the window.

**2. The fan-out is cached separately from the LLM call.** Every other AI route fingerprints its cache on the snapshot, so a hit still pays the GitHub fan-out. Here the fan-out *is* the expensive part, so it gets its own key and TTL. Verified by test: a repeat request calls the builder once.

## A bug caught only by testing against the live provider

My initial shared 300-char cap **rejected genuinely good answers.** The prompt asks the model to cite dates and counts, which makes `evidence` naturally long — measured 211–292 chars across real generations, i.e. right at the boundary, so it failed intermittently.

Fixed with per-field caps sized from measured output (hypothesis 400 / evidence 500 / next_step 300) plus explicit brevity guidance in the prompt. That change **improved quality and cut cost**: evidence went ~290 → ~105 chars and output ~600 → ~220 tokens.

Mocked tests would never have caught this.

## Verified end-to-end

Three consecutive live generations through the real code path: **3/3 schema pass**, 2–3s latency, ~640 in / ~220 out tokens. Sample output correctly correlated the workflow-change date with the first failure, and flagged that duration *dropping* (96s→41s) implies an early exit rather than slowness.

## Test plan

- [x] `pnpm exec tsc --noEmit` — **0 errors**
- [x] `pnpm test` — **212/212** (177 → 212, +35)
- [x] `pnpm run lint` — **0 errors** (11 pre-existing warnings, unchanged)
- [x] `rm -rf .next && pnpm run build` — succeeds, all 4 `/api/ai/*` routes emit
- [x] API Reference parity — clean
- [x] Live end-to-end, 3 consecutive runs
- [x] Version bumped in all locations; release-notes entries verified intact
- [x] No API key in any tracked file

## Rollback

1. Unset the AI keys — every surface hides, no redeploy
2. Promote the v4.1.1 deployment
3. `git revert` — no migration, zero schema changes