### PR TITLE
feat: v4.1.5 — bring-your-own AI provider in organization mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,49 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ---
 
+## [4.1.5] — 2026-08-15
+
+### Overview
+Organizations can bring their own AI provider. A shared team deployment usually wants its own LLM account and model choice rather than whatever the server operator configured — while a self-hosted personal instance should keep working out of the box with no setup at all. Those are different needs, so the feature is deliberately mode-dependent.
+
+### Added
+
+#### AI Provider settings — organization mode only
+- **Settings → AI Provider**: choose provider (Bailian, Gemini or Qwen), model, API key, and an optional base URL for a gateway or regional endpoint. Stored in the database (**migration 6**, `ai_settings`).
+- Model is a free-text field with per-provider suggestions, so any model an account can reach is accepted rather than only a hardcoded list.
+- **Standalone mode is untouched** — the section does not render, `PUT` returns 403, and the environment defaults apply exactly as before. Nothing about a standalone deployment changes.
+
+### Changed
+
+#### A configured key is used exclusively
+- When an organization sets its own provider, the server's keys are **never tried as a fallback behind it**. If the org's key fails, the request fails.
+- Falling back would silently bill the deployment owner for an organization's traffic — the kind of surprise best discovered before an invoice rather than after. There is a test asserting exactly one provider attempt in this case.
+
+#### Credential handling
+- The key is write-only: encrypted at rest with the same AES-256-GCM helper introduced for email credentials (`src/lib/secret-box.ts`), never returned to the browser, surfaced only as a masked hint. A blank field on save keeps the stored key.
+- Base URLs must be `https` — that URL carries the API key, so `http` is refused rather than accepted with a warning.
+- Like email settings, this is instance-wide with no per-user scoping, so `updated_by` / `updated_at` record who last changed it.
+
+#### API surface
+- `aiEnabled()` and `configuredProviders()` are now **async**, since either may depend on stored settings. All four AI routes await them.
+- `/api/ai/status` and `/api/settings/ai` both report `effective_source` — whether the override, the environment, or nothing is actually in effect.
+- Standalone mode never queries the database for this: the mode check short-circuits before any lookup.
+
+### Verified
+- Test count 266 → 278, covering mode gating, decryption failure, default-model fallback, exclusive-use billing safety, and normal environment behaviour when no override exists.
+
+### Rollback
+1. **Toggle the override off in Settings** — resolution returns to the environment defaults, no redeploy.
+2. **Promote the v4.1.4 Vercel deployment** — instant.
+3. **`git revert`** — migration 6 only *adds* a table; nothing existing is altered, so no down-migration is required.
+
+### Changed (infra)
+- Bumped app version from 4.1.4 to 4.1.5
+- Bumped Helm chart version from 0.5.4 to 0.5.5
+- Migration 6 creates `ai_settings` (singleton row, `CHECK (id = 1)`)
+
+---
+
 ## [4.1.4] — 2026-08-14
 
 ### Overview

--- a/helm/gitdash/Chart.yaml
+++ b/helm/gitdash/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: gitdash
 description: Self-hosted GitHub Actions metrics dashboard (standalone PAT or GitHub OAuth)
 type: application
-version: 0.5.4
-appVersion: "4.1.4"
+version: 0.5.5
+appVersion: "4.1.5"
 keywords:
   - github-actions
   - dashboard

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gitdash",
-  "version": "4.1.4",
+  "version": "4.1.5",
   "private": true,
   "packageManager": "pnpm@10.30.3",
   "scripts": {

--- a/src/app/api/ai/anomaly-explanation/route.ts
+++ b/src/app/api/ai/anomaly-explanation/route.ts
@@ -57,7 +57,7 @@ export async function GET(req: NextRequest) {
   const token = await getTokenFromSession();
   if (!token) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
 
-  if (!aiEnabled()) {
+  if (!(await aiEnabled())) {
     return NextResponse.json(
       { ok: false, error: "AI features are not configured" },
       { status: 503 },

--- a/src/app/api/ai/insights/route.ts
+++ b/src/app/api/ai/insights/route.ts
@@ -60,7 +60,7 @@ export async function GET(req: NextRequest) {
 
   // Checked server-side rather than trusting the client feature flag, which is
   // localStorage-backed and can be flipped by anyone.
-  if (!aiEnabled()) {
+  if (!(await aiEnabled())) {
     return NextResponse.json(
       { ok: false, error: "AI features are not configured" },
       { status: 503 },

--- a/src/app/api/ai/root-cause/route.ts
+++ b/src/app/api/ai/root-cause/route.ts
@@ -68,7 +68,7 @@ export async function GET(req: NextRequest) {
   const token = await getTokenFromSession();
   if (!token) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
 
-  if (!aiEnabled()) {
+  if (!(await aiEnabled())) {
     return NextResponse.json(
       { ok: false, error: "AI features are not configured" },
       { status: 503 },

--- a/src/app/api/ai/status/route.ts
+++ b/src/app/api/ai/status/route.ts
@@ -25,8 +25,8 @@ export async function GET() {
   if (!token) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
 
   const body: AiStatusResponse = {
-    enabled: aiEnabled(),
-    providers: configuredProviders(),
+    enabled: await aiEnabled(),
+    providers: await configuredProviders(),
   };
 
   return NextResponse.json(body, {

--- a/src/app/api/settings/ai/route.ts
+++ b/src/app/api/settings/ai/route.ts
@@ -1,0 +1,189 @@
+/**
+ * GET  /api/settings/ai — current AI provider override (never the secret).
+ * PUT  /api/settings/ai — save it.
+ *
+ * Organization mode only. A standalone deployment is meant to work from
+ * environment defaults with no setup, so both verbs refuse there rather than
+ * silently storing config that would never be read.
+ *
+ * The API key is write-only: encrypted at rest, never returned, and a blank
+ * field on submit means "keep the stored one".
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { getTokenFromSession, getSession } from "@/lib/session";
+import { getAppMode, isStandaloneMode } from "@/lib/mode";
+import { getAiSettings, saveAiSettings, type AiSettingsProvider } from "@/lib/db";
+import { envProviders, invalidateAiOverrideCache, resolveAiOverride } from "@/lib/ai";
+import { seal, maskHint } from "@/lib/secret-box";
+import { safeError } from "@/lib/validation";
+
+export const maxDuration = 60;
+
+const VALID_PROVIDERS: AiSettingsProvider[] = ["bailian", "gemini", "qwen"];
+
+export interface AiSettingsResponse {
+  /** False in standalone mode — the UI hides the section entirely. */
+  configurable: boolean;
+  mode: string;
+  enabled: boolean;
+  provider: AiSettingsProvider;
+  model: string | null;
+  base_url: string | null;
+  api_key_hint: string | null;
+  has_key: boolean;
+  updated_by: string | null;
+  updated_at: string | null;
+  /** What is actually in effect: the saved override, env defaults, or nothing. */
+  effective_source: "settings" | "env" | "none";
+  /** Providers the deployment itself has keys for — capability only, no secrets. */
+  env_providers: string[];
+  db_available: boolean;
+}
+
+export async function GET() {
+  const token = await getTokenFromSession();
+  if (!token) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const standalone = isStandaloneMode();
+  const envs = envProviders();
+  const override = standalone ? null : await resolveAiOverride();
+
+  const base = {
+    configurable: !standalone,
+    mode: getAppMode(),
+    env_providers: envs,
+    effective_source: (override ? "settings" : envs.length ? "env" : "none") as
+      | "settings" | "env" | "none",
+  };
+
+  if (standalone) {
+    return NextResponse.json(
+      {
+        ...base,
+        enabled: false, provider: "bailian" as const, model: null, base_url: null,
+        api_key_hint: null, has_key: false, updated_by: null, updated_at: null,
+        db_available: false,
+      } satisfies AiSettingsResponse,
+      { headers: { "Cache-Control": "private, no-store" } },
+    );
+  }
+
+  try {
+    const s = await getAiSettings();
+    return NextResponse.json(
+      {
+        ...base,
+        enabled: s?.enabled ?? false,
+        provider: s?.provider ?? "bailian",
+        model: s?.model ?? null,
+        base_url: s?.base_url ?? null,
+        api_key_hint: s?.api_key_hint ?? null,
+        has_key: Boolean(s?.api_key_sealed),
+        updated_by: s?.updated_by ?? null,
+        updated_at: s?.updated_at ?? null,
+        db_available: true,
+      } satisfies AiSettingsResponse,
+      { headers: { "Cache-Control": "private, no-store" } },
+    );
+  } catch {
+    return NextResponse.json(
+      {
+        ...base,
+        enabled: false, provider: "bailian" as const, model: null, base_url: null,
+        api_key_hint: null, has_key: false, updated_by: null, updated_at: null,
+        db_available: false,
+      } satisfies AiSettingsResponse,
+      { headers: { "Cache-Control": "private, no-store" } },
+    );
+  }
+}
+
+export async function PUT(req: NextRequest) {
+  const token = await getTokenFromSession();
+  if (!token) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  if (isStandaloneMode()) {
+    return NextResponse.json(
+      {
+        error:
+          "AI provider configuration is available in organization mode only. Standalone deployments use the server's environment defaults.",
+      },
+      { status: 403 },
+    );
+  }
+
+  let payload: {
+    enabled?: unknown; provider?: unknown; model?: unknown;
+    base_url?: unknown; api_key?: unknown;
+  };
+  try {
+    payload = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const enabled = payload.enabled === true;
+
+  const provider = payload.provider;
+  if (typeof provider !== "string" || !VALID_PROVIDERS.includes(provider as AiSettingsProvider)) {
+    return NextResponse.json(
+      { error: 'provider must be one of "bailian", "gemini", "qwen"' },
+      { status: 400 },
+    );
+  }
+
+  const model = typeof payload.model === "string" ? payload.model.trim() : "";
+  if (model.length > 120) {
+    return NextResponse.json({ error: "model name is too long" }, { status: 400 });
+  }
+
+  const baseUrl = typeof payload.base_url === "string" ? payload.base_url.trim() : "";
+  if (baseUrl && !/^https:\/\/[^\s]+$/i.test(baseUrl)) {
+    // http:// is refused deliberately — this URL carries an API key.
+    return NextResponse.json(
+      { error: "base_url must be an https:// URL" },
+      { status: 400 },
+    );
+  }
+
+  const apiKeyRaw = typeof payload.api_key === "string" ? payload.api_key.trim() : "";
+
+  let existingHasKey = false;
+  try {
+    existingHasKey = Boolean((await getAiSettings())?.api_key_sealed);
+  } catch {
+    return NextResponse.json(
+      { error: "No database configured — AI settings cannot be stored on this deployment." },
+      { status: 503 },
+    );
+  }
+  if (enabled && !apiKeyRaw && !existingHasKey) {
+    return NextResponse.json(
+      { error: "An API key is required to enable a custom provider" },
+      { status: 400 },
+    );
+  }
+
+  let updatedBy: string | null = null;
+  try {
+    updatedBy = (await getSession()).user?.login ?? null;
+  } catch {
+    updatedBy = null;
+  }
+
+  try {
+    await saveAiSettings({
+      enabled,
+      provider: provider as AiSettingsProvider,
+      model: model || null,
+      base_url: baseUrl || null,
+      updated_by: updatedBy,
+      ...(apiKeyRaw ? { api_key_sealed: seal(apiKeyRaw), api_key_hint: maskHint(apiKeyRaw) } : {}),
+    });
+    invalidateAiOverrideCache();
+    return NextResponse.json({ ok: true });
+  } catch (e) {
+    return safeError(e, "Failed to save AI settings");
+  }
+}

--- a/src/app/docs/page.tsx
+++ b/src/app/docs/page.tsx
@@ -1684,6 +1684,36 @@ function FeatureAiInsights() {
       </DocCard>
 
       <DocCard>
+        <div className="flex items-center gap-2 mb-2">
+          <SubHeading>Bring your own provider</SubHeading>
+          <VersionBadge v="4.1.5" />
+        </div>
+        <ProseP>
+          In <strong>organization mode</strong>, <strong>Settings → AI Provider</strong> lets a team
+          point GitDash at its own account: provider, model, API key, and an optional base URL for a
+          gateway or regional endpoint. Useful when the deployment&apos;s default key belongs to
+          someone else, or when you want a larger model than the operator chose.
+        </ProseP>
+        <ProseP>
+          In <strong>standalone mode</strong> the section does not appear at all. A self-hosted
+          personal instance is meant to work from the environment defaults with no setup, so there is
+          nothing to configure.
+        </ProseP>
+        <Callout type="warning">
+          <strong>Your key is used exclusively.</strong> When an organization configures its own
+          provider, the server&apos;s keys are never tried as a fallback behind it. If your key fails,
+          the request fails — it does not quietly succeed on someone else&apos;s account and bill
+          them. The status pill in Settings shows which source is actually in effect.
+        </Callout>
+        <ProseP>
+          The key is write-only: encrypted at rest with the same AES-256-GCM helper used for email
+          credentials, never returned to the browser, shown only as a masked hint. Leaving the field
+          blank keeps the stored key. Base URLs must be <Code>https</Code>, because that URL carries
+          the key. Changes take effect within 30 seconds.
+        </ProseP>
+      </DocCard>
+
+      <DocCard>
         <SubHeading>Providers and keys</SubHeading>
         <ProseP>
           Three providers are supported and tried in order; any without a key is skipped, so
@@ -2525,6 +2555,18 @@ function APIReference() {
         },
         {
           method: "GET",
+          path: "/api/settings/ai",
+          description: "Current AI provider override. Returns { configurable, mode, enabled, provider, model, base_url, api_key_hint, has_key, updated_by, updated_at, effective_source, env_providers, db_available }. The API key is never returned — only a masked hint. configurable is false in standalone mode, where the section is hidden and environment defaults apply.",
+          params: [],
+        },
+        {
+          method: "PUT",
+          path: "/api/settings/ai",
+          description: "Save an AI provider override. Body: { enabled, provider (\"bailian\"|\"gemini\"|\"qwen\"), model, base_url, api_key? }. Omitting api_key preserves the stored one; the key is encrypted before storage. base_url must be https. 403 in standalone mode, 503 when no database is configured. A configured override is used exclusively — server keys are never a fallback behind it.",
+          params: [],
+        },
+        {
+          method: "GET",
           path: "/api/settings/email",
           description: "Current email delivery configuration. Returns { enabled, provider, from_address, api_key_hint, has_key, updated_by, updated_at, effective_source, db_available }. The API key itself is never returned — only a masked hint. effective_source reports whether Settings, environment variables, or nothing is actually in effect.",
           params: [],
@@ -2794,9 +2836,27 @@ pnpm run lint`}
 function ReleaseNotes() {
   const releases = [
     {
+      version: "4.1.5",
+      date: "2026-08-15",
+      badge: "latest",
+      badgeColor: "bg-emerald-500/15 text-emerald-400 border-emerald-500/20",
+      changes: {
+        added: [
+          "Bring-your-own AI provider in organization mode — Settings → AI Provider lets a team choose its own provider (Bailian, Gemini or Qwen), model, API key and optional base URL, instead of using whatever the server operator configured. Stored in the database (migration 6)",
+          "Standalone deployments are deliberately unchanged: the section does not appear and the environment defaults apply, so a self-hosted instance still works out of the box with no setup",
+        ],
+        fixed: [],
+        improved: [
+          "A configured org key is used EXCLUSIVELY — the server's own keys are never tried as a fallback behind it. Falling back would silently bill the deployment owner for an organization's traffic, which is a surprise best discovered before an invoice rather than after",
+          "The API key is write-only and encrypted at rest with the same AES-256-GCM helper as email credentials; the UI shows a masked hint, and a blank field keeps the stored key. Base URLs must be https, since that URL carries the key",
+          "aiEnabled() and configuredProviders() are now async so they can account for a stored override; /api/ai/status reports which source is actually in effect",
+        ],
+      },
+    },
+    {
       version: "4.1.4",
       date: "2026-08-14",
-      badge: "latest",
+      badge: null,
       badgeColor: "bg-emerald-500/15 text-emerald-400 border-emerald-500/20",
       changes: {
         added: [
@@ -3326,7 +3386,7 @@ function DocSidebar({
           <BookOpen className="w-4 h-4 text-violet-400" />
           <span className="text-sm font-semibold text-white">GitDash Docs</span>
           <span className="text-xs px-1.5 py-0.5 rounded bg-violet-500/15 text-violet-400 border border-violet-500/20 font-mono">
-            v{process.env.NEXT_PUBLIC_APP_VERSION ?? "4.1.4"}
+            v{process.env.NEXT_PUBLIC_APP_VERSION ?? "4.1.5"}
           </span>
         </div>
         {/* Mobile close */}
@@ -3576,7 +3636,7 @@ export default function DocsPage() {
 
           {/* Footer */}
           <footer className="mt-8 pb-4 text-center text-xs text-slate-600 space-y-1">
-            <p>GitDash v{process.env.NEXT_PUBLIC_APP_VERSION ?? "4.1.4"} — GitHub Actions Dashboard</p>
+            <p>GitDash v{process.env.NEXT_PUBLIC_APP_VERSION ?? "4.1.5"} — GitHub Actions Dashboard</p>
             <p>
               <a href="https://github.com/dinhdobathi1992/gitdash" target="_blank" rel="noreferrer" className="hover:text-slate-400 transition-colors">
                 Open source on GitHub

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { useAuth } from "@/components/AuthProvider";
 import { useFeatureFlags } from "@/components/FeatureFlagsProvider";
 import EmailSettingsCard from "@/components/EmailSettingsCard";
+import AiProviderCard from "@/components/AiProviderCard";
 import { Breadcrumb } from "@/components/Sidebar";
 import type { FeatureFlags } from "@/lib/feature-flags";
 import {
@@ -271,6 +272,9 @@ export default function SettingsPage() {
           </div>
         )}
       </div>
+
+      {/* ── AI provider (organization mode only) ─────────────────────── */}
+      <AiProviderCard />
 
       {/* ── Email delivery ───────────────────────────────────────────── */}
       <EmailSettingsCard />

--- a/src/components/AiProviderCard.tsx
+++ b/src/components/AiProviderCard.tsx
@@ -1,0 +1,290 @@
+"use client";
+
+/**
+ * AI provider settings (v4.1.5) — organization mode only.
+ *
+ * A shared team deployment usually wants its own LLM account and model choice
+ * rather than whatever the server operator configured. Standalone deployments
+ * deliberately have no such section: they are meant to work out of the box
+ * from the environment defaults, so this component renders nothing there.
+ *
+ * The API key is write-only — the server returns a masked hint only, and a
+ * blank field on save keeps the stored key.
+ */
+
+import { useState } from "react";
+import useSWR from "swr";
+import { fetcher } from "@/lib/swr";
+import type { AiSettingsResponse } from "@/app/api/settings/ai/route";
+import { Sparkles, Loader2, CheckCircle2, AlertTriangle } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+type Provider = "bailian" | "gemini" | "qwen";
+
+const PROVIDER_META: Record<Provider, {
+  label: string; keyPlaceholder: string; models: string[]; note: string;
+}> = {
+  bailian: {
+    label: "Bailian (Alibaba Cloud)",
+    keyPlaceholder: "sk-sp-…",
+    models: ["qwen3.6-flash", "qwen3.6-plus", "qwen3.7-plus", "qwen3.7-max", "qwen3.8-max"],
+    note: "Anthropic-compatible endpoint. Extended thinking is disabled automatically to keep cost down.",
+  },
+  gemini: {
+    label: "Google Gemini",
+    keyPlaceholder: "AIza…",
+    models: ["gemini-2.5-flash", "gemini-2.5-pro"],
+    note: "OpenAI-compatible endpoint.",
+  },
+  qwen: {
+    label: "Qwen (DashScope)",
+    keyPlaceholder: "sk-…",
+    models: ["qwen-plus", "qwen-max", "qwen-turbo"],
+    note: "OpenAI-compatible endpoint. Distinct from Bailian.",
+  },
+};
+
+export default function AiProviderCard() {
+  const { data, mutate, isLoading } = useSWR<AiSettingsResponse>(
+    "/api/settings/ai",
+    fetcher<AiSettingsResponse>,
+  );
+
+  const [draft, setDraft] = useState<{
+    enabled: boolean; provider: Provider; model: string; baseUrl: string; apiKey: string;
+  } | null>(null);
+  const [saving, setSaving] = useState(false);
+  const [msg, setMsg] = useState<{ kind: "ok" | "err"; text: string } | null>(null);
+
+  const state =
+    draft ??
+    (data
+      ? {
+          enabled: data.enabled,
+          provider: data.provider as Provider,
+          model: data.model ?? "",
+          baseUrl: data.base_url ?? "",
+          apiKey: "",
+        }
+      : null);
+
+  function patch(p: Partial<NonNullable<typeof state>>) {
+    if (!state) return;
+    setDraft({ ...state, ...p });
+    setMsg(null);
+  }
+
+  async function save() {
+    if (!state) return;
+    setSaving(true);
+    setMsg(null);
+    try {
+      const res = await fetch("/api/settings/ai", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        credentials: "same-origin",
+        body: JSON.stringify({
+          enabled: state.enabled,
+          provider: state.provider,
+          model: state.model,
+          base_url: state.baseUrl,
+          ...(state.apiKey ? { api_key: state.apiKey } : {}),
+        }),
+      });
+      const body = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        setMsg({ kind: "err", text: body.error ?? `Save failed (${res.status})` });
+        return;
+      }
+      setMsg({ kind: "ok", text: "Saved. New requests use this provider within 30 seconds." });
+      setDraft(null);
+      mutate();
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  // Standalone deployments use environment defaults — nothing to configure.
+  if (!isLoading && data && !data.configurable) return null;
+
+  if (isLoading || !state || !data) {
+    return (
+      <div className="rounded-2xl border border-slate-800 bg-slate-900/40 p-5">
+        <div className="h-4 w-40 rounded skeleton mb-3" />
+        <div className="h-3 w-64 rounded skeleton" />
+      </div>
+    );
+  }
+
+  const meta = PROVIDER_META[state.provider];
+  const dirty = draft !== null;
+
+  return (
+    <div className="rounded-2xl border border-slate-800 bg-slate-900/40 overflow-hidden">
+      <div className="flex items-start gap-4 p-5 border-b border-slate-800">
+        <span className="shrink-0 w-9 h-9 rounded-lg border border-violet-500/30 bg-violet-500/[0.14] flex items-center justify-center">
+          <Sparkles className="w-4 h-4 text-violet-300" />
+        </span>
+        <div className="min-w-0 flex-1">
+          <h3 className="text-[15px] font-semibold text-white">AI Provider</h3>
+          <p className="text-xs text-slate-500 mt-0.5">
+            Use your own model and API key for AI Insights, anomaly explanations, failure hypotheses
+            and the leadership digest.
+          </p>
+        </div>
+        <span
+          className={cn(
+            "shrink-0 inline-flex items-center gap-1 text-[10px] font-semibold uppercase tracking-wide px-2 py-1 rounded-full border",
+            data.effective_source === "settings"
+              ? "border-violet-500/25 bg-violet-500/10 text-violet-300"
+              : data.effective_source === "env"
+                ? "border-slate-700 bg-slate-800/60 text-slate-400"
+                : "border-slate-700 bg-slate-800/60 text-slate-500",
+          )}
+        >
+          {data.effective_source === "settings" && <CheckCircle2 className="w-3 h-3" />}
+          {data.effective_source === "settings"
+            ? "Your key"
+            : data.effective_source === "env"
+              ? "Server default"
+              : "Not configured"}
+        </span>
+      </div>
+
+      <div className="p-5 space-y-4">
+        {!data.db_available && (
+          <div className="flex items-start gap-2 px-3 py-2.5 rounded-lg bg-amber-500/10 border border-amber-500/25 text-xs text-amber-200">
+            <AlertTriangle className="w-3.5 h-3.5 mt-0.5 shrink-0" />
+            <span>No database configured — settings cannot be stored on this deployment.</span>
+          </div>
+        )}
+
+        {data.effective_source === "env" && (
+          <div className="flex items-start gap-2 px-3 py-2.5 rounded-lg bg-slate-800/60 border border-slate-700 text-xs text-slate-300">
+            <AlertTriangle className="w-3.5 h-3.5 mt-0.5 shrink-0 text-slate-400" />
+            <span>
+              Currently using the server&apos;s default provider
+              {data.env_providers.length ? ` (${data.env_providers.join(", ")})` : ""}. Enabling
+              below switches to your own key — the server default is <strong>not</strong> used as a
+              fallback, so its billing stays separate from yours.
+            </span>
+          </div>
+        )}
+
+        <label className="flex items-center gap-3 cursor-pointer">
+          <input
+            type="checkbox"
+            checked={state.enabled}
+            disabled={!data.db_available}
+            onChange={(e) => patch({ enabled: e.target.checked })}
+            className="w-4 h-4 rounded accent-violet-500"
+          />
+          <span className="text-sm text-slate-200">Use our own AI provider</span>
+        </label>
+
+        {state.enabled && (
+          <div className="space-y-3.5 pl-7">
+            <Field label="Provider">
+              <select
+                value={state.provider}
+                onChange={(e) => patch({ provider: e.target.value as Provider, model: "" })}
+                className="w-full px-3 py-2 bg-slate-900/70 border border-slate-700 rounded-lg text-sm text-slate-100 focus:outline-none focus:ring-2 focus:ring-violet-500/40"
+              >
+                {(Object.keys(PROVIDER_META) as Provider[]).map((p) => (
+                  <option key={p} value={p}>{PROVIDER_META[p].label}</option>
+                ))}
+              </select>
+              <p className="text-[11px] text-slate-600 mt-1">{meta.note}</p>
+            </Field>
+
+            <Field label="Model">
+              <input
+                list="ai-model-options"
+                value={state.model}
+                placeholder={`${meta.models[0]} (default)`}
+                onChange={(e) => patch({ model: e.target.value })}
+                className="w-full px-3 py-2 bg-slate-900/70 border border-slate-700 rounded-lg text-sm text-slate-100 font-mono placeholder-slate-600 focus:outline-none focus:ring-2 focus:ring-violet-500/40"
+              />
+              <datalist id="ai-model-options">
+                {meta.models.map((m) => <option key={m} value={m} />)}
+              </datalist>
+              <p className="text-[11px] text-slate-600 mt-1">
+                Suggestions shown, but any model your account can reach is accepted. Blank uses{" "}
+                <code className="text-slate-500">{meta.models[0]}</code>.
+              </p>
+            </Field>
+
+            <Field label="API key">
+              <input
+                type="password"
+                autoComplete="off"
+                value={state.apiKey}
+                placeholder={data.has_key ? `${data.api_key_hint} — leave blank to keep` : meta.keyPlaceholder}
+                onChange={(e) => patch({ apiKey: e.target.value })}
+                className="w-full px-3 py-2 bg-slate-900/70 border border-slate-700 rounded-lg text-sm text-slate-100 font-mono placeholder-slate-600 focus:outline-none focus:ring-2 focus:ring-violet-500/40"
+              />
+              <p className="text-[11px] text-slate-600 mt-1">
+                Stored encrypted and never shown again.
+              </p>
+            </Field>
+
+            <Field label="Base URL (optional)">
+              <input
+                type="url"
+                value={state.baseUrl}
+                placeholder="Leave blank for the provider's default endpoint"
+                onChange={(e) => patch({ baseUrl: e.target.value })}
+                className="w-full px-3 py-2 bg-slate-900/70 border border-slate-700 rounded-lg text-sm text-slate-100 font-mono placeholder-slate-600 focus:outline-none focus:ring-2 focus:ring-violet-500/40"
+              />
+              <p className="text-[11px] text-slate-600 mt-1">
+                For a gateway or regional endpoint. Must be https — this URL carries your key.
+              </p>
+            </Field>
+          </div>
+        )}
+
+        {msg && (
+          <div
+            className={cn(
+              "flex items-start gap-2 px-3 py-2.5 rounded-lg text-xs border",
+              msg.kind === "ok"
+                ? "bg-emerald-500/10 border-emerald-500/25 text-emerald-200"
+                : "bg-red-500/10 border-red-500/25 text-red-200",
+            )}
+          >
+            {msg.kind === "ok"
+              ? <CheckCircle2 className="w-3.5 h-3.5 mt-0.5 shrink-0" />
+              : <AlertTriangle className="w-3.5 h-3.5 mt-0.5 shrink-0" />}
+            <span className="break-words">{msg.text}</span>
+          </div>
+        )}
+
+        <div className="flex items-center gap-2 flex-wrap">
+          <button
+            onClick={save}
+            disabled={saving || !dirty || !data.db_available}
+            className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-lg bg-violet-500/15 border border-violet-500/30 text-violet-200 hover:bg-violet-500/25 transition-colors disabled:opacity-40"
+          >
+            {saving && <Loader2 className="w-3 h-3 animate-spin" />}
+            {dirty ? "Save changes" : "Saved"}
+          </button>
+          {data.updated_by && (
+            <span className="text-[11px] text-slate-600">
+              Last changed by @{data.updated_by}
+              {data.updated_at && ` · ${new Date(data.updated_at).toLocaleDateString()}`}
+            </span>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function Field({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div>
+      <label className="block text-xs font-medium text-slate-400 mb-1.5">{label}</label>
+      {children}
+    </div>
+  );
+}

--- a/src/lib/ai.ts
+++ b/src/lib/ai.ts
@@ -24,6 +24,10 @@
  * keep this release free of schema changes (see docs/specs, §6.2).
  */
 
+import { unseal } from "./secret-box";
+import { withCache, cacheDelete } from "./cache";
+import { isStandaloneMode } from "./mode";
+
 export type AiProvider = "bailian" | "gemini" | "qwen";
 
 /**
@@ -121,15 +125,89 @@ function isDisabled(): boolean {
   return process.env.AI_DISABLED === "true";
 }
 
-/** Providers with a key present, in attempt order. Never returns key material. */
-export function configuredProviders(): AiProvider[] {
+// ── Organization-mode provider override (v4.1.5) ──────────────────────────────
+
+export interface AiOverride {
+  provider: AiProvider;
+  model: string;
+  apiKey: string;
+  baseUrl: string;
+}
+
+const OVERRIDE_CACHE_KEY = "ai-provider:settings";
+const OVERRIDE_CACHE_TTL = 30; // seconds
+
+/**
+ * Resolve an instance-configured provider, when one applies.
+ *
+ * Only ever consulted in **organization** mode. A standalone deployment is
+ * meant to work out of the box from environment defaults, so it never touches
+ * the database here — that is the whole shape of the feature.
+ *
+ * The db import is dynamic to keep this module free of a static dependency on
+ * the database layer, and because nothing should query on a request that will
+ * not make an AI call anyway.
+ */
+export async function resolveAiOverride(): Promise<AiOverride | null> {
+  if (isDisabled()) return null;
+  if (isStandaloneMode()) return null;
+
+  return withCache<AiOverride | null>(OVERRIDE_CACHE_KEY, OVERRIDE_CACHE_TTL, async () => {
+    try {
+      const { getAiSettings } = await import("./db");
+      const s = await getAiSettings();
+      if (!s || !s.enabled || !s.api_key_sealed) return null;
+
+      const apiKey = unseal(s.api_key_sealed);
+      if (!apiKey) {
+        console.error(
+          "[ai] Stored provider key could not be decrypted — re-enter it in Settings.",
+        );
+        return null;
+      }
+
+      const cfg = PROVIDERS.find((p) => p.name === s.provider);
+      if (!cfg) return null;
+
+      return {
+        provider: s.provider,
+        model: s.model || cfg.defaultModel,
+        apiKey,
+        baseUrl: (s.base_url || cfg.defaultBase).replace(/\/+$/, ""),
+      };
+    } catch {
+      // No DATABASE_URL or table unreachable — environment defaults apply.
+      return null;
+    }
+  });
+}
+
+/** Drop the cached override after a Settings save. */
+export function invalidateAiOverrideCache(): void {
+  cacheDelete(OVERRIDE_CACHE_KEY);
+}
+
+/** Providers with a key in the environment. Never returns key material. */
+export function envProviders(): AiProvider[] {
   return PROVIDERS.filter((p) => Boolean(process.env[p.keyEnv])).map((p) => p.name);
 }
 
-/** True when the layer is not hard-disabled and at least one provider has a key. */
-export function aiEnabled(): boolean {
+/**
+ * Providers actually available right now, accounting for an org-mode override.
+ * Never returns key material.
+ */
+export async function configuredProviders(): Promise<AiProvider[]> {
+  if (isDisabled()) return [];
+  const override = await resolveAiOverride();
+  if (override) return [override.provider];
+  return envProviders();
+}
+
+/** True when the layer is not hard-disabled and some provider is usable. */
+export async function aiEnabled(): Promise<boolean> {
   if (isDisabled()) return false;
-  return configuredProviders().length > 0;
+  if (await resolveAiOverride()) return true;
+  return envProviders().length > 0;
 }
 
 // ── Daily token budget ────────────────────────────────────────────────────────
@@ -279,11 +357,19 @@ async function callProvider(
   cfg: ProviderConfig,
   systemPrompt: string,
   userPayload: unknown,
-  opts: { temperature: number; maxOutputTokens: number; timeoutMs: number },
+  opts: {
+    temperature: number;
+    maxOutputTokens: number;
+    timeoutMs: number;
+    /** Set when an organization has configured its own provider in Settings. */
+    override?: AiOverride;
+  },
 ): Promise<AttemptOutcome> {
-  const key = process.env[cfg.keyEnv]!;
-  const baseUrl = (process.env[cfg.baseEnv] || cfg.defaultBase).replace(/\/+$/, "");
-  const model = process.env[cfg.modelEnv] || cfg.defaultModel;
+  const key = opts.override?.apiKey ?? process.env[cfg.keyEnv]!;
+  const baseUrl = (
+    opts.override?.baseUrl ?? process.env[cfg.baseEnv] ?? cfg.defaultBase
+  ).replace(/\/+$/, "");
+  const model = opts.override?.model ?? process.env[cfg.modelEnv] ?? cfg.defaultModel;
 
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), opts.timeoutMs);
@@ -370,7 +456,15 @@ export async function generateJson(
     return { ok: false, reason: "disabled", error: "AI layer is disabled by AI_DISABLED" };
   }
 
-  const available = PROVIDERS.filter((p) => Boolean(process.env[p.keyEnv]));
+  // An organization-configured provider takes over EXCLUSIVELY — it is never
+  // used as a first attempt with the instance's own keys behind it. Falling
+  // back would silently bill the deployment owner for an org's traffic, which
+  // is a surprise nobody wants to discover on an invoice.
+  const override = await resolveAiOverride();
+  const available = override
+    ? PROVIDERS.filter((p) => p.name === override.provider)
+    : PROVIDERS.filter((p) => Boolean(process.env[p.keyEnv]));
+
   if (available.length === 0) {
     return { ok: false, reason: "no_keys", error: "No AI provider key is configured" };
   }
@@ -400,6 +494,7 @@ export async function generateJson(
       temperature,
       maxOutputTokens,
       timeoutMs: Math.min(perAttemptMs, remaining),
+      override: override ?? undefined,
     });
 
     if (attempt.kind === "success") return attempt.result!;
@@ -413,6 +508,7 @@ export async function generateJson(
           temperature,
           maxOutputTokens,
           timeoutMs: Math.min(perAttemptMs, deadline - Date.now()),
+          override: override ?? undefined,
         });
         if (retry.kind === "success") return retry.result!;
         lastError = retry.error;

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -294,6 +294,30 @@ const MIGRATIONS: Array<{ version: number; name: string; up: string[] }> = [
       )`,
     ],
   },
+  {
+    version: 6,
+    name: "ai_settings",
+    up: [
+      // Per-instance AI provider override, editable from Settings in
+      // ORGANIZATION mode only. Standalone deployments deliberately keep using
+      // the environment defaults so they work out of the box with no setup.
+      //
+      // Singleton by the same CHECK (id = 1) construction as email_settings.
+      // api_key_sealed is AES-256-GCM from src/lib/secret-box.ts — this column
+      // reaches every backup, so it is never plaintext.
+      `CREATE TABLE IF NOT EXISTS ai_settings (
+        id              INT PRIMARY KEY DEFAULT 1 CHECK (id = 1),
+        enabled         BOOLEAN NOT NULL DEFAULT FALSE,
+        provider        VARCHAR(20) NOT NULL DEFAULT 'bailian',
+        model           VARCHAR(120),
+        base_url        TEXT,
+        api_key_sealed  TEXT,
+        api_key_hint    VARCHAR(20),
+        updated_by      VARCHAR(120),
+        updated_at      TIMESTAMPTZ DEFAULT NOW()
+      )`,
+    ],
+  },
 ];
 
 let schemaEnsured = false;
@@ -1037,6 +1061,85 @@ export async function saveEmailSettings(input: {
       enabled = EXCLUDED.enabled,
       provider = EXCLUDED.provider,
       from_address = EXCLUDED.from_address,
+      updated_by = EXCLUDED.updated_by,
+      updated_at = NOW()
+  `;
+}
+
+// ── AI settings (v4.1.5, organization mode only) ──────────────────────────────
+
+export type AiSettingsProvider = "bailian" | "gemini" | "qwen";
+
+export interface DbAiSettings {
+  enabled: boolean;
+  provider: AiSettingsProvider;
+  model: string | null;
+  base_url: string | null;
+  api_key_sealed: string | null;
+  api_key_hint: string | null;
+  updated_by: string | null;
+  updated_at: string | null;
+}
+
+/** Null when no row exists — callers then fall back to environment defaults. */
+export async function getAiSettings(): Promise<DbAiSettings | null> {
+  await ensureSchema();
+  const rows = (await getDb()`
+    SELECT enabled, provider, model, base_url, api_key_sealed, api_key_hint,
+           updated_by, updated_at
+    FROM ai_settings WHERE id = 1
+  `) as DbAiSettings[];
+  return rows[0] ?? null;
+}
+
+/**
+ * Upsert the singleton row. Omitting api_key_sealed preserves the stored key,
+ * which is what lets the UI treat a blank field as "unchanged" without ever
+ * returning the secret to the browser.
+ */
+export async function saveAiSettings(input: {
+  enabled: boolean;
+  provider: AiSettingsProvider;
+  model: string | null;
+  base_url: string | null;
+  updated_by: string | null;
+  api_key_sealed?: string;
+  api_key_hint?: string;
+}): Promise<void> {
+  await ensureSchema();
+  const db = getDb();
+
+  if (input.api_key_sealed !== undefined) {
+    await db`
+      INSERT INTO ai_settings
+        (id, enabled, provider, model, base_url, api_key_sealed, api_key_hint, updated_by, updated_at)
+      VALUES
+        (1, ${input.enabled}, ${input.provider}, ${input.model}, ${input.base_url},
+         ${input.api_key_sealed}, ${input.api_key_hint ?? null}, ${input.updated_by}, NOW())
+      ON CONFLICT (id) DO UPDATE SET
+        enabled = EXCLUDED.enabled,
+        provider = EXCLUDED.provider,
+        model = EXCLUDED.model,
+        base_url = EXCLUDED.base_url,
+        api_key_sealed = EXCLUDED.api_key_sealed,
+        api_key_hint = EXCLUDED.api_key_hint,
+        updated_by = EXCLUDED.updated_by,
+        updated_at = NOW()
+    `;
+    return;
+  }
+
+  await db`
+    INSERT INTO ai_settings
+      (id, enabled, provider, model, base_url, updated_by, updated_at)
+    VALUES
+      (1, ${input.enabled}, ${input.provider}, ${input.model}, ${input.base_url},
+       ${input.updated_by}, NOW())
+    ON CONFLICT (id) DO UPDATE SET
+      enabled = EXCLUDED.enabled,
+      provider = EXCLUDED.provider,
+      model = EXCLUDED.model,
+      base_url = EXCLUDED.base_url,
       updated_by = EXCLUDED.updated_by,
       updated_at = NOW()
   `;

--- a/tests/ai.test.ts
+++ b/tests/ai.test.ts
@@ -6,8 +6,18 @@ import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
  * the network.
  */
 
+const getAiSettings = vi.fn();
+vi.mock("@/lib/db", () => ({ getAiSettings: () => getAiSettings() }));
+
+async function sealValue(v: string) {
+  const { seal } = await import("@/lib/secret-box");
+  return seal(v);
+}
+
 const AI_ENV = [
   "AI_DISABLED",
+  "MODE",
+  "SESSION_SECRET",
   "BAILIAN_API_KEY",
   "BAILIAN_BASE_URL",
   "BAILIAN_MODEL",
@@ -51,6 +61,10 @@ beforeEach(async () => {
   vi.spyOn(console, "error").mockImplementation(() => {});
   const { __resetBudgetForTests } = await import("@/lib/ai");
   __resetBudgetForTests();
+  getAiSettings.mockReset().mockResolvedValue(null);
+  process.env.SESSION_SECRET = "a".repeat(64);
+  const { cacheDelete } = await import("@/lib/cache");
+  cacheDelete("ai-provider:settings");
 });
 
 afterEach(() => {
@@ -62,19 +76,19 @@ afterEach(() => {
 describe("aiEnabled", () => {
   it("is false when no provider key is set", async () => {
     const { aiEnabled } = await import("@/lib/ai");
-    expect(aiEnabled()).toBe(false);
+    expect(await aiEnabled()).toBe(false);
   });
 
   it("is true when GEMINI_API_KEY is set", async () => {
     process.env.GEMINI_API_KEY = "k";
     const { aiEnabled } = await import("@/lib/ai");
-    expect(aiEnabled()).toBe(true);
+    expect(await aiEnabled()).toBe(true);
   });
 
   it("is true when only QWEN_API_KEY is set", async () => {
     process.env.QWEN_API_KEY = "k";
     const { aiEnabled } = await import("@/lib/ai");
-    expect(aiEnabled()).toBe(true);
+    expect(await aiEnabled()).toBe(true);
   });
 
   it("is false when AI_DISABLED=true even with keys present", async () => {
@@ -82,27 +96,27 @@ describe("aiEnabled", () => {
     process.env.QWEN_API_KEY = "k";
     process.env.AI_DISABLED = "true";
     const { aiEnabled } = await import("@/lib/ai");
-    expect(aiEnabled()).toBe(false);
+    expect(await aiEnabled()).toBe(false);
   });
 });
 
 describe("configuredProviders", () => {
   it("returns an empty list with no keys", async () => {
     const { configuredProviders } = await import("@/lib/ai");
-    expect(configuredProviders()).toEqual([]);
+    expect(await configuredProviders()).toEqual([]);
   });
 
   it("returns gemini before qwen when both are configured", async () => {
     process.env.GEMINI_API_KEY = "k";
     process.env.QWEN_API_KEY = "k";
     const { configuredProviders } = await import("@/lib/ai");
-    expect(configuredProviders()).toEqual(["gemini", "qwen"]);
+    expect(await configuredProviders()).toEqual(["gemini", "qwen"]);
   });
 
   it("never leaks key material", async () => {
     process.env.GEMINI_API_KEY = "super-secret-value";
     const { configuredProviders } = await import("@/lib/ai");
-    expect(JSON.stringify(configuredProviders())).not.toContain("super-secret-value");
+    expect(JSON.stringify(await configuredProviders())).not.toContain("super-secret-value");
   });
 });
 
@@ -445,7 +459,7 @@ describe("generateJson — Anthropic protocol (bailian)", () => {
     fetchMock.mockResolvedValueOnce(anthropicBody());
 
     const { generateJson, configuredProviders } = await import("@/lib/ai");
-    expect(configuredProviders()).toEqual(["bailian", "gemini"]);
+    expect(await configuredProviders()).toEqual(["bailian", "gemini"]);
 
     const r = await generateJson("sys", {});
     expect(r.ok).toBe(true);
@@ -465,5 +479,155 @@ describe("generateJson — Anthropic protocol (bailian)", () => {
     // Second call used the OpenAI shape, proving the protocol switched.
     const secondBody = JSON.parse(fetchMock.mock.calls[1][1].body as string);
     expect(secondBody.messages[0].role).toBe("system");
+  });
+});
+
+// ── Organization-mode provider override (v4.1.5) ──────────────────────────────
+
+describe("resolveAiOverride — mode gating", () => {
+  it("never consults the database in standalone mode", async () => {
+    process.env.MODE = "standalone";
+    process.env.BAILIAN_API_KEY = "env-key";
+    const { resolveAiOverride } = await import("@/lib/ai");
+    expect(await resolveAiOverride()).toBeNull();
+    expect(getAiSettings).not.toHaveBeenCalled();
+  });
+
+  it("returns null in org mode when nothing is configured", async () => {
+    process.env.MODE = "organization";
+    getAiSettings.mockResolvedValue(null);
+    const { resolveAiOverride } = await import("@/lib/ai");
+    expect(await resolveAiOverride()).toBeNull();
+  });
+
+  it("returns null when the row exists but is disabled", async () => {
+    process.env.MODE = "organization";
+    getAiSettings.mockResolvedValue({
+      enabled: false, provider: "gemini", model: "m",
+      api_key_sealed: await sealValue("k"), base_url: null,
+    });
+    const { resolveAiOverride } = await import("@/lib/ai");
+    expect(await resolveAiOverride()).toBeNull();
+  });
+
+  it("returns null when AI_DISABLED is set, without touching the database", async () => {
+    process.env.MODE = "organization";
+    process.env.AI_DISABLED = "true";
+    const { resolveAiOverride } = await import("@/lib/ai");
+    expect(await resolveAiOverride()).toBeNull();
+    expect(getAiSettings).not.toHaveBeenCalled();
+  });
+
+  it("resolves provider, model and key from settings", async () => {
+    process.env.MODE = "organization";
+    getAiSettings.mockResolvedValue({
+      enabled: true, provider: "gemini", model: "gemini-2.5-pro",
+      base_url: null, api_key_sealed: await sealValue("org-key"),
+    });
+    const { resolveAiOverride } = await import("@/lib/ai");
+    expect(await resolveAiOverride()).toEqual({
+      provider: "gemini",
+      model: "gemini-2.5-pro",
+      apiKey: "org-key",
+      baseUrl: "https://generativelanguage.googleapis.com/v1beta/openai",
+    });
+  });
+
+  it("falls back to the provider's default model when none is stored", async () => {
+    process.env.MODE = "organization";
+    getAiSettings.mockResolvedValue({
+      enabled: true, provider: "bailian", model: null,
+      base_url: null, api_key_sealed: await sealValue("k"),
+    });
+    const { resolveAiOverride } = await import("@/lib/ai");
+    expect((await resolveAiOverride())?.model).toBe("qwen3.6-flash");
+  });
+
+  it("returns null when the stored key cannot be decrypted", async () => {
+    process.env.MODE = "organization";
+    const good = await sealValue("k");
+    process.env.SESSION_SECRET = "z".repeat(64); // rotated since it was stored
+    getAiSettings.mockResolvedValue({
+      enabled: true, provider: "gemini", model: "m", base_url: null, api_key_sealed: good,
+    });
+    const { resolveAiOverride } = await import("@/lib/ai");
+    expect(await resolveAiOverride()).toBeNull();
+  });
+});
+
+describe("aiEnabled / configuredProviders with an override", () => {
+  it("is enabled by an org override even with no environment keys", async () => {
+    process.env.MODE = "organization";
+    getAiSettings.mockResolvedValue({
+      enabled: true, provider: "gemini", model: "m",
+      base_url: null, api_key_sealed: await sealValue("k"),
+    });
+    const { aiEnabled, configuredProviders } = await import("@/lib/ai");
+    expect(await aiEnabled()).toBe(true);
+    expect(await configuredProviders()).toEqual(["gemini"]);
+  });
+
+  it("reports only the overridden provider, hiding the instance's env providers", async () => {
+    process.env.MODE = "organization";
+    process.env.BAILIAN_API_KEY = "env-key";
+    process.env.QWEN_API_KEY = "env-key";
+    getAiSettings.mockResolvedValue({
+      enabled: true, provider: "gemini", model: "m",
+      base_url: null, api_key_sealed: await sealValue("k"),
+    });
+    const { configuredProviders } = await import("@/lib/ai");
+    expect(await configuredProviders()).toEqual(["gemini"]);
+  });
+});
+
+describe("generateJson with an org override", () => {
+  it("uses the org's key, model and base URL", async () => {
+    process.env.MODE = "organization";
+    getAiSettings.mockResolvedValue({
+      enabled: true, provider: "gemini", model: "gemini-2.5-pro",
+      base_url: "https://org.proxy.test/v1", api_key_sealed: await sealValue("org-secret"),
+    });
+    fetchMock.mockResolvedValueOnce(okBody());
+
+    const { generateJson } = await import("@/lib/ai");
+    const r = await generateJson("sys", {});
+
+    expect(r.ok).toBe(true);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe("https://org.proxy.test/v1/chat/completions");
+    expect((init.headers as Record<string, string>).Authorization).toBe("Bearer org-secret");
+    expect(JSON.parse(init.body as string).model).toBe("gemini-2.5-pro");
+  });
+
+  it("does NOT fall back to the instance's env keys when the org key fails", async () => {
+    // Falling back would silently bill the deployment owner for org traffic.
+    process.env.MODE = "organization";
+    process.env.BAILIAN_API_KEY = "instance-key";
+    getAiSettings.mockResolvedValue({
+      enabled: true, provider: "gemini", model: "m",
+      base_url: null, api_key_sealed: await sealValue("org-key"),
+    });
+    fetchMock.mockResolvedValue(errBody(401)); // fatal for the org provider
+
+    const { generateJson } = await import("@/lib/ai");
+    const r = await generateJson("sys", {});
+
+    expect(r.ok).toBe(false);
+    // Exactly one attempt: the org's provider. No instance fallback.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses environment providers normally when no override is set", async () => {
+    process.env.MODE = "organization";
+    process.env.GEMINI_API_KEY = "env-key";
+    getAiSettings.mockResolvedValue(null);
+    fetchMock.mockResolvedValueOnce(okBody());
+
+    const { generateJson } = await import("@/lib/ai");
+    const r = await generateJson("sys", {});
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.provider).toBe("gemini");
+    expect((fetchMock.mock.calls[0][1].headers as Record<string,string>).Authorization)
+      .toBe("Bearer env-key");
   });
 });


### PR DESCRIPTION
Adds **Settings → AI Provider** so an organization can use its own model and API key, while standalone deployments keep using the server defaults — exactly as you asked.

## Behaviour by mode

| | Organization mode | Standalone mode |
|---|---|---|
| Settings section | Visible — provider, model, API key, optional base URL | **Not rendered** |
| `PUT /api/settings/ai` | Saves to DB (migration 6) | **403** |
| Resolution | Stored override, else env defaults | Env defaults only |
| DB queried? | Yes, cached 30s | **Never** — mode check short-circuits |

Standalone is genuinely untouched: no new setup, no new failure mode, works out of the box as before.

## The design decision worth your sign-off

**A configured org key is used *exclusively*.** If the org's key fails, the request fails — the server's own keys are **not** tried as a fallback behind it.

I chose that deliberately: falling back would silently bill *your* deployment for an organization's traffic, and that's the kind of surprise you'd find on an invoice rather than in a log. There's a test asserting exactly one provider attempt in that case.

If you'd rather it fall back for resilience, it's a two-line change — but I'd argue billing clarity beats availability for an optional enhancement layer.

## Security

Same pattern as v4.1.3's email credentials, for consistency:

- **Write-only key** — encrypted at rest (AES-256-GCM via `secret-box.ts`), never returned to the browser, masked hint only, blank field keeps the stored key
- **`https` enforced on base URL** — that URL carries the API key, so `http://` is refused rather than warned about
- **Instance-wide with attribution** — no per-user scoping (consistent with alert rules and email settings), so `updated_by`/`updated_at` record who changed it

## Notable refactor

`aiEnabled()` and `configuredProviders()` became **async**, since both may now depend on stored settings. All four AI routes await them; `/api/ai/status` reports `effective_source` so the UI can show whether the override, the environment, or nothing is live.

## Test plan

- [x] `pnpm exec tsc --noEmit` — **0 errors**
- [x] `pnpm test` — **278/278** (266 → 278, +12)
- [x] `pnpm run lint` — **0 errors** (11 pre-existing warnings, unchanged)
- [x] `rm -rf .next && pnpm run build` — succeeds, `/api/settings/ai` emits
- [x] API Reference parity — clean
- [x] Version bumped in all locations; release-notes entries verified intact

New tests cover: standalone never queries the DB, disabled/absent rows, `AI_DISABLED` short-circuit, undecryptable key, default-model fallback, override hiding env providers, and the exclusive-use billing guarantee.

## Rollback

1. Toggle the override off in Settings — falls back to env defaults, no redeploy
2. Promote the v4.1.4 deployment
3. `git revert` — migration 6 only *adds* a table, so no down-migration