### PR TITLE
feat: v4.1.3 — email delivery settings in the app

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -56,12 +56,17 @@ NEXT_PUBLIC_APP_URL=http://localhost:3000
 # RESEND_API_KEY=re_...
 # RESEND_FROM=alerts@yourdomain.com
 #
-# Generic SMTP / SendGrid alternative (used when RESEND_API_KEY is not set):
-# SMTP_HOST=smtp.yourprovider.com
-# SMTP_USER=apikey
-# SMTP_PASS=your_smtp_password_or_api_key
+# SendGrid alternative (used when RESEND_API_KEY is not set).
+#
+# NOTE: despite the name, this path does NOT speak the SMTP protocol -- it POSTs
+# to SendGrid's HTTP API at ${SMTP_HOST}/v3/mail/send. SMTP_HOST must therefore
+# be a full HTTPS base URL, not a mail hostname: smtp.gmail.com will NOT work.
+# SMTP_PORT is not read at all. For a real SMTP relay, none of this applies.
+#
+# Prefer configuring email in Settings -- Email Delivery instead (v4.1.3+).
+# SMTP_HOST=https://api.sendgrid.com
+# SMTP_PASS=SG.your_api_key
 # SMTP_FROM=alerts@yourdomain.com
-# SENDGRID_API_KEY=SG....   # alternative to SMTP_PASS for SendGrid
 
 # ── AI features (optional) ────────────────────────────────────────────────────
 # When no key is set, every AI surface is hidden and GitDash behaves exactly as

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,52 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ---
 
+## [4.1.3] — 2026-08-14
+
+### Overview
+Email delivery moves out of environment variables and into Settings. Three features already sent email — alert notifications, the daily digest, and the Weekly Leadership Digest — but configuring them required an env var and a redeploy, and a misconfiguration was completely invisible until an expected email simply never arrived.
+
+**This is the prerequisite for F2 (AI Leadership Digest)**, which was skipped in v4.1.2 precisely because the digest email could not send.
+
+### Added
+
+#### Email Delivery settings (`/settings`)
+- Configure **Resend** or **SendGrid** in the app, stored in the database (**migration 5**, `email_settings`). No redeploy needed.
+- **"Send test email"** — email was the one feature whose misconfiguration produced no visible signal; the only trace was a server log nobody reads.
+- Status pill shows what is *actually* in effect: Settings, environment variables, or nothing.
+
+#### Credential handling
+- The API key is **write-only**: encrypted at rest with AES-256-GCM (`src/lib/secret-box.ts`, key derived from `SESSION_SECRET` with domain separation) and never returned to the browser. The UI shows a masked hint (`••••4f2a`); a blank field means "keep the stored key".
+- Encryption exists because this column lands in every database backup — plaintext would make a leaked backup equivalent to a leaked credential. Stated limit: it does not defend against an attacker holding both the database *and* the environment.
+- `unseal()` returns null rather than throwing on a rotated `SESSION_SECRET`, tampering, or corruption, so a bad row degrades to "not configured" instead of taking down the cron.
+
+### Fixed
+
+#### The SMTP_HOST documentation was actively misleading
+- That code path has **never spoken the SMTP protocol** — it POSTs to SendGrid's HTTP API at `${SMTP_HOST}/v3/mail/send`. The documented example `SMTP_HOST=smtp.yourprovider.com` could therefore never work (it isn't even a valid URL), and `SMTP_PORT` was documented but never read.
+- `.env.local.example` now states this plainly and shows the correct value. The Settings UI is labelled by **provider** rather than "SMTP" for the same reason: a form asking for host/port/username/password would be a trap.
+
+#### Duplicated provider selection
+- The same env-var branching was copy-pasted across three send paths (`deliverEmail`, `deliverDigestEmail`, `deliverLeadershipDigestEmail`). Resolution now happens once in `resolveEmailProvider()`, and `process.env` is read in exactly one place.
+
+### Changed
+- **Resolution is database-first with an environment fallback**, so an instance already using `RESEND_API_KEY` keeps working after upgrading and only switches over when someone explicitly enables email in Settings. Covered by a regression test.
+- Settings are **instance-wide** (like `alert_rules`, which has no per-user scoping either), so any authenticated user can change them. `updated_by` / `updated_at` record who last did, and the key cannot be read back.
+- Provider resolution is cached for 30s — digests send in a loop and would otherwise query per recipient.
+- Test count 212 → 240.
+
+### Rollback
+1. **Toggle email off in Settings** — resolution falls straight back to environment variables.
+2. **Promote the v4.1.2 Vercel deployment** — instant.
+3. **`git revert`** — migration 5 only *adds* a table; existing rows and behaviour are untouched, so no down-migration is required.
+
+### Changed (infra)
+- Bumped app version from 4.1.2 to 4.1.3
+- Bumped Helm chart version from 0.5.2 to 0.5.3
+- **First schema change since v4.0.x** — migration 5 creates `email_settings` (singleton row, `CHECK (id = 1)`)
+
+---
+
 ## [4.1.2] — 2026-08-14
 
 ### Overview

--- a/helm/gitdash/Chart.yaml
+++ b/helm/gitdash/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: gitdash
 description: Self-hosted GitHub Actions metrics dashboard (standalone PAT or GitHub OAuth)
 type: application
-version: 0.5.2
-appVersion: "4.1.2"
+version: 0.5.3
+appVersion: "4.1.3"
 keywords:
   - github-actions
   - dashboard

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gitdash",
-  "version": "4.1.2",
+  "version": "4.1.3",
   "private": true,
   "packageManager": "pnpm@10.30.3",
   "scripts": {

--- a/src/app/api/settings/email/route.ts
+++ b/src/app/api/settings/email/route.ts
@@ -1,0 +1,156 @@
+/**
+ * GET  /api/settings/email — current email delivery config (never the secret).
+ * PUT  /api/settings/email — save it.
+ *
+ * The API key is write-only by design. It is never returned, only a masked
+ * hint like "••••4f2a", so a logged-in user can confirm *which* key is stored
+ * without being able to read it back. Submitting the form without a key
+ * preserves the stored one.
+ *
+ * This config is instance-wide — like alert_rules, it has no per-user scoping,
+ * so any authenticated user can change it. `updated_by` records who did, which
+ * is what makes that acceptable rather than silent.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { getTokenFromSession } from "@/lib/session";
+import { getSession } from "@/lib/session";
+import { getEmailSettings, saveEmailSettings, type EmailProvider } from "@/lib/db";
+import { resolveEmailProvider, invalidateEmailProviderCache } from "@/lib/notifier";
+import { seal, maskHint } from "@/lib/secret-box";
+import { safeError } from "@/lib/validation";
+
+export const maxDuration = 60;
+
+const VALID_PROVIDERS: EmailProvider[] = ["resend", "sendgrid"];
+
+/** Deliberately permissive — real-world addresses are stranger than any strict regex. */
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+export interface EmailSettingsResponse {
+  enabled: boolean;
+  provider: EmailProvider;
+  from_address: string | null;
+  /** Masked, e.g. "••••4f2a". Null when no key is stored. */
+  api_key_hint: string | null;
+  has_key: boolean;
+  updated_by: string | null;
+  updated_at: string | null;
+  /**
+   * What the app would actually send through right now, accounting for the
+   * environment-variable fallback. "env" means legacy config is still in
+   * charge; "none" means nothing will send.
+   */
+  effective_source: "settings" | "env" | "none";
+  db_available: boolean;
+}
+
+export async function GET() {
+  const token = await getTokenFromSession();
+  if (!token) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const resolved = await resolveEmailProvider();
+
+  try {
+    const s = await getEmailSettings();
+    const body: EmailSettingsResponse = {
+      enabled: s?.enabled ?? false,
+      provider: s?.provider ?? "resend",
+      from_address: s?.from_address ?? null,
+      api_key_hint: s?.api_key_hint ?? null,
+      has_key: Boolean(s?.api_key_sealed),
+      updated_by: s?.updated_by ?? null,
+      updated_at: s?.updated_at ?? null,
+      effective_source: resolved?.source ?? "none",
+      db_available: true,
+    };
+    return NextResponse.json(body, { headers: { "Cache-Control": "private, no-store" } });
+  } catch {
+    // No DATABASE_URL — the section still renders, read-only, explaining that
+    // env vars are the only option on this deployment.
+    const body: EmailSettingsResponse = {
+      enabled: false,
+      provider: "resend",
+      from_address: null,
+      api_key_hint: null,
+      has_key: false,
+      updated_by: null,
+      updated_at: null,
+      effective_source: resolved?.source ?? "none",
+      db_available: false,
+    };
+    return NextResponse.json(body, { headers: { "Cache-Control": "private, no-store" } });
+  }
+}
+
+export async function PUT(req: NextRequest) {
+  const token = await getTokenFromSession();
+  if (!token) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  let payload: {
+    enabled?: unknown;
+    provider?: unknown;
+    from_address?: unknown;
+    api_key?: unknown;
+  };
+  try {
+    payload = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const enabled = payload.enabled === true;
+
+  const provider = payload.provider;
+  if (typeof provider !== "string" || !VALID_PROVIDERS.includes(provider as EmailProvider)) {
+    return NextResponse.json({ error: 'provider must be "resend" or "sendgrid"' }, { status: 400 });
+  }
+
+  const fromRaw = typeof payload.from_address === "string" ? payload.from_address.trim() : "";
+  if (fromRaw && !EMAIL_RE.test(fromRaw)) {
+    return NextResponse.json({ error: "from_address is not a valid email address" }, { status: 400 });
+  }
+
+  const apiKeyRaw = typeof payload.api_key === "string" ? payload.api_key.trim() : "";
+
+  // Enabling with no key stored and none supplied would silently do nothing —
+  // reject it rather than let the UI show "enabled" over a dead config.
+  let existingHasKey = false;
+  try {
+    existingHasKey = Boolean((await getEmailSettings())?.api_key_sealed);
+  } catch {
+    return NextResponse.json(
+      { error: "No database configured — email settings must be set via environment variables." },
+      { status: 503 },
+    );
+  }
+  if (enabled && !apiKeyRaw && !existingHasKey) {
+    return NextResponse.json({ error: "An API key is required to enable email" }, { status: 400 });
+  }
+  if (enabled && !fromRaw) {
+    return NextResponse.json({ error: "A from address is required to enable email" }, { status: 400 });
+  }
+
+  // Attribution: who last changed the instance-wide credential.
+  let updatedBy: string | null = null;
+  try {
+    const session = await getSession();
+    updatedBy = session.user?.login ?? null;
+  } catch {
+    updatedBy = null;
+  }
+
+  try {
+    await saveEmailSettings({
+      enabled,
+      provider: provider as EmailProvider,
+      from_address: fromRaw || null,
+      updated_by: updatedBy,
+      ...(apiKeyRaw ? { api_key_sealed: seal(apiKeyRaw), api_key_hint: maskHint(apiKeyRaw) } : {}),
+    });
+    invalidateEmailProviderCache();
+    return NextResponse.json({ ok: true });
+  } catch (e) {
+    return safeError(e, "Failed to save email settings");
+  }
+}

--- a/src/app/api/settings/email/test/route.ts
+++ b/src/app/api/settings/email/test/route.ts
@@ -1,0 +1,63 @@
+/**
+ * POST /api/settings/email/test — send a verification email.
+ *
+ * Email is the one feature whose misconfiguration is otherwise invisible: an
+ * alert or a Monday digest simply never arrives, and the only trace is a
+ * server log nobody reads. This closes that loop.
+ *
+ * Rate-limited because it sends real mail on demand — an unmetered send
+ * endpoint behind a session is a spam relay.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { getTokenFromSession } from "@/lib/session";
+import { sendTestEmail } from "@/lib/notifier";
+import { aiRateLimit } from "@/lib/ratelimit";
+import { hashKey } from "@/lib/cache";
+import { safeError } from "@/lib/validation";
+
+export const maxDuration = 60;
+
+const RATE_LIMIT_PER_MIN = 3;
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+export async function POST(req: NextRequest) {
+  const token = await getTokenFromSession();
+  if (!token) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const limit = aiRateLimit(hashKey(token), "email-test", RATE_LIMIT_PER_MIN);
+  if (!limit.allowed) {
+    return NextResponse.json(
+      { ok: false, error: "Too many test emails — wait a minute." },
+      {
+        status: 429,
+        headers: { "Retry-After": String(Math.ceil((limit.retryAfterMs ?? 60_000) / 1000)) },
+      },
+    );
+  }
+
+  let to: string;
+  try {
+    const body = await req.json();
+    to = typeof body.to === "string" ? body.to.trim() : "";
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  if (!to || !EMAIL_RE.test(to)) {
+    return NextResponse.json({ error: "A valid recipient address is required" }, { status: 400 });
+  }
+
+  try {
+    const result = await sendTestEmail(to);
+    if (!result.ok) {
+      // The provider's own error is genuinely useful here (bad key, unverified
+      // domain, wrong sender) and contains no secret — this is the one place
+      // it is worth surfacing rather than swallowing.
+      return NextResponse.json({ ok: false, error: result.error }, { status: 502 });
+    }
+    return NextResponse.json({ ok: true, source: result.source });
+  } catch (e) {
+    return safeError(e, "Failed to send test email");
+  }
+}

--- a/src/app/docs/page.tsx
+++ b/src/app/docs/page.tsx
@@ -1329,7 +1329,7 @@ function FeatureSettings() {
     <section className="space-y-6">
       <FeaturePageHeader
         icon={Sliders} name="Settings" path="/settings"
-        chips={["PAT management", "Session info", "Billing widget"]}
+        chips={["PAT management", "Email delivery", "Feature flags", "Billing widget"]}
       />
       <ProseP>
         In <strong>standalone mode</strong> — update or revoke your GitHub Personal Access Token.
@@ -1338,6 +1338,51 @@ function FeatureSettings() {
         billing period.
       </ProseP>
       <ScreenshotSlot file="16-settings.png" alt="Settings page" />
+
+      <DocCard>
+        <div className="flex items-center gap-2 mb-2">
+          <SubHeading>Email Delivery</SubHeading>
+          <VersionBadge v="4.1.3" />
+        </div>
+        <ProseP>
+          Three features send email — alert notifications, the daily digest, and the Weekly
+          Leadership Digest. All three need a provider. Before v4.1.3 that meant an environment
+          variable and a redeploy; now it is configured here and stored in the database.
+        </ProseP>
+
+        <Callout type="warning">
+          <strong>This is not SMTP.</strong> GitDash talks to Resend and SendGrid over their HTTP
+          APIs — there is no SMTP client in the codebase. A mail hostname and port
+          (<Code>smtp.gmail.com</Code>, <Code>587</Code>) cannot work, and a corporate SMTP relay is
+          not supported. You need an API key from one of the two providers.
+        </Callout>
+
+        <DocTable
+          headers={["Field", "Notes"]}
+          rows={[
+            ["Provider", "Resend or SendGrid. Both are HTTP APIs — no host or port to configure"],
+            ["API key", "Encrypted at rest and never returned to the browser. The form shows a masked hint; leave it blank to keep the stored key"],
+            ["From address", "Must be on a domain you have verified with the provider, or delivery will be rejected"],
+            ["Send test email", "Verifies the whole path immediately, rather than finding out on Monday"],
+          ]}
+        />
+
+        <DocCard>
+          <SubHeading>Precedence and upgrades</SubHeading>
+          <ProseP>
+            Settings take priority, with environment variables as the fallback. An instance already
+            using <Code>RESEND_API_KEY</Code> keeps working untouched after upgrading — the database
+            only takes over once someone explicitly enables email here. The status pill shows which
+            source is actually in effect.
+          </ProseP>
+        </DocCard>
+
+        <Callout type="warning">
+          <strong>These settings are instance-wide.</strong> Like alert rules, they have no per-user
+          scoping, so any signed-in user can change them and redirect where mail is sent. The API key
+          itself cannot be read back, and the settings record who last changed them and when.
+        </Callout>
+      </DocCard>
     </section>
   );
 }
@@ -2450,6 +2495,24 @@ function APIReference() {
         },
         {
           method: "GET",
+          path: "/api/settings/email",
+          description: "Current email delivery configuration. Returns { enabled, provider, from_address, api_key_hint, has_key, updated_by, updated_at, effective_source, db_available }. The API key itself is never returned — only a masked hint. effective_source reports whether Settings, environment variables, or nothing is actually in effect.",
+          params: [],
+        },
+        {
+          method: "PUT",
+          path: "/api/settings/email",
+          description: "Save email delivery configuration. Body: { enabled, provider (\"resend\"|\"sendgrid\"), from_address, api_key? }. Omitting api_key preserves the stored one. The key is encrypted with AES-256-GCM before storage. Rejects enabling without a key or from address. 503 when no database is configured.",
+          params: [],
+        },
+        {
+          method: "POST",
+          path: "/api/settings/email/test",
+          description: "Send a test email through the currently-resolved provider to verify configuration. Body: { to }. Returns the provider's own error verbatim on failure (bad key, unverified sender) since it is actionable and contains no secret. Rate-limited to 3/min per token.",
+          params: [],
+        },
+        {
+          method: "GET",
           path: "/api/health",
           description: "Liveness/readiness probe. Returns {\"status\":\"ok\"} with no authentication. Used by Kubernetes and load balancers.",
           params: [],
@@ -2701,9 +2764,30 @@ pnpm run lint`}
 function ReleaseNotes() {
   const releases = [
     {
-      version: "4.1.2",
+      version: "4.1.3",
       date: "2026-08-14",
       badge: "latest",
+      badgeColor: "bg-emerald-500/15 text-emerald-400 border-emerald-500/20",
+      changes: {
+        added: [
+          "Email Delivery settings — configure Resend or SendGrid from Settings instead of environment variables, so enabling alert emails, daily digests and the Weekly Leadership Digest no longer needs a redeploy. Stored in the database (migration 5)",
+          "\"Send test email\" button. Email was previously the one feature whose misconfiguration was invisible — an alert or a Monday digest simply never arrived, and the only trace was a server log",
+          "The API key is write-only: it is encrypted at rest with AES-256-GCM (keyed from SESSION_SECRET) and never returned to the browser. The UI shows a masked hint like \"••••4f2a\", and leaving the field blank keeps the stored key",
+        ],
+        fixed: [
+          "The SMTP_HOST documentation was actively misleading. That path has never spoken the SMTP protocol — it POSTs to SendGrid's HTTP API at ${SMTP_HOST}/v3/mail/send — so the documented example smtp.yourprovider.com could never work, and SMTP_PORT was never read at all. The example is corrected and the limitation stated plainly",
+          "Provider selection was duplicated across three send paths with three copies of the same env-var branching. Now resolved once in resolveEmailProvider()",
+        ],
+        improved: [
+          "Existing env-var setups are untouched: resolution is database-first with an environment fallback, so an instance already using RESEND_API_KEY keeps working after upgrading and only switches over when someone explicitly enables email in Settings",
+          "Email config is instance-wide, like alert rules — any authenticated user can change it, so the settings record and display who last changed it and when",
+        ],
+      },
+    },
+    {
+      version: "4.1.2",
+      date: "2026-08-14",
+      badge: null,
       badgeColor: "bg-emerald-500/15 text-emerald-400 border-emerald-500/20",
       changes: {
         added: [
@@ -3193,7 +3277,7 @@ function DocSidebar({
           <BookOpen className="w-4 h-4 text-violet-400" />
           <span className="text-sm font-semibold text-white">GitDash Docs</span>
           <span className="text-xs px-1.5 py-0.5 rounded bg-violet-500/15 text-violet-400 border border-violet-500/20 font-mono">
-            v{process.env.NEXT_PUBLIC_APP_VERSION ?? "4.1.2"}
+            v{process.env.NEXT_PUBLIC_APP_VERSION ?? "4.1.3"}
           </span>
         </div>
         {/* Mobile close */}
@@ -3443,7 +3527,7 @@ export default function DocsPage() {
 
           {/* Footer */}
           <footer className="mt-8 pb-4 text-center text-xs text-slate-600 space-y-1">
-            <p>GitDash v{process.env.NEXT_PUBLIC_APP_VERSION ?? "4.1.2"} — GitHub Actions Dashboard</p>
+            <p>GitDash v{process.env.NEXT_PUBLIC_APP_VERSION ?? "4.1.3"} — GitHub Actions Dashboard</p>
             <p>
               <a href="https://github.com/dinhdobathi1992/gitdash" target="_blank" rel="noreferrer" className="hover:text-slate-400 transition-colors">
                 Open source on GitHub

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import { useAuth } from "@/components/AuthProvider";
 import { useFeatureFlags } from "@/components/FeatureFlagsProvider";
+import EmailSettingsCard from "@/components/EmailSettingsCard";
 import { Breadcrumb } from "@/components/Sidebar";
 import type { FeatureFlags } from "@/lib/feature-flags";
 import {
@@ -270,6 +271,9 @@ export default function SettingsPage() {
           </div>
         )}
       </div>
+
+      {/* ── Email delivery ───────────────────────────────────────────── */}
+      <EmailSettingsCard />
 
       {/* ── Feature flags — card grid fills the page ──────────────────── */}
       <div className="space-y-4">

--- a/src/components/EmailSettingsCard.tsx
+++ b/src/components/EmailSettingsCard.tsx
@@ -1,0 +1,314 @@
+"use client";
+
+/**
+ * Email delivery settings (v4.1.3).
+ *
+ * Moves email provider config out of environment variables and into the app,
+ * so enabling alert/digest email no longer needs a redeploy.
+ *
+ * Deliberately labelled by provider rather than "SMTP": this path speaks the
+ * Resend and SendGrid HTTP APIs, not the SMTP protocol, so a form asking for
+ * host/port/username/password would be a trap — those values cannot work here.
+ *
+ * The API key is write-only. The server returns a masked hint only, and an
+ * empty key field means "keep the stored one".
+ */
+
+import { useState } from "react";
+import useSWR from "swr";
+import { fetcher } from "@/lib/swr";
+import type { EmailSettingsResponse } from "@/app/api/settings/email/route";
+import { Mail, Loader2, CheckCircle2, AlertTriangle, Send } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+const PROVIDER_META = {
+  resend: { label: "Resend", keyLabel: "API key", keyPlaceholder: "re_…", docs: "https://resend.com" },
+  sendgrid: { label: "SendGrid", keyLabel: "API key", keyPlaceholder: "SG.…", docs: "https://sendgrid.com" },
+} as const;
+
+type Provider = keyof typeof PROVIDER_META;
+
+export default function EmailSettingsCard() {
+  const { data, mutate, isLoading } = useSWR<EmailSettingsResponse>(
+    "/api/settings/email",
+    fetcher<EmailSettingsResponse>,
+  );
+
+  const [draft, setDraft] = useState<{
+    enabled: boolean;
+    provider: Provider;
+    from: string;
+    apiKey: string;
+  } | null>(null);
+
+  const [saving, setSaving] = useState(false);
+  const [testing, setTesting] = useState(false);
+  const [msg, setMsg] = useState<{ kind: "ok" | "err"; text: string } | null>(null);
+  const [testTo, setTestTo] = useState("");
+
+  // Seed the draft once the server state arrives, then let the user own it.
+  const state =
+    draft ??
+    (data
+      ? {
+          enabled: data.enabled,
+          provider: data.provider as Provider,
+          from: data.from_address ?? "",
+          apiKey: "",
+        }
+      : null);
+
+  function patch(p: Partial<NonNullable<typeof state>>) {
+    if (!state) return;
+    setDraft({ ...state, ...p });
+    setMsg(null);
+  }
+
+  async function save() {
+    if (!state) return;
+    setSaving(true);
+    setMsg(null);
+    try {
+      const res = await fetch("/api/settings/email", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        credentials: "same-origin",
+        body: JSON.stringify({
+          enabled: state.enabled,
+          provider: state.provider,
+          from_address: state.from,
+          // Omitted when blank — the server keeps the stored key.
+          ...(state.apiKey ? { api_key: state.apiKey } : {}),
+        }),
+      });
+      const body = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        setMsg({ kind: "err", text: body.error ?? `Save failed (${res.status})` });
+        return;
+      }
+      setMsg({ kind: "ok", text: "Saved." });
+      setDraft(null); // fall back to server state, clearing the key field
+      mutate();
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function sendTest() {
+    setTesting(true);
+    setMsg(null);
+    try {
+      const res = await fetch("/api/settings/email/test", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        credentials: "same-origin",
+        body: JSON.stringify({ to: testTo }),
+      });
+      const body = await res.json().catch(() => ({}));
+      setMsg(
+        res.ok
+          ? { kind: "ok", text: `Test email sent to ${testTo}.` }
+          : { kind: "err", text: body.error ?? `Send failed (${res.status})` },
+      );
+    } finally {
+      setTesting(false);
+    }
+  }
+
+  if (isLoading || !state || !data) {
+    return (
+      <div className="rounded-2xl border border-slate-800 bg-slate-900/40 p-5">
+        <div className="h-4 w-40 rounded skeleton mb-3" />
+        <div className="h-3 w-64 rounded skeleton" />
+      </div>
+    );
+  }
+
+  const meta = PROVIDER_META[state.provider];
+  const dirty = draft !== null;
+
+  return (
+    <div className="rounded-2xl border border-slate-800 bg-slate-900/40 overflow-hidden">
+      <div className="flex items-start gap-4 p-5 border-b border-slate-800">
+        <span className="shrink-0 w-9 h-9 rounded-lg border border-sky-500/30 bg-sky-500/[0.12] flex items-center justify-center">
+          <Mail className="w-4 h-4 text-sky-300" />
+        </span>
+        <div className="min-w-0 flex-1">
+          <h3 className="text-[15px] font-semibold text-white">Email Delivery</h3>
+          <p className="text-xs text-slate-500 mt-0.5">
+            Powers alert emails, daily digests, and the Weekly Leadership Digest. Without it, those
+            features run but never deliver.
+          </p>
+        </div>
+        <StatusPill data={data} />
+      </div>
+
+      <div className="p-5 space-y-4">
+        {!data.db_available && (
+          <div className="flex items-start gap-2 px-3 py-2.5 rounded-lg bg-amber-500/10 border border-amber-500/25 text-xs text-amber-200">
+            <AlertTriangle className="w-3.5 h-3.5 mt-0.5 shrink-0" />
+            <span>
+              No database is configured on this deployment, so settings cannot be saved here. Use the{" "}
+              <code className="text-amber-100">RESEND_API_KEY</code> environment variable instead.
+            </span>
+          </div>
+        )}
+
+        {data.effective_source === "env" && (
+          <div className="flex items-start gap-2 px-3 py-2.5 rounded-lg bg-slate-800/60 border border-slate-700 text-xs text-slate-300">
+            <AlertTriangle className="w-3.5 h-3.5 mt-0.5 shrink-0 text-slate-400" />
+            <span>
+              Email is currently configured by environment variables. Anything saved here takes over
+              once you enable it.
+            </span>
+          </div>
+        )}
+
+        <label className="flex items-center gap-3 cursor-pointer">
+          <input
+            type="checkbox"
+            checked={state.enabled}
+            disabled={!data.db_available}
+            onChange={(e) => patch({ enabled: e.target.checked })}
+            className="w-4 h-4 rounded accent-violet-500"
+          />
+          <span className="text-sm text-slate-200">Enable email delivery</span>
+        </label>
+
+        {state.enabled && (
+          <div className="space-y-3.5 pl-7">
+            <Field label="Provider">
+              <select
+                value={state.provider}
+                onChange={(e) => patch({ provider: e.target.value as Provider })}
+                className="w-full px-3 py-2 bg-slate-900/70 border border-slate-700 rounded-lg text-sm text-slate-100 focus:outline-none focus:ring-2 focus:ring-violet-500/40"
+              >
+                {(Object.keys(PROVIDER_META) as Provider[]).map((p) => (
+                  <option key={p} value={p}>{PROVIDER_META[p].label}</option>
+                ))}
+              </select>
+              <p className="text-[11px] text-slate-600 mt-1">
+                Both use their HTTP API — no SMTP server or port required.
+              </p>
+            </Field>
+
+            <Field label={meta.keyLabel}>
+              <input
+                type="password"
+                autoComplete="off"
+                value={state.apiKey}
+                placeholder={data.has_key ? `${data.api_key_hint} — leave blank to keep` : meta.keyPlaceholder}
+                onChange={(e) => patch({ apiKey: e.target.value })}
+                className="w-full px-3 py-2 bg-slate-900/70 border border-slate-700 rounded-lg text-sm text-slate-100 font-mono placeholder-slate-600 focus:outline-none focus:ring-2 focus:ring-violet-500/40"
+              />
+              <p className="text-[11px] text-slate-600 mt-1">
+                Stored encrypted and never shown again. Get one at{" "}
+                <a href={meta.docs} target="_blank" rel="noopener noreferrer" className="text-violet-400 hover:underline">
+                  {meta.label}
+                </a>.
+              </p>
+            </Field>
+
+            <Field label="From address">
+              <input
+                type="email"
+                value={state.from}
+                placeholder="alerts@yourdomain.com"
+                onChange={(e) => patch({ from: e.target.value })}
+                className="w-full px-3 py-2 bg-slate-900/70 border border-slate-700 rounded-lg text-sm text-slate-100 placeholder-slate-600 focus:outline-none focus:ring-2 focus:ring-violet-500/40"
+              />
+              <p className="text-[11px] text-slate-600 mt-1">
+                Must be on a domain you have verified with {meta.label}.
+              </p>
+            </Field>
+          </div>
+        )}
+
+        {msg && (
+          <div
+            className={cn(
+              "flex items-start gap-2 px-3 py-2.5 rounded-lg text-xs border",
+              msg.kind === "ok"
+                ? "bg-emerald-500/10 border-emerald-500/25 text-emerald-200"
+                : "bg-red-500/10 border-red-500/25 text-red-200",
+            )}
+          >
+            {msg.kind === "ok" ? (
+              <CheckCircle2 className="w-3.5 h-3.5 mt-0.5 shrink-0" />
+            ) : (
+              <AlertTriangle className="w-3.5 h-3.5 mt-0.5 shrink-0" />
+            )}
+            <span className="break-words">{msg.text}</span>
+          </div>
+        )}
+
+        <div className="flex items-center gap-2 flex-wrap">
+          <button
+            onClick={save}
+            disabled={saving || !dirty || !data.db_available}
+            className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-lg bg-violet-500/15 border border-violet-500/30 text-violet-200 hover:bg-violet-500/25 transition-colors disabled:opacity-40"
+          >
+            {saving && <Loader2 className="w-3 h-3 animate-spin" />}
+            {dirty ? "Save changes" : "Saved"}
+          </button>
+
+          {data.updated_by && (
+            <span className="text-[11px] text-slate-600">
+              Last changed by @{data.updated_by}
+              {data.updated_at && ` · ${new Date(data.updated_at).toLocaleDateString()}`}
+            </span>
+          )}
+        </div>
+
+        {/* Verification — the only way to know this works before Monday. */}
+        {data.effective_source !== "none" && (
+          <div className="pt-3 border-t border-slate-800 space-y-2">
+            <p className="text-xs text-slate-400">Send a test email</p>
+            <div className="flex items-center gap-2 flex-wrap">
+              <input
+                type="email"
+                value={testTo}
+                placeholder="you@yourdomain.com"
+                onChange={(e) => setTestTo(e.target.value)}
+                className="flex-1 min-w-[200px] px-3 py-1.5 bg-slate-900/70 border border-slate-700 rounded-lg text-xs text-slate-100 placeholder-slate-600 focus:outline-none focus:ring-2 focus:ring-violet-500/40"
+              />
+              <button
+                onClick={sendTest}
+                disabled={testing || !testTo}
+                className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs rounded-lg bg-slate-800 border border-slate-700 text-slate-300 hover:bg-slate-700 transition-colors disabled:opacity-40"
+              >
+                {testing ? <Loader2 className="w-3 h-3 animate-spin" /> : <Send className="w-3 h-3" />}
+                Send test
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function Field({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div>
+      <label className="block text-xs font-medium text-slate-400 mb-1.5">{label}</label>
+      {children}
+    </div>
+  );
+}
+
+function StatusPill({ data }: { data: EmailSettingsResponse }) {
+  if (data.effective_source === "none") {
+    return (
+      <span className="shrink-0 text-[10px] font-semibold uppercase tracking-wide px-2 py-1 rounded-full border border-slate-700 bg-slate-800/60 text-slate-400">
+        Not configured
+      </span>
+    );
+  }
+  return (
+    <span className="shrink-0 inline-flex items-center gap-1 text-[10px] font-semibold uppercase tracking-wide px-2 py-1 rounded-full border border-emerald-500/25 bg-emerald-500/10 text-emerald-300">
+      <CheckCircle2 className="w-3 h-3" />
+      {data.effective_source === "settings" ? "Active" : "Active (env)"}
+    </span>
+  );
+}

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -266,6 +266,34 @@ const MIGRATIONS: Array<{ version: number; name: string; up: string[] }> = [
       `CREATE INDEX IF NOT EXISTS idx_ae_digest_pending ON alert_events(digest_sent_at) WHERE digest_sent_at IS NULL`,
     ],
   },
+  {
+    version: 5,
+    name: "email_settings",
+    up: [
+      // Instance-wide email delivery config, editable from Settings instead of
+      // requiring an env var and a redeploy.
+      //
+      // Singleton by construction: `id` is pinned to 1 by a CHECK, so an UPSERT
+      // on the primary key is the whole write path and no code can accidentally
+      // create a second competing row.
+      //
+      // api_key_sealed holds an AES-256-GCM value from src/lib/secret-box.ts —
+      // never plaintext, because this column ends up in every backup.
+      // updated_by records the GitHub login that last changed it: the table is
+      // instance-global (like alert_rules) so any authenticated user can edit
+      // it, and attribution is what makes that acceptable.
+      `CREATE TABLE IF NOT EXISTS email_settings (
+        id              INT PRIMARY KEY DEFAULT 1 CHECK (id = 1),
+        enabled         BOOLEAN NOT NULL DEFAULT FALSE,
+        provider        VARCHAR(20) NOT NULL DEFAULT 'resend',
+        api_key_sealed  TEXT,
+        api_key_hint    VARCHAR(20),
+        from_address    TEXT,
+        updated_by      VARCHAR(120),
+        updated_at      TIMESTAMPTZ DEFAULT NOW()
+      )`,
+    ],
+  },
 ];
 
 let schemaEnsured = false;
@@ -932,3 +960,84 @@ export async function evaluateAlertRulesForRepo(repoKey: string): Promise<number
 
 // Re-export for backward compatibility
 export { _METRIC_LABELS as METRIC_LABELS };
+
+// ── Email settings (v4.1.3) ───────────────────────────────────────────────────
+
+export type EmailProvider = "resend" | "sendgrid";
+
+export interface DbEmailSettings {
+  enabled: boolean;
+  provider: EmailProvider;
+  api_key_sealed: string | null;
+  api_key_hint: string | null;
+  from_address: string | null;
+  updated_by: string | null;
+  updated_at: string | null;
+}
+
+/**
+ * Read the instance email config. Returns null when the table has no row yet
+ * (nobody has configured it) — callers then fall back to environment
+ * variables, so upgrading to v4.1.3 never breaks a working env-var setup.
+ */
+export async function getEmailSettings(): Promise<DbEmailSettings | null> {
+  await ensureSchema();
+  const rows = (await getDb()`
+    SELECT enabled, provider, api_key_sealed, api_key_hint,
+           from_address, updated_by, updated_at
+    FROM email_settings WHERE id = 1
+  `) as DbEmailSettings[];
+  return rows[0] ?? null;
+}
+
+/**
+ * Upsert the singleton row.
+ *
+ * `api_key_sealed` is only written when a new key is supplied — passing
+ * undefined preserves the stored one, which is what lets the UI show a masked
+ * field and treat "left blank" as "unchanged" without ever round-tripping the
+ * secret through the browser.
+ */
+export async function saveEmailSettings(input: {
+  enabled: boolean;
+  provider: EmailProvider;
+  from_address: string | null;
+  updated_by: string | null;
+  api_key_sealed?: string;
+  api_key_hint?: string;
+}): Promise<void> {
+  await ensureSchema();
+  const db = getDb();
+
+  if (input.api_key_sealed !== undefined) {
+    await db`
+      INSERT INTO email_settings
+        (id, enabled, provider, api_key_sealed, api_key_hint, from_address, updated_by, updated_at)
+      VALUES
+        (1, ${input.enabled}, ${input.provider}, ${input.api_key_sealed},
+         ${input.api_key_hint ?? null}, ${input.from_address}, ${input.updated_by}, NOW())
+      ON CONFLICT (id) DO UPDATE SET
+        enabled = EXCLUDED.enabled,
+        provider = EXCLUDED.provider,
+        api_key_sealed = EXCLUDED.api_key_sealed,
+        api_key_hint = EXCLUDED.api_key_hint,
+        from_address = EXCLUDED.from_address,
+        updated_by = EXCLUDED.updated_by,
+        updated_at = NOW()
+    `;
+    return;
+  }
+
+  await db`
+    INSERT INTO email_settings
+      (id, enabled, provider, from_address, updated_by, updated_at)
+    VALUES
+      (1, ${input.enabled}, ${input.provider}, ${input.from_address}, ${input.updated_by}, NOW())
+    ON CONFLICT (id) DO UPDATE SET
+      enabled = EXCLUDED.enabled,
+      provider = EXCLUDED.provider,
+      from_address = EXCLUDED.from_address,
+      updated_by = EXCLUDED.updated_by,
+      updated_at = NOW()
+  `;
+}

--- a/src/lib/notifier.ts
+++ b/src/lib/notifier.ts
@@ -7,6 +7,8 @@
  */
 
 import type { DbAlertRule } from "./db";
+import { unseal } from "./secret-box";
+import { withCache, cacheDelete } from "./cache";
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
@@ -104,12 +106,116 @@ export async function deliverSlack(payload: AlertPayload): Promise<DeliveryResul
   }
 }
 
+// ── Email provider resolution (v4.1.3) ────────────────────────────────────────
+
+export interface ResolvedEmailProvider {
+  provider: "resend" | "sendgrid";
+  apiKey: string;
+  from: string;
+  /** Where the config came from — surfaced in Settings and the test endpoint. */
+  source: "settings" | "env";
+}
+
+const DEFAULT_FROM = "alerts@gitdash.app";
+const PROVIDER_CACHE_TTL = 30; // seconds — digests send in a loop
+
+/**
+ * Resolve which provider to send through: database settings first, then
+ * environment variables.
+ *
+ * The precedence matters for upgrades. An instance that already had
+ * RESEND_API_KEY set keeps working untouched after v4.1.3; the database only
+ * takes over once someone explicitly enables email in Settings.
+ *
+ * The db import is dynamic on purpose: src/lib/db.ts imports this module, so a
+ * static import here would close a cycle. It is also genuinely lazy — nothing
+ * touches the database unless an email is actually being sent.
+ */
+export async function resolveEmailProvider(): Promise<ResolvedEmailProvider | null> {
+  const fromSettings = await withCache<ResolvedEmailProvider | null>(
+    "email-provider:settings",
+    PROVIDER_CACHE_TTL,
+    async () => {
+      try {
+        const { getEmailSettings } = await import("./db");
+        const s = await getEmailSettings();
+        if (!s || !s.enabled || !s.api_key_sealed) return null;
+
+        const apiKey = unseal(s.api_key_sealed);
+        if (!apiKey) {
+          // Sealed with a different SESSION_SECRET, or corrupted. Fall through
+          // to env rather than failing outright, and say so in the log — this
+          // is the one case an operator genuinely needs to know about.
+          console.error(
+            "[notifier] Stored email credential could not be decrypted — re-enter it in Settings.",
+          );
+          return null;
+        }
+        return {
+          provider: s.provider,
+          apiKey,
+          from: s.from_address || DEFAULT_FROM,
+          source: "settings" as const,
+        };
+      } catch {
+        // No DATABASE_URL, or the table is not reachable. Env fallback covers it.
+        return null;
+      }
+    },
+  );
+
+  if (fromSettings) return fromSettings;
+
+  const resendKey = process.env.RESEND_API_KEY;
+  if (resendKey) {
+    return {
+      provider: "resend",
+      apiKey: resendKey,
+      from: process.env.RESEND_FROM ?? DEFAULT_FROM,
+      source: "env",
+    };
+  }
+
+  const sendgridKey = process.env.SMTP_PASS ?? process.env.SENDGRID_API_KEY;
+  if (process.env.SMTP_HOST && sendgridKey) {
+    return {
+      provider: "sendgrid",
+      apiKey: sendgridKey,
+      from: process.env.SMTP_FROM ?? process.env.SMTP_USER ?? DEFAULT_FROM,
+      source: "env",
+    };
+  }
+
+  return null;
+}
+
+/** Invalidate the provider cache after a Settings save. */
+export function invalidateEmailProviderCache(): void {
+  cacheDelete("email-provider:settings");
+}
+
+const NO_PROVIDER_ERROR =
+  "No email provider configured. Enable email in Settings, or set RESEND_API_KEY.";
+
+/** Single send path for every email the app produces. */
+async function sendEmail(
+  to: string,
+  subject: string,
+  html: string,
+  text: string,
+): Promise<DeliveryResult> {
+  const cfg = await resolveEmailProvider();
+  if (!cfg) return { ok: false, error: NO_PROVIDER_ERROR };
+
+  return cfg.provider === "resend"
+    ? deliverViaResend(to, subject, html, text, cfg.apiKey, cfg.from)
+    : deliverViaSendgridCompat(to, subject, text, html, cfg.apiKey, cfg.from);
+}
+
 // ── Email delivery ────────────────────────────────────────────────────────────
 
 /**
- * Email delivery via Resend (RESEND_API_KEY) or a generic SMTP provider
- * (SMTP_HOST / SMTP_PORT / SMTP_USER / SMTP_PASS / SMTP_FROM).
- * Resend is preferred when RESEND_API_KEY is set.
+ * Alert email. Provider selection is centralised in resolveEmailProvider().
  */
 export async function deliverEmail(payload: AlertPayload): Promise<DeliveryResult> {
   const { rule, repo, value, metricLabel, metricUnit, triggeredAt } = payload;
@@ -135,18 +241,7 @@ export async function deliverEmail(payload: AlertPayload): Promise<DeliveryResul
     `Value: ${value}${metricUnit} (threshold: ${rule.threshold}${metricUnit})\n` +
     `Window: ${rule.window_hours}h — triggered at ${triggeredAt}`;
 
-  const resendKey = process.env.RESEND_API_KEY;
-
-  if (resendKey) {
-    return deliverViaResend(rule.destination, subject, html, text, resendKey);
-  }
-
-  const smtpHost = process.env.SMTP_HOST;
-  if (smtpHost) {
-    return deliverViaSendgridCompat(rule.destination, subject, text, html);
-  }
-
-  return { ok: false, error: "No email provider configured. Set RESEND_API_KEY or SMTP_HOST." };
+  return sendEmail(rule.destination, subject, html, text);
 }
 
 async function deliverViaResend(
@@ -155,8 +250,8 @@ async function deliverViaResend(
   html: string,
   text: string,
   apiKey: string,
+  from: string,
 ): Promise<DeliveryResult> {
-  const from = process.env.RESEND_FROM ?? "alerts@gitdash.app";
   try {
     const res = await fetch("https://api.resend.com/emails", {
       method: "POST",
@@ -186,14 +281,13 @@ async function deliverViaSendgridCompat(
   subject: string,
   text: string,
   html: string,
+  apiKey: string,
+  from: string,
 ): Promise<DeliveryResult> {
-  const apiKey = process.env.SMTP_PASS ?? process.env.SENDGRID_API_KEY;
-  const from   = process.env.SMTP_FROM ?? process.env.SMTP_USER ?? "alerts@gitdash.app";
-  const host   = process.env.SMTP_HOST ?? "";
-
-  if (!apiKey) {
-    return { ok: false, error: "SMTP_PASS / SENDGRID_API_KEY not configured" };
-  }
+  // SendGrid's HTTP API base. SMTP_HOST is a legacy name for it — this path
+  // has never spoken the SMTP protocol, so a hostname like smtp.gmail.com
+  // cannot work here. Settings-based config always supplies the real base URL.
+  const host = process.env.SMTP_HOST || "https://api.sendgrid.com";
 
   try {
     const res = await fetch(`${host}/v3/mail/send`, {
@@ -283,13 +377,7 @@ export async function deliverDigestEmail(
       return `${i.repo}: ${meta.label} = ${i.value ?? "—"}${meta.unit} at ${i.fired_at}`;
     }).join("\n");
 
-  const resendKey = process.env.RESEND_API_KEY;
-  if (resendKey) return deliverViaResend(to, subject, html, text, resendKey);
-
-  const smtpHost = process.env.SMTP_HOST;
-  if (smtpHost) return deliverViaSendgridCompat(to, subject, text, html);
-
-  return { ok: false, error: "No email provider configured. Set RESEND_API_KEY or SMTP_HOST." };
+  return sendEmail(to, subject, html, text);
 }
 
 // ── Weekly Leadership Digest (v4.0.3) ──────────────────────────────────────────
@@ -323,11 +411,38 @@ export async function deliverLeadershipDigestEmail(
     `Highlights:\n${narrative.highlights.length ? narrative.highlights.map((i) => `- ${i}`).join("\n") : "None this week."}\n\n` +
     `Needs attention:\n${narrative.concerns.length ? narrative.concerns.map((i) => `- ${i}`).join("\n") : "None this week."}`;
 
-  const resendKey = process.env.RESEND_API_KEY;
-  if (resendKey) return deliverViaResend(to, narrative.subject, html, text, resendKey);
+  return sendEmail(to, narrative.subject, html, text);
+}
 
-  const smtpHost = process.env.SMTP_HOST;
-  if (smtpHost) return deliverViaSendgridCompat(to, narrative.subject, text, html);
+// ── Test send (v4.1.3) ────────────────────────────────────────────────────────
 
-  return { ok: false, error: "No email provider configured. Set RESEND_API_KEY or SMTP_HOST." };
+/**
+ * Send a verification email using the currently-resolved provider.
+ *
+ * Exists because email is the one feature whose failure is otherwise invisible
+ * until a real alert or a Monday digest silently does not arrive.
+ */
+export async function sendTestEmail(to: string): Promise<DeliveryResult & { source?: string }> {
+  const cfg = await resolveEmailProvider();
+  if (!cfg) return { ok: false, error: NO_PROVIDER_ERROR };
+
+  const subject = "[GitDash] Test email";
+  const html = `
+    <h2>GitDash email is working</h2>
+    <p>This is a test message sent from your GitDash instance.</p>
+    <p style="color:#888;font-size:12px">
+      Provider: ${cfg.provider} · configured via ${cfg.source === "settings" ? "Settings" : "environment variables"}
+    </p>
+  `;
+  const text =
+    `GitDash email is working.\n\n` +
+    `This is a test message sent from your GitDash instance.\n` +
+    `Provider: ${cfg.provider} (configured via ${cfg.source === "settings" ? "Settings" : "environment variables"})`;
+
+  const result =
+    cfg.provider === "resend"
+      ? await deliverViaResend(to, subject, html, text, cfg.apiKey, cfg.from)
+      : await deliverViaSendgridCompat(to, subject, text, html, cfg.apiKey, cfg.from);
+
+  return { ...result, source: cfg.source };
 }

--- a/src/lib/secret-box.ts
+++ b/src/lib/secret-box.ts
@@ -1,0 +1,87 @@
+/**
+ * Symmetric encryption for secrets stored in the database (v4.1.3).
+ *
+ * Email provider API keys are entered in Settings and persisted, which means
+ * they land in every database backup and every `pg_dump`. Storing them in
+ * plaintext would make a leaked backup equivalent to a leaked credential, so
+ * they are sealed here first.
+ *
+ * The key is derived from SESSION_SECRET, which the app already requires to be
+ * >= 32 characters in production and already treats as its root secret (it
+ * encrypts session cookies). Deriving rather than reusing it directly means a
+ * sealed value cannot be fed to the session layer or vice versa.
+ *
+ * Threat model, stated plainly: this protects against a leaked *database*.
+ * It does not protect against an attacker who has both the database and the
+ * environment — at that point they have SESSION_SECRET and can unseal. That
+ * is the same bar as the rest of the app's secret handling.
+ *
+ * Format: v1.<iv-b64>.<tag-b64>.<ciphertext-b64>
+ * The version prefix exists so the algorithm can be rotated later without
+ * guessing at what an existing row contains.
+ */
+
+import { createCipheriv, createDecipheriv, createHash, randomBytes } from "crypto";
+
+const VERSION = "v1";
+const ALGORITHM = "aes-256-gcm";
+const IV_BYTES = 12; // GCM standard
+
+function derivedKey(): Buffer {
+  const secret = process.env.SESSION_SECRET;
+  if (!secret || secret.length < 32) {
+    throw new Error(
+      "[GitDash] SESSION_SECRET must be set to at least 32 characters before secrets can be stored.",
+    );
+  }
+  // Domain-separated from the session cookie's use of the same root secret.
+  return createHash("sha256").update(`gitdash:secret-box:v1:${secret}`).digest();
+}
+
+/** Encrypt a plaintext secret for storage. Returns an opaque, versioned string. */
+export function seal(plaintext: string): string {
+  const iv = randomBytes(IV_BYTES);
+  const cipher = createCipheriv(ALGORITHM, derivedKey(), iv);
+  const ciphertext = Buffer.concat([cipher.update(plaintext, "utf8"), cipher.final()]);
+  const tag = cipher.getAuthTag();
+  return [
+    VERSION,
+    iv.toString("base64"),
+    tag.toString("base64"),
+    ciphertext.toString("base64"),
+  ].join(".");
+}
+
+/**
+ * Decrypt a sealed secret. Returns null rather than throwing on any problem —
+ * a corrupted or wrong-key row should degrade to "email not configured",
+ * never take down the cron that reads it.
+ */
+export function unseal(sealed: string): string | null {
+  try {
+    const parts = sealed.split(".");
+    if (parts.length !== 4 || parts[0] !== VERSION) return null;
+    const [, ivB64, tagB64, dataB64] = parts;
+
+    const decipher = createDecipheriv(ALGORITHM, derivedKey(), Buffer.from(ivB64, "base64"));
+    decipher.setAuthTag(Buffer.from(tagB64, "base64"));
+    const plaintext = Buffer.concat([
+      decipher.update(Buffer.from(dataB64, "base64")),
+      decipher.final(),
+    ]);
+    return plaintext.toString("utf8");
+  } catch {
+    // Wrong key, tampered ciphertext, or malformed input — all indistinguishable
+    // to the caller by design.
+    return null;
+  }
+}
+
+/**
+ * Last-4 hint for the UI, so a user can tell which key is stored without the
+ * server ever returning it. Short secrets reveal nothing at all.
+ */
+export function maskHint(plaintext: string): string {
+  if (plaintext.length < 8) return "••••";
+  return `••••${plaintext.slice(-4)}`;
+}

--- a/tests/email-provider.test.ts
+++ b/tests/email-provider.test.ts
@@ -1,0 +1,186 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+/**
+ * Provider resolution: database settings first, environment variables second.
+ *
+ * The critical property under test is the fallback guarantee — an instance
+ * that already had RESEND_API_KEY set must keep working after v4.1.3 without
+ * anyone touching Settings.
+ */
+
+const getEmailSettings = vi.fn();
+
+vi.mock("@/lib/db", () => ({
+  getEmailSettings: () => getEmailSettings(),
+}));
+
+const ENV = ["SESSION_SECRET", "RESEND_API_KEY", "RESEND_FROM", "SMTP_HOST", "SMTP_PASS", "SMTP_FROM", "SMTP_USER", "SENDGRID_API_KEY"];
+
+function clearEnv() {
+  for (const k of ENV) delete process.env[k];
+}
+
+beforeEach(async () => {
+  clearEnv();
+  process.env.SESSION_SECRET = "a".repeat(64);
+  getEmailSettings.mockReset();
+  vi.spyOn(console, "error").mockImplementation(() => {});
+  // The resolver memoises for 30s — clear between cases.
+  const { cacheDelete } = await import("@/lib/cache");
+  cacheDelete("email-provider:settings");
+});
+
+afterEach(() => {
+  clearEnv();
+  vi.restoreAllMocks();
+});
+
+async function resolve() {
+  const { resolveEmailProvider } = await import("@/lib/notifier");
+  return resolveEmailProvider();
+}
+
+async function sealed(value: string) {
+  const { seal } = await import("@/lib/secret-box");
+  return seal(value);
+}
+
+describe("resolveEmailProvider — nothing configured", () => {
+  it("returns null when neither database nor env has config", async () => {
+    getEmailSettings.mockResolvedValue(null);
+    expect(await resolve()).toBeNull();
+  });
+
+  it("returns null when the database row exists but is disabled", async () => {
+    getEmailSettings.mockResolvedValue({
+      enabled: false, provider: "resend",
+      api_key_sealed: await sealed("re_key"), from_address: "a@b.com",
+    });
+    expect(await resolve()).toBeNull();
+  });
+
+  it("returns null when enabled but no key is stored", async () => {
+    getEmailSettings.mockResolvedValue({
+      enabled: true, provider: "resend", api_key_sealed: null, from_address: "a@b.com",
+    });
+    expect(await resolve()).toBeNull();
+  });
+});
+
+describe("resolveEmailProvider — database config", () => {
+  it("uses stored settings and decrypts the key", async () => {
+    getEmailSettings.mockResolvedValue({
+      enabled: true, provider: "resend",
+      api_key_sealed: await sealed("re_from_db"), from_address: "alerts@corp.com",
+    });
+
+    const cfg = await resolve();
+    expect(cfg).toEqual({
+      provider: "resend",
+      apiKey: "re_from_db",
+      from: "alerts@corp.com",
+      source: "settings",
+    });
+  });
+
+  it("supports sendgrid as the stored provider", async () => {
+    getEmailSettings.mockResolvedValue({
+      enabled: true, provider: "sendgrid",
+      api_key_sealed: await sealed("SG.key"), from_address: "a@b.com",
+    });
+    expect((await resolve())?.provider).toBe("sendgrid");
+  });
+
+  it("takes precedence over environment variables", async () => {
+    process.env.RESEND_API_KEY = "re_from_env";
+    getEmailSettings.mockResolvedValue({
+      enabled: true, provider: "resend",
+      api_key_sealed: await sealed("re_from_db"), from_address: "a@b.com",
+    });
+
+    const cfg = await resolve();
+    expect(cfg?.apiKey).toBe("re_from_db");
+    expect(cfg?.source).toBe("settings");
+  });
+});
+
+describe("resolveEmailProvider — environment fallback", () => {
+  it("uses RESEND_API_KEY when the database has no config", async () => {
+    getEmailSettings.mockResolvedValue(null);
+    process.env.RESEND_API_KEY = "re_env";
+    process.env.RESEND_FROM = "env@corp.com";
+
+    expect(await resolve()).toEqual({
+      provider: "resend", apiKey: "re_env", from: "env@corp.com", source: "env",
+    });
+  });
+
+  it("keeps a pre-v4.1.3 env-only instance working when the database is unreachable", async () => {
+    // This is the upgrade-safety guarantee: no DATABASE_URL, env still wins.
+    getEmailSettings.mockRejectedValue(new Error("DATABASE_URL is not set"));
+    process.env.RESEND_API_KEY = "re_env";
+
+    const cfg = await resolve();
+    expect(cfg?.apiKey).toBe("re_env");
+    expect(cfg?.source).toBe("env");
+  });
+
+  it("falls back to the SendGrid env pair", async () => {
+    getEmailSettings.mockResolvedValue(null);
+    process.env.SMTP_HOST = "https://api.sendgrid.com";
+    process.env.SMTP_PASS = "SG.env";
+    process.env.SMTP_FROM = "sg@corp.com";
+
+    expect(await resolve()).toEqual({
+      provider: "sendgrid", apiKey: "SG.env", from: "sg@corp.com", source: "env",
+    });
+  });
+
+  it("does not treat SMTP_HOST alone as configured — a host without a key cannot send", async () => {
+    getEmailSettings.mockResolvedValue(null);
+    process.env.SMTP_HOST = "https://api.sendgrid.com";
+    expect(await resolve()).toBeNull();
+  });
+});
+
+describe("resolveEmailProvider — undecryptable stored key", () => {
+  it("falls back to env instead of failing outright", async () => {
+    const good = await sealed("re_from_db");
+    // Simulate SESSION_SECRET having been rotated since the key was stored.
+    process.env.SESSION_SECRET = "c".repeat(64);
+    process.env.RESEND_API_KEY = "re_env";
+    getEmailSettings.mockResolvedValue({
+      enabled: true, provider: "resend", api_key_sealed: good, from_address: "a@b.com",
+    });
+
+    const cfg = await resolve();
+    expect(cfg?.apiKey).toBe("re_env");
+    expect(cfg?.source).toBe("env");
+  });
+
+  it("logs an actionable message so the operator can re-enter it", async () => {
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const good = await sealed("re_from_db");
+    process.env.SESSION_SECRET = "c".repeat(64);
+    getEmailSettings.mockResolvedValue({
+      enabled: true, provider: "resend", api_key_sealed: good, from_address: "a@b.com",
+    });
+
+    await resolve();
+    expect(spy.mock.calls.flat().join(" ")).toMatch(/could not be decrypted/i);
+  });
+
+  it("never logs the sealed value itself", async () => {
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const good = await sealed("re_SENSITIVE");
+    process.env.SESSION_SECRET = "c".repeat(64);
+    getEmailSettings.mockResolvedValue({
+      enabled: true, provider: "resend", api_key_sealed: good, from_address: "a@b.com",
+    });
+
+    await resolve();
+    const logged = spy.mock.calls.flat().join(" ");
+    expect(logged).not.toContain(good);
+    expect(logged).not.toContain("re_SENSITIVE");
+  });
+});

--- a/tests/secret-box.test.ts
+++ b/tests/secret-box.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { seal, unseal, maskHint } from "@/lib/secret-box";
+
+const GOOD_SECRET = "a".repeat(64);
+const OTHER_SECRET = "b".repeat(64);
+
+beforeEach(() => {
+  process.env.SESSION_SECRET = GOOD_SECRET;
+});
+afterEach(() => {
+  delete process.env.SESSION_SECRET;
+});
+
+describe("seal / unseal", () => {
+  it("round-trips a secret", () => {
+    const key = "re_live_abcdef123456";
+    expect(unseal(seal(key))).toBe(key);
+  });
+
+  it("round-trips unicode and long values", () => {
+    const v = "sk-ünïcøde-🔑-" + "x".repeat(500);
+    expect(unseal(seal(v))).toBe(v);
+  });
+
+  it("never emits the plaintext in the sealed form", () => {
+    const key = "re_live_SUPERSECRETVALUE";
+    expect(seal(key)).not.toContain("SUPERSECRETVALUE");
+  });
+
+  it("produces a different ciphertext each time (random IV)", () => {
+    const a = seal("same-input");
+    const b = seal("same-input");
+    expect(a).not.toBe(b);
+    // …but both still decrypt correctly.
+    expect(unseal(a)).toBe("same-input");
+    expect(unseal(b)).toBe("same-input");
+  });
+
+  it("carries a version prefix so the algorithm can be rotated later", () => {
+    expect(seal("x").startsWith("v1.")).toBe(true);
+  });
+});
+
+describe("unseal — failure modes all return null rather than throwing", () => {
+  it("returns null for a value sealed under a different SESSION_SECRET", () => {
+    const sealed = seal("secret");
+    process.env.SESSION_SECRET = OTHER_SECRET;
+    expect(unseal(sealed)).toBeNull();
+  });
+
+  it("returns null when the ciphertext has been tampered with", () => {
+    const sealed = seal("secret");
+    const parts = sealed.split(".");
+    // Flip the payload; the GCM auth tag must reject it.
+    parts[3] = Buffer.from("tampered-payload").toString("base64");
+    expect(unseal(parts.join("."))).toBeNull();
+  });
+
+  it("returns null when the auth tag has been swapped", () => {
+    const sealed = seal("secret");
+    const parts = sealed.split(".");
+    parts[2] = Buffer.from("0123456789abcdef").toString("base64");
+    expect(unseal(parts.join("."))).toBeNull();
+  });
+
+  it("returns null on a malformed or empty string", () => {
+    for (const bad of ["", "garbage", "v1.only.three", "v9.a.b.c"]) {
+      expect(unseal(bad)).toBeNull();
+    }
+  });
+
+  it("does not throw when SESSION_SECRET is missing", () => {
+    const sealed = seal("secret");
+    delete process.env.SESSION_SECRET;
+    expect(() => unseal(sealed)).not.toThrow();
+    expect(unseal(sealed)).toBeNull();
+  });
+});
+
+describe("seal — refuses a weak root secret", () => {
+  it("throws when SESSION_SECRET is too short to derive a key from", () => {
+    process.env.SESSION_SECRET = "short";
+    expect(() => seal("x")).toThrow(/SESSION_SECRET/);
+  });
+
+  it("throws when SESSION_SECRET is missing entirely", () => {
+    delete process.env.SESSION_SECRET;
+    expect(() => seal("x")).toThrow(/SESSION_SECRET/);
+  });
+});
+
+describe("maskHint", () => {
+  it("shows only the last four characters", () => {
+    expect(maskHint("re_live_abcdef4f2a")).toBe("••••4f2a");
+  });
+
+  it("reveals nothing at all for a short value", () => {
+    expect(maskHint("abc")).toBe("••••");
+    expect(maskHint("1234567")).toBe("••••");
+  });
+
+  it("never contains the leading part of the secret", () => {
+    expect(maskHint("re_live_SECRETHEAD_9999")).not.toContain("SECRETHEAD");
+  });
+});


### PR DESCRIPTION
Moves email provider config out of environment variables and into Settings, per your request. **This is the prerequisite for F2** (AI Leadership Digest), which was skipped in v4.1.2 precisely because the digest email couldn't send.

## Summary

- **Settings → Email Delivery** — configure Resend or SendGrid in the app, stored in the DB (**migration 5**). No redeploy.
- **"Send test email"** — email was the one feature whose misconfiguration produced *no visible signal*; you'd find out on Monday when the digest didn't arrive.
- **Status pill** shows what's actually in effect: Settings, env vars, or nothing.

## Why the UI says "Provider", not "SMTP"

You asked for SMTP config, and I need to flag why it isn't labelled that way.

**That code path has never spoken the SMTP protocol.** It POSTs to SendGrid's HTTP API at `${SMTP_HOST}/v3/mail/send`. So:

- The documented example `SMTP_HOST=smtp.yourprovider.com` **could never work** — it isn't even a valid URL
- `SMTP_PORT` was documented but never read by any code
- A corporate SMTP relay, Gmail, or Office 365 **cannot** be used

A form asking for host/port/username/password would fail 100% of the time. So the UI asks for a provider + API key, which is what actually works, and `.env.local.example` now states the limitation plainly instead of implying otherwise.

Per your decision, real SMTP (nodemailer) was left out — if you later need a corporate relay, that's an additive change.

## Security decisions

| Decision | Reasoning |
|---|---|
| **AES-256-GCM at rest** (`secret-box.ts`, keyed from `SESSION_SECRET`) | This column lands in every DB backup; plaintext would make a leaked backup == a leaked credential |
| **Write-only over the API** | Key is never returned — only `••••4f2a`. Blank field = keep stored key |
| **`unseal()` returns null, never throws** | A rotated `SESSION_SECRET` degrades to "not configured" rather than taking down the cron |
| **Instance-wide + attribution** | Per your call: consistent with `alert_rules`, which any user can already edit. Records who changed it and when |

Stated limit, in code and docs: this defends against a leaked *database*, not against an attacker holding the database **and** the environment.

## Upgrade safety

Resolution is **database-first with an env fallback**. An instance already using `RESEND_API_KEY` keeps working untouched and only switches over when someone explicitly enables email in Settings. There's a regression test for exactly this, including the DB-unreachable case.

Also deduplicated: provider selection was copy-pasted across three send paths. `process.env` is now read in exactly one place.

## Test plan

- [x] `pnpm exec tsc --noEmit` — **0 errors**
- [x] `pnpm test` — **240/240** (212 → 240, +28)
- [x] `pnpm run lint` — **0 errors** (11 pre-existing warnings, unchanged)
- [x] `rm -rf .next && pnpm run build` — succeeds, both new routes emit
- [x] API Reference parity — clean
- [x] Version bumped in all locations; release-notes entries verified intact

New tests cover: encryption round-trip, tampering rejection, wrong-key rejection, masking, and the full provider-precedence matrix including the upgrade-safety fallback.

## Rollback

1. **Toggle email off in Settings** — falls straight back to env vars
2. Promote the v4.1.2 deployment
3. `git revert` — migration 5 only *adds* a table, so no down-migration needed

## After merge

Nothing is configured yet — you'll need a Resend account and API key. Once that's in and a test email lands, **F2 becomes worth building** and I'll ship it as v4.1.4.