### PR TITLE
feat: v4.2.0 — GitHub security alerts on the Security page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,55 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ---
 
+## [4.2.0] — 2026-08-15
+
+### Overview
+The Security page reported none of GitHub's own security findings. It statically analysed workflow YAML — useful, and something GitHub does not do for you — but a page called *Security* that cannot say how many critical CVEs are open, or whether a credential is currently leaked, is answering the wrong question first. This adds those.
+
+First of four features chosen from a codebase gap review; the others are honest DORA from real deployments, issues/triage health, and a command palette.
+
+### Added
+
+#### GitHub Security Alerts
+- New panel on `/repos/[owner]/[repo]/security`, above the workflow analysis — a live CVE or leaked credential outranks a YAML anti-pattern.
+- Three sources: **Dependabot** (vulnerable dependencies), **code scanning** (CodeQL and third-party), and **secret scanning** (committed credentials).
+- Severity counts, the age of the oldest open alert, and — per source — how many alerts were resolved in the last 90 days plus **mean time to remediate**. "We fix things quickly" becomes a number.
+- New `GET /api/github/security-alerts`, cached 5 minutes.
+
+### Changed
+
+#### An unreadable source must never look like a clean one
+This is the design rule the whole feature is built around, and it drove most of the code:
+
+- Each source carries its **own status** — `ok`, `forbidden`, `not_enabled`, or `error` — rather than collapsing into one success/failure for the request.
+- A `403` renders as a loud, actionable warning; a genuinely clean repo renders as a calm green state. Showing "0 alerts" when the real answer is "we could not check" would turn a token permission gap into false confidence on a security page.
+- A `404` is reported as *not enabled for this repo*, not as a permission problem — those need different fixes and shouldn't be conflated.
+- Every failure mode is covered by a test, including all three sources failing at once.
+
+#### Scope requirement, stated plainly
+- These endpoints need the **`security_events`** scope, which GitDash has never requested — so most existing tokens will be refused. The panel says exactly that, with the fix for both classic and fine-grained PATs, instead of surfacing a generic error.
+
+#### Severity normalisation
+- GitHub uses several severity vocabularies. Dependabot's `moderate` maps to medium; code scanning prefers `security_severity_level` over `rule.severity`, since the latter describes rule *confidence* (note/warning/error), not impact.
+- Secret scanning alerts carry no severity at all and are always ranked **critical** — a live credential needs no triage debate.
+
+#### Page retitled
+- "Workflow Security" → **"Security"**, since it now covers more than workflow files.
+
+### Verified
+- Test count 278 → 291, covering permission and availability failures, severity normalisation across all three vocabularies, ordering, ageing, and MTTR.
+
+### Rollback
+1. **Disable the Security Scan feature flag** — hides the whole page including the new panel.
+2. **Promote the v4.1.5 Vercel deployment** — instant.
+3. **`git revert`** — no schema change in this release.
+
+### Changed (infra)
+- Bumped app version from 4.1.5 to 4.2.0
+- Bumped Helm chart version from 0.5.5 to 0.6.0
+
+---
+
 ## [4.1.5] — 2026-08-15
 
 ### Overview

--- a/helm/gitdash/Chart.yaml
+++ b/helm/gitdash/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: gitdash
 description: Self-hosted GitHub Actions metrics dashboard (standalone PAT or GitHub OAuth)
 type: application
-version: 0.5.5
-appVersion: "4.1.5"
+version: 0.6.0
+appVersion: "4.2.0"
 keywords:
   - github-actions
   - dashboard

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gitdash",
-  "version": "4.1.5",
+  "version": "4.2.0",
   "private": true,
   "packageManager": "pnpm@10.30.3",
   "scripts": {

--- a/src/app/api/github/security-alerts/route.ts
+++ b/src/app/api/github/security-alerts/route.ts
@@ -1,0 +1,50 @@
+/**
+ * GET /api/github/security-alerts — GitHub's own security findings.
+ *
+ * Complements /api/github/security-scan, which statically analyses workflow
+ * YAML. This one reports what GitHub itself has found: vulnerable
+ * dependencies, code scanning results, and exposed secrets.
+ *
+ * Never fails wholesale on a permission problem. Each source carries its own
+ * status, because on a security page "we couldn't look" and "there's nothing
+ * there" must never render the same way.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { getTokenFromSession } from "@/lib/session";
+import { getSecurityAlerts } from "@/lib/security-alerts";
+import { withCache, hashKey } from "@/lib/cache";
+import { validateOwner, validateRepo, safeError } from "@/lib/validation";
+
+export type {
+  SecurityAlertsResponse, SecurityAlert, SourceResult,
+  AlertSeverity, AlertSource, SourceStatus,
+} from "@/lib/security-alerts";
+
+export const maxDuration = 60;
+
+const CACHE_TTL = 300; // 5 min — six API calls, and alerts do not move minute to minute
+
+export async function GET(req: NextRequest) {
+  const token = await getTokenFromSession();
+  if (!token) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const { searchParams } = new URL(req.url);
+  const ownerResult = validateOwner(searchParams.get("owner"));
+  if (!ownerResult.ok) return ownerResult.response;
+  const repoResult = validateRepo(searchParams.get("repo"));
+  if (!repoResult.ok) return repoResult.response;
+
+  try {
+    const data = await withCache(
+      `security-alerts:${hashKey(token)}:${ownerResult.data}/${repoResult.data}`,
+      CACHE_TTL,
+      () => getSecurityAlerts(token, ownerResult.data, repoResult.data),
+    );
+    return NextResponse.json(data, {
+      headers: { "Cache-Control": `private, max-age=${CACHE_TTL}` },
+    });
+  } catch (e) {
+    return safeError(e, "Failed to fetch security alerts");
+  }
+}

--- a/src/app/docs/page.tsx
+++ b/src/app/docs/page.tsx
@@ -1096,14 +1096,49 @@ function FeatureSecurity() {
   return (
     <section className="space-y-6">
       <FeaturePageHeader
-        icon={ShieldAlert} name="Security Scan" path="/repos/[owner]/[repo]/security"
-        chips={["Static analysis", "Severity grouping", "Per-file findings"]}
+        icon={ShieldAlert} name="Security" path="/repos/[owner]/[repo]/security"
+        chips={["GitHub alerts", "Static analysis", "Severity grouping", "Remediation time"]}
       />
       <ProseP>
-        Runs static analysis on all workflow YAML files in the repository, checking for common
-        security anti-patterns without executing any code. Findings are grouped by severity and
-        collapsed per file for easy triage.
+        Two independent layers. <strong>GitHub Security Alerts</strong> reports what GitHub itself
+        has found — vulnerable dependencies, code scanning results, and exposed secrets.{" "}
+        <strong>Workflow static analysis</strong> then checks your Actions YAML for anti-patterns,
+        which GitHub does not do for you.
       </ProseP>
+
+      <DocCard>
+        <div className="flex items-center gap-2 mb-2">
+          <SubHeading>GitHub Security Alerts</SubHeading>
+          <VersionBadge v="4.2.0" />
+        </div>
+        <DocTable
+          headers={["Source", "What it reports"]}
+          rows={[
+            ["Dependabot", "Vulnerable dependencies, with advisory severity and CVE"],
+            ["Code scanning", "CodeQL and third-party analysis findings, ranked by security severity rather than rule confidence"],
+            ["Secret scanning", "Credentials committed to the repository — always ranked critical"],
+          ]}
+        />
+        <ProseP>
+          Each source also reports how many alerts were resolved in the last 90 days and the mean
+          time to remediate, so &ldquo;we fix things quickly&rdquo; becomes a number rather than a
+          belief.
+        </ProseP>
+
+        <Callout type="warning">
+          <strong>Requires the <Code>security_events</Code> scope</strong>, which GitDash does not
+          request by default — so an existing token will most likely be refused. Add it to a classic
+          PAT, or grant <em>Dependabot alerts</em>, <em>Code scanning alerts</em> and{" "}
+          <em>Secret scanning alerts</em> read access on a fine-grained PAT.
+        </Callout>
+
+        <Callout type="info">
+          <strong>An unreadable source never looks like a clean one.</strong> Each source carries its
+          own status, and a permission failure renders as a warning rather than an empty list. On a
+          security page, showing &ldquo;0 alerts&rdquo; when the real answer is &ldquo;we could not
+          check&rdquo; would turn a token gap into false confidence.
+        </Callout>
+      </DocCard>
       <ScreenshotSlot file="10-security.png" alt="Security Scan results" />
       <DocCard>
         <SubHeading>Checks performed</SubHeading>
@@ -2555,6 +2590,15 @@ function APIReference() {
         },
         {
           method: "GET",
+          path: "/api/github/security-alerts",
+          description: "GitHub's own security findings: Dependabot, code scanning and secret scanning alerts. Returns { sources, alerts[], counts, total_open, oldest_open_days, partial, needs_scope } where each source carries its own status (ok | forbidden | not_enabled | error) plus 90-day fix count and mean time to remediate. Requires the security_events scope; a 403 on any source sets needs_scope rather than failing the request, so an unreadable source is never reported as a clean one.",
+          params: [
+            { name: "owner", type: "string", optional: false, desc: "Repository owner" },
+            { name: "repo", type: "string", optional: false, desc: "Repository name" },
+          ],
+        },
+        {
+          method: "GET",
           path: "/api/settings/ai",
           description: "Current AI provider override. Returns { configurable, mode, enabled, provider, model, base_url, api_key_hint, has_key, updated_by, updated_at, effective_source, env_providers, db_available }. The API key is never returned — only a masked hint. configurable is false in standalone mode, where the section is hidden and environment defaults apply.",
           params: [],
@@ -2836,9 +2880,27 @@ pnpm run lint`}
 function ReleaseNotes() {
   const releases = [
     {
-      version: "4.1.5",
+      version: "4.2.0",
       date: "2026-08-15",
       badge: "latest",
+      badgeColor: "bg-emerald-500/15 text-emerald-400 border-emerald-500/20",
+      changes: {
+        added: [
+          "GitHub Security Alerts on the Security page — vulnerable dependencies (Dependabot), code scanning findings, and exposed secrets, with severity counts, age of the oldest open alert, and mean time to remediate per source. Until now the page only lint-checked workflow YAML and showed none of GitHub's own findings",
+          "Exposed secrets are always ranked critical: those alerts carry no severity field, and a live credential needs no triage debate",
+        ],
+        fixed: [],
+        improved: [
+          "An unreadable source can never look like a clean one. Each source reports its own status, and a permission failure renders as a loud actionable warning rather than an empty list — on a security page, conflating \"we couldn't look\" with \"nothing found\" would let a token gap read as safety",
+          "Reading these alerts needs the security_events scope, which GitDash has never requested. When a source returns 403 the panel says exactly that and how to fix it, for both classic and fine-grained tokens",
+          "The page is now titled \"Security\" rather than \"Workflow Security\", since it covers more than workflow files",
+        ],
+      },
+    },
+    {
+      version: "4.1.5",
+      date: "2026-08-15",
+      badge: null,
       badgeColor: "bg-emerald-500/15 text-emerald-400 border-emerald-500/20",
       changes: {
         added: [
@@ -3386,7 +3448,7 @@ function DocSidebar({
           <BookOpen className="w-4 h-4 text-violet-400" />
           <span className="text-sm font-semibold text-white">GitDash Docs</span>
           <span className="text-xs px-1.5 py-0.5 rounded bg-violet-500/15 text-violet-400 border border-violet-500/20 font-mono">
-            v{process.env.NEXT_PUBLIC_APP_VERSION ?? "4.1.5"}
+            v{process.env.NEXT_PUBLIC_APP_VERSION ?? "4.2.0"}
           </span>
         </div>
         {/* Mobile close */}
@@ -3636,7 +3698,7 @@ export default function DocsPage() {
 
           {/* Footer */}
           <footer className="mt-8 pb-4 text-center text-xs text-slate-600 space-y-1">
-            <p>GitDash v{process.env.NEXT_PUBLIC_APP_VERSION ?? "4.1.5"} — GitHub Actions Dashboard</p>
+            <p>GitDash v{process.env.NEXT_PUBLIC_APP_VERSION ?? "4.2.0"} — GitHub Actions Dashboard</p>
             <p>
               <a href="https://github.com/dinhdobathi1992/gitdash" target="_blank" rel="noreferrer" className="hover:text-slate-400 transition-colors">
                 Open source on GitHub

--- a/src/app/repos/[owner]/[repo]/security/page.tsx
+++ b/src/app/repos/[owner]/[repo]/security/page.tsx
@@ -4,6 +4,7 @@ import { useParams } from "next/navigation";
 import Link from "next/link";
 import useSWR from "swr";
 import { useFeatureFlags } from "@/components/FeatureFlagsProvider";
+import SecurityAlertsPanel from "@/components/SecurityAlertsPanel";
 import { fetcher } from "@/lib/swr";
 import { RepoWorkflowBreadcrumb } from "@/components/Sidebar";
 import type {
@@ -406,9 +407,9 @@ export default function SecurityPage() {
       {/* Header */}
       <div className="flex items-start justify-between gap-4 flex-wrap">
         <div>
-          <h1 className="text-2xl font-bold text-white mb-1">Workflow Security</h1>
+          <h1 className="text-2xl font-bold text-white mb-1">Security</h1>
           <p className="text-sm text-slate-400">
-            Static analysis of GitHub Actions workflow YAML files for security issues in{" "}
+            GitHub&apos;s own security alerts, plus static analysis of workflow YAML, for{" "}
             <span className="font-mono text-slate-300">
               {owner}/{repo}
             </span>
@@ -421,6 +422,15 @@ export default function SecurityPage() {
           <ArrowLeft className="w-3.5 h-3.5" /> Back to repo
         </Link>
       </div>
+
+      {/* GitHub's own findings — shown above the YAML analysis because a live
+          CVE or leaked credential outranks a workflow anti-pattern. Gated on
+          the same flag as the rest of the page. */}
+      {flags.securityScan && <SecurityAlertsPanel owner={owner} repo={repo} />}
+
+      {flags.securityScan && (
+        <h2 className="text-base font-semibold text-white pt-2">Workflow static analysis</h2>
+      )}
 
       {/* Disabled state */}
       {!flags.securityScan && (

--- a/src/components/SecurityAlertsPanel.tsx
+++ b/src/components/SecurityAlertsPanel.tsx
@@ -1,0 +1,231 @@
+"use client";
+
+/**
+ * GitHub security alerts panel (v4.2.0).
+ *
+ * Design rule that drives everything here: on a security page, "we could not
+ * look" must never resemble "there is nothing to find". A 403 renders as a
+ * loud, actionable warning; a genuinely clean repo renders as a calm green
+ * state. Conflating them would let a token permission gap read as safety.
+ */
+
+import useSWR from "swr";
+import { fetcher } from "@/lib/swr";
+import type {
+  SecurityAlertsResponse, AlertSeverity, AlertSource, SourceStatus,
+} from "@/app/api/github/security-alerts/route";
+import {
+  ShieldAlert, ShieldCheck, KeyRound, Package, Code2,
+  AlertTriangle, ExternalLink, Clock, Lock,
+} from "lucide-react";
+import { cn } from "@/lib/utils";
+
+const SEVERITY_STYLE: Record<AlertSeverity, { chip: string; dot: string; label: string }> = {
+  critical: { chip: "bg-red-500/10 text-red-300 border-red-500/25", dot: "bg-red-400", label: "Critical" },
+  high:     { chip: "bg-orange-500/10 text-orange-300 border-orange-500/25", dot: "bg-orange-400", label: "High" },
+  medium:   { chip: "bg-amber-500/10 text-amber-300 border-amber-500/25", dot: "bg-amber-400", label: "Medium" },
+  low:      { chip: "bg-slate-700/40 text-slate-400 border-slate-600/40", dot: "bg-slate-500", label: "Low" },
+};
+
+const SOURCE_META: Record<AlertSource, { label: string; icon: React.ElementType }> = {
+  dependabot: { label: "Dependabot", icon: Package },
+  code_scanning: { label: "Code scanning", icon: Code2 },
+  secret_scanning: { label: "Secret scanning", icon: KeyRound },
+};
+
+const STATUS_NOTE: Record<Exclude<SourceStatus, "ok">, string> = {
+  forbidden: "Token lacks permission",
+  not_enabled: "Not enabled for this repo",
+  error: "Could not be read",
+};
+
+export default function SecurityAlertsPanel({ owner, repo }: { owner: string; repo: string }) {
+  const { data, error, isLoading } = useSWR<SecurityAlertsResponse>(
+    `/api/github/security-alerts?owner=${encodeURIComponent(owner)}&repo=${encodeURIComponent(repo)}`,
+    fetcher<SecurityAlertsResponse>,
+  );
+
+  if (isLoading) {
+    return (
+      <div className="rounded-2xl border border-slate-800 bg-slate-900/40 p-5">
+        <div className="h-4 w-48 rounded skeleton mb-3" />
+        <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+          {Array.from({ length: 4 }).map((_, i) => <div key={i} className="h-16 rounded-xl skeleton" />)}
+        </div>
+      </div>
+    );
+  }
+
+  if (error || !data) {
+    return (
+      <div className="rounded-2xl border border-slate-800 bg-slate-900/40 p-5 text-sm text-slate-500">
+        Could not load GitHub security alerts.
+      </div>
+    );
+  }
+
+  const clean = data.total_open === 0 && !data.partial;
+
+  return (
+    <div className="rounded-2xl border border-slate-800 bg-slate-900/40 overflow-hidden">
+      <div className="flex items-start gap-4 p-5 border-b border-slate-800">
+        <span
+          className={cn(
+            "shrink-0 w-9 h-9 rounded-lg border flex items-center justify-center",
+            clean
+              ? "border-emerald-500/30 bg-emerald-500/[0.12]"
+              : "border-red-500/30 bg-red-500/[0.12]",
+          )}
+        >
+          {clean
+            ? <ShieldCheck className="w-4 h-4 text-emerald-300" />
+            : <ShieldAlert className="w-4 h-4 text-red-300" />}
+        </span>
+        <div className="min-w-0 flex-1">
+          <h3 className="text-[15px] font-semibold text-white">GitHub Security Alerts</h3>
+          <p className="text-xs text-slate-500 mt-0.5">
+            Vulnerable dependencies, code scanning results and exposed secrets reported by GitHub
+            itself — distinct from the workflow analysis below.
+          </p>
+        </div>
+      </div>
+
+      <div className="p-5 space-y-4">
+        {/* A permission gap is the loudest thing on this panel: without it, an
+            unreadable source looks identical to a clean one. */}
+        {data.needs_scope && (
+          <div className="flex items-start gap-2.5 px-4 py-3 rounded-xl bg-amber-500/10 border border-amber-500/30 text-xs text-amber-100">
+            <Lock className="w-4 h-4 mt-0.5 shrink-0 text-amber-300" />
+            <div className="space-y-1">
+              <p className="font-semibold">Some sources could not be read — this is not an all-clear.</p>
+              <p className="text-amber-200/80">
+                Reading security alerts needs the <code className="text-amber-100">security_events</code>{" "}
+                scope, which GitDash does not request by default. Regenerate your token with it
+                added (classic PAT), or grant <em>Dependabot alerts</em>, <em>Code scanning
+                alerts</em> and <em>Secret scanning alerts</em> read access on a fine-grained PAT.
+              </p>
+            </div>
+          </div>
+        )}
+
+        {/* Severity summary */}
+        <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+          {(["critical", "high", "medium", "low"] as AlertSeverity[]).map((sev) => (
+            <div
+              key={sev}
+              className={cn(
+                "rounded-xl border p-3.5",
+                data.counts[sev] > 0 ? SEVERITY_STYLE[sev].chip : "border-slate-800 bg-slate-900/40",
+              )}
+            >
+              <div className="flex items-center gap-1.5 text-[10.5px] font-semibold uppercase tracking-[0.12em] mb-1.5">
+                <span className={cn("w-1.5 h-1.5 rounded-full", SEVERITY_STYLE[sev].dot)} />
+                {SEVERITY_STYLE[sev].label}
+              </div>
+              <div className={cn("font-mono text-2xl font-bold tabular-nums", data.counts[sev] === 0 && "text-slate-600")}>
+                {data.counts[sev]}
+              </div>
+            </div>
+          ))}
+        </div>
+
+        {/* Per-source status — the row that makes "unreadable" visible */}
+        <div className="grid grid-cols-1 sm:grid-cols-3 gap-2.5">
+          {(Object.keys(SOURCE_META) as AlertSource[]).map((src) => {
+            const s = data.sources[src];
+            const Icon = SOURCE_META[src].icon;
+            const ok = s.status === "ok";
+            return (
+              <div
+                key={src}
+                className={cn(
+                  "rounded-xl border px-3.5 py-3",
+                  ok ? "border-slate-800 bg-slate-900/40" : "border-amber-500/25 bg-amber-500/[0.06]",
+                )}
+              >
+                <div className="flex items-center gap-2 mb-1.5">
+                  <Icon className={cn("w-3.5 h-3.5", ok ? "text-slate-400" : "text-amber-400")} />
+                  <span className="text-xs font-medium text-slate-300">{SOURCE_META[src].label}</span>
+                </div>
+                {s.status === "ok" ? (
+                  <div className="flex items-baseline gap-2">
+                    <span className={cn("font-mono text-lg font-bold", s.open_count > 0 ? "text-white" : "text-emerald-400")}>
+                      {s.open_count}
+                    </span>
+                    <span className="text-[11px] text-slate-500">
+                      open{s.mttr_days !== null && ` · ${s.mttr_days}d avg fix`}
+                    </span>
+                  </div>
+                ) : (
+                  <span className="text-[11px] text-amber-300/90">{STATUS_NOTE[s.status]}</span>
+                )}
+              </div>
+            );
+          })}
+        </div>
+
+        {data.oldest_open_days !== null && data.oldest_open_days > 30 && (
+          <div className="flex items-center gap-2 px-3 py-2 rounded-lg bg-red-500/10 border border-red-500/25 text-xs text-red-200">
+            <Clock className="w-3.5 h-3.5 shrink-0" />
+            The oldest open alert has been unresolved for{" "}
+            <strong>{data.oldest_open_days} days</strong>.
+          </div>
+        )}
+
+        {/* Alert list */}
+        {data.alerts.length > 0 ? (
+          <div className="rounded-xl border border-slate-800 overflow-hidden">
+            {data.alerts.map((a) => {
+              const style = SEVERITY_STYLE[a.severity];
+              return (
+                <a
+                  key={`${a.source}-${a.number}`}
+                  href={a.html_url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="group flex items-center gap-3 px-4 py-3 border-b border-slate-800/60 last:border-b-0 hover:bg-slate-800/40 transition-colors"
+                >
+                  <span className={cn("shrink-0 text-[10px] font-semibold uppercase px-1.5 py-0.5 rounded border", style.chip)}>
+                    {style.label}
+                  </span>
+                  <div className="min-w-0 flex-1">
+                    <p className="text-xs text-slate-200 truncate group-hover:text-white transition-colors">
+                      {a.title}
+                    </p>
+                    <p className="text-[11px] text-slate-500 font-mono truncate">
+                      {SOURCE_META[a.source].label} · {a.subject}
+                    </p>
+                  </div>
+                  <span className="shrink-0 text-[11px] text-slate-500 tabular-nums">{a.age_days}d</span>
+                  <ExternalLink className="w-3 h-3 shrink-0 text-slate-700 group-hover:text-slate-400 transition-colors" />
+                </a>
+              );
+            })}
+          </div>
+        ) : data.partial ? (
+          <p className="text-xs text-slate-500 italic">
+            No alerts returned by the sources that could be read.
+          </p>
+        ) : (
+          <div className="flex items-center gap-2 px-4 py-3 rounded-xl bg-emerald-500/[0.06] border border-emerald-500/25 text-sm text-emerald-200">
+            <ShieldCheck className="w-4 h-4 shrink-0" />
+            No open security alerts. All three sources were checked.
+          </div>
+        )}
+
+        {data.total_open > data.alerts.length && (
+          <p className="text-[11px] text-slate-600">
+            Showing the {data.alerts.length} most severe of {data.total_open} open alerts.
+          </p>
+        )}
+
+        {data.partial && !data.needs_scope && (
+          <p className="flex items-start gap-1.5 text-[11px] text-slate-500">
+            <AlertTriangle className="w-3 h-3 mt-0.5 shrink-0 text-slate-600" />
+            Some sources are not enabled for this repository, so this is not a complete picture.
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/lib/security-alerts.ts
+++ b/src/lib/security-alerts.ts
@@ -1,0 +1,276 @@
+/**
+ * GitHub security alerts (v4.2.0) — Dependabot, code scanning, secret scanning.
+ *
+ * The existing Security page statically analyses workflow YAML for
+ * anti-patterns. Useful, but it means a page called "Security" showed none of
+ * GitHub's own findings. This module adds those.
+ *
+ * ── Access is the hard part ───────────────────────────────────────────────
+ * All three endpoints need the `security_events` scope, which GitDash has
+ * never asked for — so most existing tokens will 403 here. That is not an
+ * error state to bury: each source reports its own status so the UI can say
+ * "your token can't read this, here's how to fix it" instead of showing an
+ * empty list that looks like good news.
+ *
+ * An empty result and an inaccessible result must never look the same on a
+ * security page.
+ */
+
+import { getOctokit } from "@/lib/github";
+
+export type AlertSeverity = "critical" | "high" | "medium" | "low";
+export type AlertSource = "dependabot" | "code_scanning" | "secret_scanning";
+
+/**
+ * Why a source has no data. Distinguishing these is the whole point:
+ * "clean" is good news, "forbidden" and "not_enabled" are not.
+ */
+export type SourceStatus = "ok" | "forbidden" | "not_enabled" | "error";
+
+export interface SecurityAlert {
+  source: AlertSource;
+  /** GitHub's alert number, unique per repo per source. */
+  number: number;
+  severity: AlertSeverity;
+  title: string;
+  /** Package, rule id, or secret type — whatever identifies the finding. */
+  subject: string;
+  created_at: string;
+  age_days: number;
+  html_url: string;
+}
+
+export interface SourceResult {
+  status: SourceStatus;
+  open_count: number;
+  /** Null when the source was not readable. */
+  fixed_last_90d: number | null;
+  /** Mean days from open to fix over the last 90 days. Null when no fixes. */
+  mttr_days: number | null;
+}
+
+export interface SecurityAlertsResponse {
+  repo: string;
+  sources: Record<AlertSource, SourceResult>;
+  /** Open alerts across all readable sources, worst-first then oldest-first. */
+  alerts: SecurityAlert[];
+  counts: Record<AlertSeverity, number>;
+  total_open: number;
+  /** Age in days of the oldest open alert, or null when there are none. */
+  oldest_open_days: number | null;
+  /** True when at least one source could not be read — the UI must say so. */
+  partial: boolean;
+  /** True when any source returned 403 — actionable: the token needs a scope. */
+  needs_scope: boolean;
+}
+
+const MAX_ALERTS_RETURNED = 50;
+const SEVERITY_ORDER: Record<AlertSeverity, number> = {
+  critical: 0, high: 1, medium: 2, low: 3,
+};
+
+function daysSince(iso: string): number {
+  return Math.max(0, Math.floor((Date.now() - new Date(iso).getTime()) / 86_400_000));
+}
+
+/** Map GitHub's several severity vocabularies onto one scale. */
+function normaliseSeverity(raw: string | null | undefined): AlertSeverity {
+  switch ((raw ?? "").toLowerCase()) {
+    case "critical": return "critical";
+    case "high": case "error": return "high";
+    case "medium": case "moderate": case "warning": return "medium";
+    default: return "low";
+  }
+}
+
+/** Classify a failure so the UI can distinguish "can't read" from "nothing found". */
+function statusFromError(e: unknown): SourceStatus {
+  const status = (e as { status?: number })?.status;
+  if (status === 403) return "forbidden";
+  // 404 here means the feature is off for this repo (or the repo is private
+  // without Advanced Security) — not an error worth alarming anyone about.
+  if (status === 404) return "not_enabled";
+  return "error";
+}
+
+interface RawAlert {
+  number: number;
+  state: string;
+  created_at: string;
+  html_url?: string;
+  fixed_at?: string | null;
+  updated_at?: string;
+}
+
+/** Mean days-to-fix across alerts resolved in the window. */
+function computeMttr(fixed: { created_at: string; fixed_at: string }[]): number | null {
+  if (fixed.length === 0) return null;
+  const total = fixed.reduce(
+    (sum, a) =>
+      sum + (new Date(a.fixed_at).getTime() - new Date(a.created_at).getTime()) / 86_400_000,
+    0,
+  );
+  return Math.round((total / fixed.length) * 10) / 10;
+}
+
+const NINETY_DAYS_MS = 90 * 86_400_000;
+const isRecent = (iso: string) => Date.now() - new Date(iso).getTime() <= NINETY_DAYS_MS;
+
+export async function getSecurityAlerts(
+  token: string,
+  owner: string,
+  repo: string,
+): Promise<SecurityAlertsResponse> {
+  const octokit = getOctokit(token);
+
+  const [depRes, codeRes, secretRes] = await Promise.allSettled([
+    octokit.rest.dependabot.listAlertsForRepo({ owner, repo, per_page: 100, state: "open" }),
+    octokit.rest.codeScanning.listAlertsForRepo({ owner, repo, per_page: 100, state: "open" }),
+    octokit.rest.secretScanning.listAlertsForRepo({ owner, repo, per_page: 100, state: "open" }),
+  ]);
+
+  // Resolved alerts power MTTR. Fetched separately and best-effort — a failure
+  // here costs a metric, not the page.
+  const [depFixed, codeFixed, secretFixed] = await Promise.allSettled([
+    octokit.rest.dependabot.listAlertsForRepo({ owner, repo, per_page: 100, state: "fixed" }),
+    octokit.rest.codeScanning.listAlertsForRepo({ owner, repo, per_page: 100, state: "fixed" }),
+    octokit.rest.secretScanning.listAlertsForRepo({ owner, repo, per_page: 100, state: "resolved" }),
+  ]);
+
+  const alerts: SecurityAlert[] = [];
+  const sources = {} as Record<AlertSource, SourceResult>;
+
+  // ── Dependabot ──────────────────────────────────────────────────────────
+  if (depRes.status === "fulfilled") {
+    const open = depRes.value.data as unknown as (RawAlert & {
+      security_advisory?: { severity?: string; summary?: string; cve_id?: string | null };
+      dependency?: { package?: { name?: string } };
+    })[];
+    for (const a of open) {
+      alerts.push({
+        source: "dependabot",
+        number: a.number,
+        severity: normaliseSeverity(a.security_advisory?.severity),
+        title: a.security_advisory?.summary ?? a.security_advisory?.cve_id ?? "Vulnerable dependency",
+        subject: a.dependency?.package?.name ?? "unknown package",
+        created_at: a.created_at,
+        age_days: daysSince(a.created_at),
+        html_url: a.html_url ?? "",
+      });
+    }
+    const fixed =
+      depFixed.status === "fulfilled"
+        ? (depFixed.value.data as unknown as RawAlert[])
+            .filter((a) => a.fixed_at && isRecent(a.fixed_at))
+            .map((a) => ({ created_at: a.created_at, fixed_at: a.fixed_at! }))
+        : [];
+    sources.dependabot = {
+      status: "ok",
+      open_count: open.length,
+      fixed_last_90d: depFixed.status === "fulfilled" ? fixed.length : null,
+      mttr_days: computeMttr(fixed),
+    };
+  } else {
+    sources.dependabot = {
+      status: statusFromError(depRes.reason),
+      open_count: 0, fixed_last_90d: null, mttr_days: null,
+    };
+  }
+
+  // ── Code scanning ───────────────────────────────────────────────────────
+  if (codeRes.status === "fulfilled") {
+    const open = codeRes.value.data as unknown as (RawAlert & {
+      rule?: { security_severity_level?: string | null; severity?: string | null; description?: string; id?: string };
+    })[];
+    for (const a of open) {
+      alerts.push({
+        source: "code_scanning",
+        number: a.number,
+        // security_severity_level is the meaningful one; rule.severity is
+        // note/warning/error, which is about confidence, not impact.
+        severity: normaliseSeverity(a.rule?.security_severity_level ?? a.rule?.severity),
+        title: a.rule?.description ?? "Code scanning finding",
+        subject: a.rule?.id ?? "rule",
+        created_at: a.created_at,
+        age_days: daysSince(a.created_at),
+        html_url: a.html_url ?? "",
+      });
+    }
+    const fixed =
+      codeFixed.status === "fulfilled"
+        ? (codeFixed.value.data as unknown as RawAlert[])
+            .filter((a) => a.updated_at && isRecent(a.updated_at))
+            .map((a) => ({ created_at: a.created_at, fixed_at: a.updated_at! }))
+        : [];
+    sources.code_scanning = {
+      status: "ok",
+      open_count: open.length,
+      fixed_last_90d: codeFixed.status === "fulfilled" ? fixed.length : null,
+      mttr_days: computeMttr(fixed),
+    };
+  } else {
+    sources.code_scanning = {
+      status: statusFromError(codeRes.reason),
+      open_count: 0, fixed_last_90d: null, mttr_days: null,
+    };
+  }
+
+  // ── Secret scanning ─────────────────────────────────────────────────────
+  if (secretRes.status === "fulfilled") {
+    const open = secretRes.value.data as unknown as (RawAlert & {
+      secret_type_display_name?: string; secret_type?: string;
+    })[];
+    for (const a of open) {
+      alerts.push({
+        source: "secret_scanning",
+        number: a.number,
+        // A live leaked credential has no severity field and needs no triage
+        // discussion — it is always the most urgent thing on the page.
+        severity: "critical",
+        title: "Exposed secret detected",
+        subject: a.secret_type_display_name ?? a.secret_type ?? "secret",
+        created_at: a.created_at,
+        age_days: daysSince(a.created_at),
+        html_url: a.html_url ?? "",
+      });
+    }
+    const fixed =
+      secretFixed.status === "fulfilled"
+        ? (secretFixed.value.data as unknown as RawAlert[])
+            .filter((a) => a.updated_at && isRecent(a.updated_at))
+            .map((a) => ({ created_at: a.created_at, fixed_at: a.updated_at! }))
+        : [];
+    sources.secret_scanning = {
+      status: "ok",
+      open_count: open.length,
+      fixed_last_90d: secretFixed.status === "fulfilled" ? fixed.length : null,
+      mttr_days: computeMttr(fixed),
+    };
+  } else {
+    sources.secret_scanning = {
+      status: statusFromError(secretRes.reason),
+      open_count: 0, fixed_last_90d: null, mttr_days: null,
+    };
+  }
+
+  alerts.sort(
+    (a, b) =>
+      SEVERITY_ORDER[a.severity] - SEVERITY_ORDER[b.severity] || b.age_days - a.age_days,
+  );
+
+  const counts: Record<AlertSeverity, number> = { critical: 0, high: 0, medium: 0, low: 0 };
+  for (const a of alerts) counts[a.severity]++;
+
+  const statuses = Object.values(sources).map((s) => s.status);
+
+  return {
+    repo: `${owner}/${repo}`,
+    sources,
+    alerts: alerts.slice(0, MAX_ALERTS_RETURNED),
+    counts,
+    total_open: alerts.length,
+    oldest_open_days: alerts.length ? Math.max(...alerts.map((a) => a.age_days)) : null,
+    partial: statuses.some((s) => s !== "ok"),
+    needs_scope: statuses.includes("forbidden"),
+  };
+}

--- a/tests/security-alerts.test.ts
+++ b/tests/security-alerts.test.ts
@@ -1,0 +1,197 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+/**
+ * The property under test throughout: an unreadable source must never be
+ * indistinguishable from a clean one. On a security page that conflation
+ * would let a token permission gap read as "you're safe".
+ */
+
+const listDependabot = vi.fn();
+const listCodeScanning = vi.fn();
+const listSecretScanning = vi.fn();
+
+vi.mock("@/lib/github", () => ({
+  getOctokit: () => ({
+    rest: {
+      dependabot: { listAlertsForRepo: (...a: unknown[]) => listDependabot(...a) },
+      codeScanning: { listAlertsForRepo: (...a: unknown[]) => listCodeScanning(...a) },
+      secretScanning: { listAlertsForRepo: (...a: unknown[]) => listSecretScanning(...a) },
+    },
+  }),
+}));
+
+function httpError(status: number) {
+  const e = new Error(`HTTP ${status}`) as Error & { status: number };
+  e.status = status;
+  return e;
+}
+
+const daysAgo = (n: number) => new Date(Date.now() - n * 86_400_000).toISOString();
+
+function depAlert(over: Record<string, unknown> = {}) {
+  return {
+    number: 1,
+    state: "open",
+    created_at: daysAgo(10),
+    html_url: "https://github.com/o/r/security/dependabot/1",
+    security_advisory: { severity: "high", summary: "Prototype pollution", cve_id: "CVE-1" },
+    dependency: { package: { name: "lodash" } },
+    ...over,
+  };
+}
+
+beforeEach(() => {
+  // Default: every source readable and empty.
+  listDependabot.mockReset().mockResolvedValue({ data: [] });
+  listCodeScanning.mockReset().mockResolvedValue({ data: [] });
+  listSecretScanning.mockReset().mockResolvedValue({ data: [] });
+});
+
+async function run() {
+  const { getSecurityAlerts } = await import("@/lib/security-alerts");
+  return getSecurityAlerts("tok", "o", "r");
+}
+
+describe("getSecurityAlerts — clean repo", () => {
+  it("reports zero alerts with every source ok and nothing partial", async () => {
+    const r = await run();
+    expect(r.total_open).toBe(0);
+    expect(r.partial).toBe(false);
+    expect(r.needs_scope).toBe(false);
+    expect(r.oldest_open_days).toBeNull();
+    expect(Object.values(r.sources).every((s) => s.status === "ok")).toBe(true);
+  });
+});
+
+describe("getSecurityAlerts — permission and availability failures", () => {
+  it("marks a 403 source forbidden and flags needs_scope", async () => {
+    listDependabot.mockRejectedValue(httpError(403));
+    const r = await run();
+
+    expect(r.sources.dependabot.status).toBe("forbidden");
+    expect(r.needs_scope).toBe(true);
+    expect(r.partial).toBe(true);
+    // Crucially, this is NOT reported as a clean repo.
+    expect(r.sources.dependabot.open_count).toBe(0);
+  });
+
+  it("marks a 404 source not_enabled without claiming a scope problem", async () => {
+    listCodeScanning.mockRejectedValue(httpError(404));
+    const r = await run();
+
+    expect(r.sources.code_scanning.status).toBe("not_enabled");
+    expect(r.partial).toBe(true);
+    expect(r.needs_scope).toBe(false); // a disabled feature is not a permission gap
+  });
+
+  it("marks any other failure as error", async () => {
+    listSecretScanning.mockRejectedValue(httpError(500));
+    const r = await run();
+    expect(r.sources.secret_scanning.status).toBe("error");
+    expect(r.partial).toBe(true);
+  });
+
+  it("still returns readable sources when another one fails", async () => {
+    listDependabot.mockRejectedValue(httpError(403));
+    listCodeScanning.mockResolvedValue({
+      data: [{ number: 7, state: "open", created_at: daysAgo(2), html_url: "u",
+               rule: { security_severity_level: "critical", description: "SQL injection", id: "js/sql" } }],
+    });
+
+    const r = await run();
+    expect(r.sources.dependabot.status).toBe("forbidden");
+    expect(r.sources.code_scanning.status).toBe("ok");
+    expect(r.total_open).toBe(1);
+    expect(r.alerts[0].severity).toBe("critical");
+  });
+
+  it("never throws when every source fails", async () => {
+    listDependabot.mockRejectedValue(httpError(403));
+    listCodeScanning.mockRejectedValue(httpError(403));
+    listSecretScanning.mockRejectedValue(httpError(403));
+
+    const r = await run();
+    expect(r.total_open).toBe(0);
+    expect(r.partial).toBe(true);
+    expect(r.needs_scope).toBe(true);
+  });
+});
+
+describe("getSecurityAlerts — severity normalisation", () => {
+  it("maps GitHub's several vocabularies onto one scale", async () => {
+    listDependabot.mockResolvedValue({
+      data: [
+        depAlert({ number: 1, security_advisory: { severity: "critical", summary: "c" } }),
+        depAlert({ number: 2, security_advisory: { severity: "moderate", summary: "m" } }),
+        depAlert({ number: 3, security_advisory: { severity: "LOW", summary: "l" } }),
+      ],
+    });
+    const r = await run();
+    expect(r.counts.critical).toBe(1);
+    expect(r.counts.medium).toBe(1); // "moderate" → medium
+    expect(r.counts.low).toBe(1);
+  });
+
+  it("prefers security_severity_level over rule.severity for code scanning", async () => {
+    // rule.severity is about confidence (note/warning/error), not impact.
+    listCodeScanning.mockResolvedValue({
+      data: [{ number: 1, state: "open", created_at: daysAgo(1), html_url: "u",
+               rule: { security_severity_level: "critical", severity: "warning", description: "d", id: "r" } }],
+    });
+    const r = await run();
+    expect(r.alerts[0].severity).toBe("critical");
+  });
+
+  it("always treats an exposed secret as critical", async () => {
+    // Secret scanning alerts carry no severity field, and a live credential
+    // needs no triage debate.
+    listSecretScanning.mockResolvedValue({
+      data: [{ number: 1, state: "open", created_at: daysAgo(1), html_url: "u",
+               secret_type_display_name: "AWS Access Key" }],
+    });
+    const r = await run();
+    expect(r.alerts[0].severity).toBe("critical");
+    expect(r.alerts[0].subject).toBe("AWS Access Key");
+  });
+});
+
+describe("getSecurityAlerts — ordering and ageing", () => {
+  it("sorts by severity, then oldest first within a severity", async () => {
+    listDependabot.mockResolvedValue({
+      data: [
+        depAlert({ number: 1, created_at: daysAgo(1), security_advisory: { severity: "low", summary: "l" } }),
+        depAlert({ number: 2, created_at: daysAgo(5), security_advisory: { severity: "critical", summary: "c-new" } }),
+        depAlert({ number: 3, created_at: daysAgo(40), security_advisory: { severity: "critical", summary: "c-old" } }),
+      ],
+    });
+    const r = await run();
+    expect(r.alerts.map((a) => a.title)).toEqual(["c-old", "c-new", "l"]);
+  });
+
+  it("reports the age of the oldest open alert", async () => {
+    listDependabot.mockResolvedValue({
+      data: [depAlert({ created_at: daysAgo(47) }), depAlert({ number: 2, created_at: daysAgo(3) })],
+    });
+    const r = await run();
+    expect(r.oldest_open_days).toBe(47);
+  });
+
+  it("computes mean time to remediate from recently fixed alerts", async () => {
+    listDependabot
+      .mockResolvedValueOnce({ data: [] }) // open
+      .mockResolvedValueOnce({
+        data: [
+          { number: 9, state: "fixed", created_at: daysAgo(20), fixed_at: daysAgo(10) }, // 10d
+          { number: 8, state: "fixed", created_at: daysAgo(14), fixed_at: daysAgo(10) }, //  4d
+        ],
+      });
+    const r = await run();
+    expect(r.sources.dependabot.fixed_last_90d).toBe(2);
+    expect(r.sources.dependabot.mttr_days).toBe(7); // (10 + 4) / 2
+  });
+
+  it("reports a null MTTR rather than zero when nothing was fixed", async () => {
+    const r = await run();
+    expect(r.sources.dependabot.mttr_days).toBeNull();
+  });
+});


### PR DESCRIPTION
First of the four features you picked. The Security page lint-checked workflow YAML but showed **none of GitHub's own security findings** — so a page called *Security* couldn't say how many critical CVEs were open or whether a credential was currently leaked.

## Summary

New panel above the workflow analysis (a live CVE outranks a YAML anti-pattern), covering three sources:

| Source | Reports |
|---|---|
| **Dependabot** | Vulnerable dependencies, advisory severity, CVE |
| **Code scanning** | CodeQL / third-party findings |
| **Secret scanning** | Committed credentials — always ranked critical |

Plus severity counts, age of the oldest open alert, and per-source **mean time to remediate** over 90 days. That turns "we fix things quickly" into a number.

## The design rule this is built around

**An unreadable source must never look like a clean one.**

Each source carries its own status — `ok` / `forbidden` / `not_enabled` / `error` — rather than collapsing into one request-level success. A 403 renders as a loud actionable warning; a genuinely clean repo renders calm green.

Showing "0 alerts" when the real answer is "we couldn't check" would turn a token permission gap into **false confidence on a security page**. Every failure mode has a test, including all three sources failing at once.

`404` is also handled separately as *not enabled for this repo* — a different problem needing a different fix, so it shouldn't be conflated with a permission error.

## ⚠️ Your token will likely be refused at first

These endpoints need the **`security_events`** scope, which GitDash has never requested. The panel says exactly that and how to fix it, for both classic and fine-grained PATs — rather than surfacing a generic error.

Worth knowing before you open the page and wonder why it's empty.

## Severity normalisation

GitHub uses several vocabularies. Dependabot `moderate` → medium. Code scanning prefers `security_severity_level` over `rule.severity`, because the latter is rule *confidence* (note/warning/error), not impact. Secret scanning has no severity field at all — always critical, since a live credential needs no triage debate.

## Test plan

- [x] `pnpm exec tsc --noEmit` — **0 errors**
- [x] `pnpm test` — **291/291** (278 → 291, +13)
- [x] `pnpm run lint` — **0 errors** (11 pre-existing warnings, unchanged)
- [x] `rm -rf .next && pnpm run build` — succeeds, route emits
- [x] API Reference parity — clean
- [x] Version bumped in all locations; release-notes entries verified intact

## Rollback

1. Disable the Security Scan feature flag — hides the page including this panel
2. Promote the v4.1.5 deployment
3. `git revert` — no schema change

## Next

Three remaining from your selection: real deployments → honest DORA (v4.2.1), issues & triage health (v4.2.2), ⌘K palette + the 11 reload bugs (v4.2.3).