### PR TITLE
feat: v4.2.1 — real deployment metrics, and honest provenance for DORA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,58 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ---
 
+## [4.2.1] — 2026-08-15
+
+### Overview
+The DORA figures on the repository overview were **inferred from naming conventions, not measured**. This adds real delivery metrics from GitHub's Deployments API — and, just as importantly, makes the app state which of the two you are looking at.
+
+### The problem
+
+| Metric | Previous derivation | How it failed |
+| --- | --- | --- |
+| Deploy frequency | GitHub Releases → **falls back to every merged PR** | A team that doesn't tag releases had its *merge rate* reported as its deploy rate |
+| Change failure rate | PRs whose branch matches `/hotfix\|revert\|fix-prod\|emergency/` | A team that doesn't use those names got **exactly 0%** — which reads as excellence, not as no signal |
+| MTTR | How long those PRs took to merge | Same fragility, plus it measured *merge speed*, not recovery |
+
+These are reasonable proxies. The danger is that they fail **quietly and flatteringly**.
+
+### Added
+
+#### Deployments panel (`/repos/[owner]/[repo]`)
+- Real deploy frequency, change failure rate and MTTR from GitHub's Deployments API, with a per-environment breakdown and recent rollout history.
+- Production environment is detected by convention (`production`, `prod`, `live`, `main`), falling back to the busiest environment.
+- New `GET /api/github/deployments`, cached 10 minutes.
+
+### Changed
+
+#### Provenance is now explicit
+- Measured figures **never silently replace** estimated ones. The response carries `source`, and the panel is labelled **Measured** when real deployments exist.
+- When a repo has no deployments, the panel *explains what the DORA cards above actually represent* rather than hiding. Knowing whether a number was measured or inferred matters more than the number.
+- The DORA metrics reference now documents both definitions side by side.
+
+#### Definitions that avoid flattering the numbers
+- **Only successful production deploys** count toward frequency — a failed rollout is not a delivery.
+- Pending and in-progress deploys are excluded from the failure rate entirely; a rate with nothing conclusive returns **null rather than 0%**.
+- MTTR measures from the **first failure of a streak** to the next success, because recovery starts when things broke, not at the last symptom before the fix.
+- A deployment with no status is treated as inconclusive, never as a failure.
+- MTTR built from a single recovery is labelled as an anecdote in the UI rather than presented as a trend.
+
+### Cost
+- One call to list deployments, then status lookups for the 40 most recent (concurrency 8) — bounded, and `partial` is set when the sample was truncated or a lookup failed.
+
+### Verified
+- Test count 291 → 308, covering provenance, production-environment selection, rate exclusions, streak-aware MTTR, unrecovered failures, and partial-sample resilience.
+
+### Rollback
+1. **Promote the v4.2.0 Vercel deployment** — instant.
+2. **`git revert`** — the panel is additive and the existing DORA calculation is untouched; no schema change.
+
+### Changed (infra)
+- Bumped app version from 4.2.0 to 4.2.1
+- Bumped Helm chart version from 0.6.0 to 0.6.1
+
+---
+
 ## [4.2.0] — 2026-08-15
 
 ### Overview

--- a/helm/gitdash/Chart.yaml
+++ b/helm/gitdash/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: gitdash
 description: Self-hosted GitHub Actions metrics dashboard (standalone PAT or GitHub OAuth)
 type: application
-version: 0.6.0
-appVersion: "4.2.0"
+version: 0.6.1
+appVersion: "4.2.1"
 keywords:
   - github-actions
   - dashboard

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gitdash",
-  "version": "4.2.0",
+  "version": "4.2.1",
   "private": true,
   "packageManager": "pnpm@10.30.3",
   "scripts": {

--- a/src/app/api/github/deployments/route.ts
+++ b/src/app/api/github/deployments/route.ts
@@ -1,0 +1,47 @@
+/**
+ * GET /api/github/deployments — measured delivery metrics.
+ *
+ * Returns source: "deployments" when the repo actually uses GitHub's
+ * Deployments API, and "none" when it does not. The caller keeps its existing
+ * release/PR estimates in the latter case — this never silently replaces one
+ * with the other, because knowing whether a figure was measured or inferred
+ * matters more than the figure.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { getTokenFromSession } from "@/lib/session";
+import { getDeploymentsSummary } from "@/lib/deployments";
+import { withCache, hashKey } from "@/lib/cache";
+import { validateOwner, validateRepo, safeError } from "@/lib/validation";
+
+export type {
+  DeploymentsSummary, DeploymentRecord, EnvironmentStat, DeployMetricSource,
+} from "@/lib/deployments";
+
+export const maxDuration = 60;
+
+const CACHE_TTL = 600; // 10 min — up to 41 API calls on a miss
+
+export async function GET(req: NextRequest) {
+  const token = await getTokenFromSession();
+  if (!token) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const { searchParams } = new URL(req.url);
+  const ownerResult = validateOwner(searchParams.get("owner"));
+  if (!ownerResult.ok) return ownerResult.response;
+  const repoResult = validateRepo(searchParams.get("repo"));
+  if (!repoResult.ok) return repoResult.response;
+
+  try {
+    const data = await withCache(
+      `deployments:${hashKey(token)}:${ownerResult.data}/${repoResult.data}`,
+      CACHE_TTL,
+      () => getDeploymentsSummary(token, ownerResult.data, repoResult.data),
+    );
+    return NextResponse.json(data, {
+      headers: { "Cache-Control": `private, max-age=${CACHE_TTL}` },
+    });
+  } catch (e) {
+    return safeError(e, "Failed to fetch deployments");
+  }
+}

--- a/src/app/docs/page.tsx
+++ b/src/app/docs/page.tsx
@@ -1895,6 +1895,35 @@ function MetricsDora() {
             ["Time to Restore (MTTR)", "How quickly the team recovers from a production failure", "Average cycle time (open → merged) of hotfix/revert PRs identified in the Change Failure Rate calculation.", "Elite: <1h · High: <1d · Medium: <1wk · Low: ≥1wk"],
           ]}
         />
+
+        <div className="flex items-center gap-2 mt-5 mb-2">
+          <SubHeading>Measured vs estimated</SubHeading>
+          <VersionBadge v="4.2.1" />
+        </div>
+        <ProseP>
+          The calculations above are <strong>estimates</strong>, and they fail quietly. A team that
+          does not tag releases has its <em>merge rate</em> reported as its deploy rate. A team that
+          does not name branches <Code>hotfix</Code> or <Code>revert</Code> gets a change failure
+          rate of exactly 0% — which reads as excellence rather than as no signal.
+        </ProseP>
+        <ProseP>
+          When a repository actually uses GitHub&apos;s <strong>Deployments API</strong>, the same
+          three metrics become measurable and appear in a separate <strong>Deployments</strong> panel
+          on the repository overview, labelled <em>Measured</em>:
+        </ProseP>
+        <DocTable
+          headers={["Metric", "Measured definition"]}
+          rows={[
+            ["Deploy Frequency", "Successful production deployments per day. A failed rollout is not a delivery, so it does not count."],
+            ["Change Failure Rate", "Failed ÷ conclusive production deployments. Pending and in-progress deploys are excluded entirely."],
+            ["Time to Restore (MTTR)", "Hours from the first failure of a streak to the next successful deploy on that environment — when it broke, not the last symptom before the fix."],
+          ]}
+        />
+        <Callout type="info">
+          The measured figures never silently replace the estimated ones. If a repo has no
+          deployments, the panel says so and explains what the numbers above actually represent.
+          Knowing which of the two you are reading matters more than the number itself.
+        </Callout>
       </DocCard>
       <DocCard>
         <SubHeading>Throughput &amp; Velocity</SubHeading>
@@ -2590,6 +2619,15 @@ function APIReference() {
         },
         {
           method: "GET",
+          path: "/api/github/deployments",
+          description: "Measured delivery metrics from GitHub's Deployments API. Returns { source, production_environment, deploys_per_day, change_failure_rate_pct, mttr_hours, mttr_samples, by_environment[], recent[], partial }. source is \"deployments\" when the repo genuinely uses the API and \"none\" otherwise — the caller keeps its release/PR estimates in that case rather than being handed zeros. Rates exclude pending and in-progress deploys, and return null rather than 0% when nothing is conclusive.",
+          params: [
+            { name: "owner", type: "string", optional: false, desc: "Repository owner" },
+            { name: "repo", type: "string", optional: false, desc: "Repository name" },
+          ],
+        },
+        {
+          method: "GET",
           path: "/api/github/security-alerts",
           description: "GitHub's own security findings: Dependabot, code scanning and secret scanning alerts. Returns { sources, alerts[], counts, total_open, oldest_open_days, partial, needs_scope } where each source carries its own status (ok | forbidden | not_enabled | error) plus 90-day fix count and mean time to remediate. Requires the security_events scope; a 403 on any source sets needs_scope rather than failing the request, so an unreadable source is never reported as a clean one.",
           params: [
@@ -2880,9 +2918,27 @@ pnpm run lint`}
 function ReleaseNotes() {
   const releases = [
     {
-      version: "4.2.0",
+      version: "4.2.1",
       date: "2026-08-15",
       badge: "latest",
+      badgeColor: "bg-emerald-500/15 text-emerald-400 border-emerald-500/20",
+      changes: {
+        added: [
+          "Deployments panel on the repository overview, using GitHub's Deployments API — real deploy frequency, change failure rate and MTTR, plus a per-environment breakdown and recent rollout history",
+          "MTTR is measured from the first failure of a streak to the next successful deploy on the same environment, which is when things actually broke rather than the last symptom before the fix",
+        ],
+        fixed: [],
+        improved: [
+          "DORA figures now state their provenance. Until now deploy frequency came from Releases (falling back to counting every merged PR), and change failure rate from PRs whose branch matched /hotfix|revert|emergency/ — so a team that does not tag releases had its merge rate reported as its deploy rate, and a team that does not name branches \"hotfix\" got a change failure rate of exactly 0%, which reads as excellence rather than as no signal",
+          "Measured figures never silently replace estimated ones. When a repo has no deployments the panel explains what the existing numbers actually mean instead of hiding, so you always know which you are reading",
+          "Only successful production deploys count toward frequency — a failed rollout is not a delivery. Pending and in-progress deploys are excluded from the failure rate entirely, and a rate with nothing conclusive reports null rather than a flattering 0%",
+        ],
+      },
+    },
+    {
+      version: "4.2.0",
+      date: "2026-08-15",
+      badge: null,
       badgeColor: "bg-emerald-500/15 text-emerald-400 border-emerald-500/20",
       changes: {
         added: [
@@ -3448,7 +3504,7 @@ function DocSidebar({
           <BookOpen className="w-4 h-4 text-violet-400" />
           <span className="text-sm font-semibold text-white">GitDash Docs</span>
           <span className="text-xs px-1.5 py-0.5 rounded bg-violet-500/15 text-violet-400 border border-violet-500/20 font-mono">
-            v{process.env.NEXT_PUBLIC_APP_VERSION ?? "4.2.0"}
+            v{process.env.NEXT_PUBLIC_APP_VERSION ?? "4.2.1"}
           </span>
         </div>
         {/* Mobile close */}
@@ -3698,7 +3754,7 @@ export default function DocsPage() {
 
           {/* Footer */}
           <footer className="mt-8 pb-4 text-center text-xs text-slate-600 space-y-1">
-            <p>GitDash v{process.env.NEXT_PUBLIC_APP_VERSION ?? "4.2.0"} — GitHub Actions Dashboard</p>
+            <p>GitDash v{process.env.NEXT_PUBLIC_APP_VERSION ?? "4.2.1"} — GitHub Actions Dashboard</p>
             <p>
               <a href="https://github.com/dinhdobathi1992/gitdash" target="_blank" rel="noreferrer" className="hover:text-slate-400 transition-colors">
                 Open source on GitHub

--- a/src/app/repos/[owner]/[repo]/page.tsx
+++ b/src/app/repos/[owner]/[repo]/page.tsx
@@ -13,6 +13,7 @@ import { RunHistoryBars, TrendSparkline, StatusBadge, HealthScoreRing } from "@/
 import { DoraKpiCards, DoraKpiSkeleton } from "@/components/DoraKpiCards";
 import PartialDataBadge from "@/components/PartialDataBadge";
 import AiInsightsCard from "@/components/AiInsightsCard";
+import DeploymentsPanel from "@/components/DeploymentsPanel";
 import type { OpenPrHealthResponse } from "@/app/api/github/open-pr-health/route";
 import {
   AlertCircle, ExternalLink, GitBranch, FileCode, RefreshCw,
@@ -479,6 +480,11 @@ export default function RepoDetailPage() {
               DORA Metrics are disabled — enable in <a href="/settings" className="text-violet-400 hover:underline ml-1">Settings → Feature Flags</a>
             </div>
           )}
+
+          {/* Deployments — sits directly beneath the DORA cards because it
+              qualifies them: measured figures when the repo uses GitHub
+              deployments, otherwise an explanation of what "estimated" means. */}
+          {flags.dora && <DeploymentsPanel owner={owner} repo={repo} />}
 
           {/* PR Lifecycle Extension */}
           {flags.prLifecycle ? (

--- a/src/components/DeploymentsPanel.tsx
+++ b/src/components/DeploymentsPanel.tsx
@@ -1,0 +1,233 @@
+"use client";
+
+/**
+ * Deployment metrics panel (v4.2.1).
+ *
+ * The point of this panel is provenance as much as data. The DORA cards above
+ * it are inferred from releases and branch names; when a repo genuinely uses
+ * the Deployments API, the same three metrics can be measured — and the
+ * difference between "measured" and "estimated" is stated plainly rather than
+ * quietly improving the numbers.
+ *
+ * When a repo has no deployments, this renders a short explanation of what the
+ * existing figures actually mean, which is more useful than hiding.
+ */
+
+import useSWR from "swr";
+import { fetcher } from "@/lib/swr";
+import type { DeploymentsSummary } from "@/app/api/github/deployments/route";
+import {
+  Rocket, CheckCircle2, XCircle, Clock, Info, AlertTriangle, GitBranch,
+} from "lucide-react";
+import { cn } from "@/lib/utils";
+
+function StateDot({ state }: { state: string | null }) {
+  const cls =
+    state === "success" ? "bg-emerald-400"
+      : state === "failure" || state === "error" ? "bg-red-400"
+      : state === "in_progress" || state === "pending" ? "bg-amber-400"
+      : "bg-slate-600";
+  return <span className={cn("w-1.5 h-1.5 rounded-full shrink-0", cls)} />;
+}
+
+export default function DeploymentsPanel({ owner, repo }: { owner: string; repo: string }) {
+  const { data, error, isLoading } = useSWR<DeploymentsSummary>(
+    `/api/github/deployments?owner=${encodeURIComponent(owner)}&repo=${encodeURIComponent(repo)}`,
+    fetcher<DeploymentsSummary>,
+  );
+
+  if (isLoading) {
+    return (
+      <div className="rounded-2xl border border-slate-800 bg-slate-900/40 p-5">
+        <div className="h-4 w-40 rounded skeleton mb-3" />
+        <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+          {Array.from({ length: 4 }).map((_, i) => <div key={i} className="h-16 rounded-xl skeleton" />)}
+        </div>
+      </div>
+    );
+  }
+
+  if (error || !data) return null;
+
+  // No deployments recorded — explain what the DORA cards above are actually
+  // measuring, rather than leaving the reader to assume they are exact.
+  if (data.source === "none") {
+    return (
+      <div className="rounded-2xl border border-slate-800 bg-slate-900/40 p-5">
+        <div className="flex items-start gap-3">
+          <span className="shrink-0 w-9 h-9 rounded-lg border border-slate-700 bg-slate-800/60 flex items-center justify-center">
+            <Rocket className="w-4 h-4 text-slate-400" />
+          </span>
+          <div className="min-w-0">
+            <h3 className="text-[15px] font-semibold text-white">Deployments</h3>
+            <p className="text-xs text-slate-500 mt-1 leading-relaxed">
+              This repository has no deployments recorded through GitHub&apos;s Deployments API in
+              the last {data.period_days} days, so the DORA figures above are{" "}
+              <strong className="text-slate-400">estimated</strong>: deployment frequency from
+              releases (or merged PRs when there are no releases), and change failure rate from PRs
+              whose branch looks like a hotfix or revert.
+            </p>
+            <p className="text-xs text-slate-500 mt-2 leading-relaxed">
+              If your pipeline creates GitHub deployments, those numbers become measured instead —
+              actual deploys, actual failed rollouts, actual recovery time.
+            </p>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  const cfr = data.change_failure_rate_pct;
+
+  return (
+    <div className="rounded-2xl border border-emerald-500/20 bg-emerald-500/[0.03] overflow-hidden">
+      <div className="flex items-start gap-4 p-5 border-b border-emerald-500/15">
+        <span className="shrink-0 w-9 h-9 rounded-lg border border-emerald-500/30 bg-emerald-500/[0.12] flex items-center justify-center">
+          <Rocket className="w-4 h-4 text-emerald-300" />
+        </span>
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-2 flex-wrap">
+            <h3 className="text-[15px] font-semibold text-white">Deployments</h3>
+            <span className="text-[10px] font-semibold uppercase tracking-wide px-2 py-0.5 rounded-full border border-emerald-500/25 bg-emerald-500/10 text-emerald-300">
+              Measured
+            </span>
+          </div>
+          <p className="text-xs text-slate-500 mt-0.5">
+            From GitHub&apos;s Deployments API — actual rollouts, not inferred from releases or
+            branch names.
+            {data.production_environment && (
+              <> Production environment: <span className="font-mono text-slate-400">{data.production_environment}</span>.</>
+            )}
+          </p>
+        </div>
+      </div>
+
+      <div className="p-5 space-y-4">
+        <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+          <Metric
+            label="Deploys / day"
+            value={data.deploys_per_day !== null ? data.deploys_per_day.toFixed(2) : "—"}
+            note="successful, production"
+            tone="emerald"
+          />
+          <Metric
+            label="Change fail rate"
+            value={cfr !== null ? `${cfr}%` : "—"}
+            note={cfr === null ? "no conclusive deploys" : "failed / conclusive"}
+            tone={cfr === null ? "slate" : cfr >= 15 ? "red" : cfr >= 5 ? "amber" : "emerald"}
+          />
+          <Metric
+            label="MTTR"
+            value={data.mttr_hours !== null ? `${data.mttr_hours}h` : "—"}
+            note={
+              data.mttr_samples === 0
+                ? "no failures to recover from"
+                : `${data.mttr_samples} recovery${data.mttr_samples === 1 ? "" : "s"}`
+            }
+            tone="slate"
+          />
+          <Metric
+            label="Total"
+            value={String(data.total_deployments)}
+            note={`${data.successful} ok · ${data.failed} failed`}
+            tone="slate"
+          />
+        </div>
+
+        {/* A single recovery is an anecdote, not a metric. Say so. */}
+        {data.mttr_samples === 1 && (
+          <p className="flex items-start gap-1.5 text-[11px] text-slate-500">
+            <Info className="w-3 h-3 mt-0.5 shrink-0" />
+            MTTR is based on a single recovery — treat it as an anecdote rather than a trend.
+          </p>
+        )}
+
+        {data.by_environment.length > 1 && (
+          <div>
+            <p className="text-[10.5px] font-semibold uppercase tracking-[0.12em] text-slate-500 mb-2">
+              By environment
+            </p>
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+              {data.by_environment.map((env) => (
+                <div
+                  key={env.environment}
+                  className={cn(
+                    "flex items-center gap-3 px-3.5 py-2.5 rounded-xl border",
+                    env.environment === data.production_environment
+                      ? "border-emerald-500/25 bg-emerald-500/[0.05]"
+                      : "border-slate-800 bg-slate-900/40",
+                  )}
+                >
+                  <GitBranch className="w-3.5 h-3.5 shrink-0 text-slate-500" />
+                  <span className="font-mono text-xs text-slate-200 truncate flex-1">
+                    {env.environment}
+                  </span>
+                  <span className="text-[11px] text-slate-500 tabular-nums shrink-0">
+                    {env.total} deploy{env.total === 1 ? "" : "s"}
+                    {env.failure_rate_pct !== null && ` · ${env.failure_rate_pct}% fail`}
+                  </span>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {data.recent.length > 0 && (
+          <div>
+            <p className="text-[10.5px] font-semibold uppercase tracking-[0.12em] text-slate-500 mb-2">
+              Recent
+            </p>
+            <div className="rounded-xl border border-slate-800 overflow-hidden">
+              {data.recent.slice(0, 8).map((d) => (
+                <div
+                  key={d.id}
+                  className="flex items-center gap-3 px-3.5 py-2 border-b border-slate-800/60 last:border-b-0 text-xs"
+                >
+                  <StateDot state={d.state} />
+                  <span className="font-mono text-slate-300 truncate w-24 shrink-0">
+                    {d.environment}
+                  </span>
+                  <span className="font-mono text-slate-500 truncate flex-1">{d.ref || d.sha.slice(0, 7)}</span>
+                  <span className="text-slate-600 shrink-0 tabular-nums">
+                    {new Date(d.created_at).toLocaleDateString()}
+                  </span>
+                  {d.state === "success" && <CheckCircle2 className="w-3 h-3 text-emerald-400 shrink-0" />}
+                  {(d.state === "failure" || d.state === "error") && <XCircle className="w-3 h-3 text-red-400 shrink-0" />}
+                  {(d.state === "pending" || d.state === "in_progress") && <Clock className="w-3 h-3 text-amber-400 shrink-0" />}
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {data.partial && (
+          <p className="flex items-start gap-1.5 text-[11px] text-slate-500">
+            <AlertTriangle className="w-3 h-3 mt-0.5 shrink-0 text-slate-600" />
+            Status was resolved for the most recent deployments only, so rates are based on a
+            partial sample.
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function Metric({
+  label, value, note, tone,
+}: {
+  label: string; value: string; note: string; tone: "emerald" | "amber" | "red" | "slate";
+}) {
+  const color = {
+    emerald: "text-emerald-400", amber: "text-amber-400",
+    red: "text-red-400", slate: "text-slate-100",
+  }[tone];
+  return (
+    <div className="rounded-xl border border-slate-800 bg-slate-900/50 p-3.5">
+      <div className="text-[10.5px] font-semibold uppercase tracking-[0.12em] text-slate-500 mb-1.5">
+        {label}
+      </div>
+      <div className={cn("font-mono text-2xl font-bold tabular-nums leading-none", color)}>{value}</div>
+      <div className="text-[11px] text-slate-600 mt-1.5">{note}</div>
+    </div>
+  );
+}

--- a/src/lib/deployments.ts
+++ b/src/lib/deployments.ts
@@ -1,0 +1,263 @@
+/**
+ * Real deployment metrics from GitHub's Deployments API (v4.2.1).
+ *
+ * ── Why this exists ───────────────────────────────────────────────────────
+ * The DORA figures on the repo overview were inferred, not measured:
+ *
+ *   deploy frequency  ← GitHub Releases, falling back to *every merged PR*
+ *   change fail rate  ← PRs whose branch matches /hotfix|revert|emergency/
+ *   MTTR              ← how long those PRs took to merge
+ *
+ * Those proxies fail quietly. A team that does not tag releases has its merge
+ * rate reported as its deploy rate. A team that does not name branches
+ * "hotfix" gets a change failure rate of exactly 0% — which reads as
+ * excellence rather than as no signal.
+ *
+ * When a repo actually uses the Deployments API, all three become measurable:
+ * a deployment is a deployment, a failed deployment status is a failure, and
+ * recovery is the gap until the next success on that environment.
+ *
+ * ── The honest part ───────────────────────────────────────────────────────
+ * Many repos do not use deployments at all, so this never replaces the old
+ * numbers silently. It reports `source`, and the UI states whether a figure
+ * was measured or estimated. Knowing which you are looking at matters more
+ * than the figure itself.
+ */
+
+import { getOctokit } from "@/lib/github";
+import { pLimitSettled } from "@/lib/concurrency";
+
+/** Where a metric came from. Surfaced in the UI — never hidden. */
+export type DeployMetricSource = "deployments" | "none";
+
+export interface DeploymentRecord {
+  id: number;
+  environment: string;
+  /** GitHub's deployment status state, or null when it never reported one. */
+  state: "success" | "failure" | "error" | "pending" | "in_progress" | "inactive" | null;
+  created_at: string;
+  /** When the terminal status landed — used for recovery timing. */
+  status_at: string | null;
+  ref: string;
+  sha: string;
+}
+
+export interface EnvironmentStat {
+  environment: string;
+  total: number;
+  success: number;
+  failed: number;
+  /** Null when nothing conclusive was recorded for this environment. */
+  failure_rate_pct: number | null;
+}
+
+export interface DeploymentsSummary {
+  repo: string;
+  source: DeployMetricSource;
+  /** Environment treated as production for headline figures. */
+  production_environment: string | null;
+  period_days: number;
+  total_deployments: number;
+  successful: number;
+  failed: number;
+  /** Successful production deployments per day. Null when unmeasurable. */
+  deploys_per_day: number | null;
+  /** Failed / conclusive production deployments. Null when unmeasurable. */
+  change_failure_rate_pct: number | null;
+  /** Mean hours from a failed production deploy to the next success. */
+  mttr_hours: number | null;
+  /** How many recovery pairs the MTTR is based on — 1 is not a trend. */
+  mttr_samples: number;
+  by_environment: EnvironmentStat[];
+  recent: DeploymentRecord[];
+  /** True when some status fetches failed — figures are from a partial sample. */
+  partial: boolean;
+}
+
+/** Status lookups are one call each, so the newest slice is the bounded part. */
+const MAX_STATUS_LOOKUPS = 40;
+const MAX_RECENT_RETURNED = 15;
+const DEFAULT_PERIOD_DAYS = 30;
+
+/** Names teams actually use for production, in preference order. */
+const PRODUCTION_NAMES = ["production", "prod", "live", "main"];
+
+function pickProductionEnvironment(records: DeploymentRecord[]): string | null {
+  if (records.length === 0) return null;
+
+  const counts = new Map<string, number>();
+  for (const r of records) counts.set(r.environment, (counts.get(r.environment) ?? 0) + 1);
+
+  for (const name of PRODUCTION_NAMES) {
+    for (const env of counts.keys()) {
+      if (env.toLowerCase() === name) return env;
+    }
+  }
+  // No conventional name — fall back to the busiest environment, which is
+  // very nearly always the one that matters.
+  return [...counts.entries()].sort((a, b) => b[1] - a[1])[0][0];
+}
+
+const isSuccess = (r: DeploymentRecord) => r.state === "success";
+const isFailure = (r: DeploymentRecord) => r.state === "failure" || r.state === "error";
+
+/**
+ * Mean hours from each failed production deployment to the next successful
+ * one on the same environment — the actual definition of recovery, rather
+ * than how fast someone merged a branch named "hotfix".
+ */
+function computeMttr(records: DeploymentRecord[]): { hours: number | null; samples: number } {
+  const chronological = [...records].sort(
+    (a, b) => new Date(a.created_at).getTime() - new Date(b.created_at).getTime(),
+  );
+
+  const gaps: number[] = [];
+  let failedAt: number | null = null;
+
+  for (const r of chronological) {
+    const ts = new Date(r.status_at ?? r.created_at).getTime();
+    if (isFailure(r)) {
+      // Keep the FIRST failure of a streak: recovery is measured from when
+      // things broke, not from the last symptom before they were fixed.
+      if (failedAt === null) failedAt = ts;
+    } else if (isSuccess(r) && failedAt !== null) {
+      if (ts > failedAt) gaps.push((ts - failedAt) / 3_600_000);
+      failedAt = null;
+    }
+  }
+
+  if (gaps.length === 0) return { hours: null, samples: 0 };
+  const mean = gaps.reduce((s, g) => s + g, 0) / gaps.length;
+  return { hours: Math.round(mean * 10) / 10, samples: gaps.length };
+}
+
+export async function getDeploymentsSummary(
+  token: string,
+  owner: string,
+  repo: string,
+  periodDays: number = DEFAULT_PERIOD_DAYS,
+): Promise<DeploymentsSummary> {
+  const octokit = getOctokit(token);
+
+  const empty: DeploymentsSummary = {
+    repo: `${owner}/${repo}`,
+    source: "none",
+    production_environment: null,
+    period_days: periodDays,
+    total_deployments: 0,
+    successful: 0,
+    failed: 0,
+    deploys_per_day: null,
+    change_failure_rate_pct: null,
+    mttr_hours: null,
+    mttr_samples: 0,
+    by_environment: [],
+    recent: [],
+    partial: false,
+  };
+
+  let deployments: { id: number; environment: string; created_at: string; ref: string; sha: string }[];
+  try {
+    const { data } = await octokit.rest.repos.listDeployments({ owner, repo, per_page: 100 });
+    deployments = data.map((d) => ({
+      id: d.id,
+      environment: d.environment ?? "unknown",
+      created_at: d.created_at,
+      ref: d.ref ?? "",
+      sha: d.sha ?? "",
+    }));
+  } catch {
+    // 404 on a repo with deployments disabled, or no access. Either way there
+    // is nothing to measure and the caller keeps its existing estimates.
+    return empty;
+  }
+
+  const cutoff = Date.now() - periodDays * 86_400_000;
+  const inWindow = deployments.filter((d) => new Date(d.created_at).getTime() >= cutoff);
+  if (inWindow.length === 0) return empty;
+
+  // Statuses are one request per deployment, so only the newest slice is
+  // resolved. Everything older still counts toward volume.
+  const toResolve = inWindow.slice(0, MAX_STATUS_LOOKUPS);
+  const settled = await pLimitSettled(
+    toResolve.map((d) => async () => {
+      const { data } = await octokit.rest.repos.listDeploymentStatuses({
+        owner, repo, deployment_id: d.id, per_page: 10,
+      });
+      return { id: d.id, statuses: data };
+    }),
+    { concurrency: 8 },
+  );
+
+  let partial = false;
+  const statusById = new Map<number, { state: string; created_at: string }>();
+  for (const res of settled) {
+    if (res.status === "rejected") {
+      partial = true;
+      continue;
+    }
+    const { id, statuses } = res.value;
+    // listDeploymentStatuses returns newest first — index 0 is current state.
+    const latest = statuses[0];
+    if (latest) statusById.set(id, { state: latest.state, created_at: latest.created_at });
+  }
+
+  const records: DeploymentRecord[] = inWindow.map((d) => {
+    const s = statusById.get(d.id);
+    return {
+      id: d.id,
+      environment: d.environment,
+      state: (s?.state as DeploymentRecord["state"]) ?? null,
+      created_at: d.created_at,
+      status_at: s?.created_at ?? null,
+      ref: d.ref,
+      sha: d.sha,
+    };
+  });
+
+  const productionEnvironment = pickProductionEnvironment(records);
+  const production = records.filter((r) => r.environment === productionEnvironment);
+
+  const prodSuccess = production.filter(isSuccess).length;
+  const prodFailed = production.filter(isFailure).length;
+  const prodConclusive = prodSuccess + prodFailed;
+
+  const byEnvironment = new Map<string, EnvironmentStat>();
+  for (const r of records) {
+    const stat = byEnvironment.get(r.environment) ?? {
+      environment: r.environment, total: 0, success: 0, failed: 0, failure_rate_pct: null,
+    };
+    stat.total++;
+    if (isSuccess(r)) stat.success++;
+    if (isFailure(r)) stat.failed++;
+    byEnvironment.set(r.environment, stat);
+  }
+  for (const stat of byEnvironment.values()) {
+    const conclusive = stat.success + stat.failed;
+    stat.failure_rate_pct = conclusive > 0 ? Math.round((stat.failed / conclusive) * 100) : null;
+  }
+
+  const { hours: mttrHours, samples: mttrSamples } = computeMttr(production);
+
+  return {
+    repo: `${owner}/${repo}`,
+    source: "deployments",
+    production_environment: productionEnvironment,
+    period_days: periodDays,
+    total_deployments: records.length,
+    successful: records.filter(isSuccess).length,
+    failed: records.filter(isFailure).length,
+    // Frequency counts SUCCESSFUL production deploys: a failed rollout is not
+    // a delivery, and counting it would flatter the number.
+    deploys_per_day: Math.round((prodSuccess / periodDays) * 100) / 100,
+    change_failure_rate_pct:
+      prodConclusive > 0 ? Math.round((prodFailed / prodConclusive) * 100) : null,
+    mttr_hours: mttrHours,
+    mttr_samples: mttrSamples,
+    by_environment: [...byEnvironment.values()].sort((a, b) => b.total - a.total),
+    recent: records
+      .sort((a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime())
+      .slice(0, MAX_RECENT_RETURNED),
+    partial: partial || inWindow.length > toResolve.length,
+  };
+}

--- a/tests/deployments.test.ts
+++ b/tests/deployments.test.ts
@@ -1,0 +1,248 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+/**
+ * The guarantee under test: measured figures never silently replace estimated
+ * ones. `source` always says which you are looking at, and a repo with no
+ * deployments returns "none" rather than zeros that would read as real.
+ */
+
+const listDeployments = vi.fn();
+const listDeploymentStatuses = vi.fn();
+
+vi.mock("@/lib/github", () => ({
+  getOctokit: () => ({
+    rest: {
+      repos: {
+        listDeployments: (...a: unknown[]) => listDeployments(...a),
+        listDeploymentStatuses: (...a: unknown[]) => listDeploymentStatuses(...a),
+      },
+    },
+  }),
+}));
+
+const hoursAgo = (h: number) => new Date(Date.now() - h * 3_600_000).toISOString();
+const daysAgo = (d: number) => new Date(Date.now() - d * 86_400_000).toISOString();
+
+function dep(id: number, environment: string, created_at: string) {
+  return { id, environment, created_at, ref: "main", sha: `sha${id}` };
+}
+
+/** Status lookups are keyed by deployment_id, so drive them from a map. */
+function statusMap(m: Record<number, { state: string; at: string }>) {
+  listDeploymentStatuses.mockImplementation(async ({ deployment_id }: { deployment_id: number }) => {
+    const s = m[deployment_id];
+    return { data: s ? [{ state: s.state, created_at: s.at }] : [] };
+  });
+}
+
+beforeEach(() => {
+  listDeployments.mockReset().mockResolvedValue({ data: [] });
+  listDeploymentStatuses.mockReset().mockResolvedValue({ data: [] });
+});
+
+async function run(periodDays = 30) {
+  const { getDeploymentsSummary } = await import("@/lib/deployments");
+  return getDeploymentsSummary("tok", "o", "r", periodDays);
+}
+
+describe("getDeploymentsSummary — provenance", () => {
+  it('reports source "none" when the repo has no deployments', async () => {
+    const r = await run();
+    expect(r.source).toBe("none");
+    expect(r.deploys_per_day).toBeNull();
+    expect(r.change_failure_rate_pct).toBeNull();
+  });
+
+  it('reports source "none" when the API is unavailable, without throwing', async () => {
+    listDeployments.mockRejectedValue(Object.assign(new Error("404"), { status: 404 }));
+    const r = await run();
+    expect(r.source).toBe("none");
+    expect(r.total_deployments).toBe(0);
+  });
+
+  it('reports source "none" when every deployment predates the window', async () => {
+    listDeployments.mockResolvedValue({ data: [dep(1, "production", daysAgo(90))] });
+    const r = await run(30);
+    expect(r.source).toBe("none");
+  });
+
+  it('reports source "deployments" once there is data in the window', async () => {
+    listDeployments.mockResolvedValue({ data: [dep(1, "production", daysAgo(2))] });
+    statusMap({ 1: { state: "success", at: daysAgo(2) } });
+    const r = await run();
+    expect(r.source).toBe("deployments");
+  });
+});
+
+describe("getDeploymentsSummary — production environment selection", () => {
+  it("prefers a conventionally named production environment", async () => {
+    listDeployments.mockResolvedValue({
+      data: [
+        dep(1, "staging", daysAgo(1)), dep(2, "staging", daysAgo(2)),
+        dep(3, "staging", daysAgo(3)), dep(4, "production", daysAgo(4)),
+      ],
+    });
+    statusMap({});
+    // staging is busier, but production is what the headline should describe.
+    expect((await run()).production_environment).toBe("production");
+  });
+
+  it("falls back to the busiest environment when no conventional name exists", async () => {
+    listDeployments.mockResolvedValue({
+      data: [dep(1, "eu-west", daysAgo(1)), dep(2, "eu-west", daysAgo(2)), dep(3, "canary", daysAgo(3))],
+    });
+    statusMap({});
+    expect((await run()).production_environment).toBe("eu-west");
+  });
+});
+
+describe("getDeploymentsSummary — rates", () => {
+  it("counts only SUCCESSFUL production deploys toward frequency", async () => {
+    listDeployments.mockResolvedValue({
+      data: [
+        dep(1, "production", daysAgo(1)), dep(2, "production", daysAgo(2)),
+        dep(3, "production", daysAgo(3)),
+      ],
+    });
+    statusMap({
+      1: { state: "success", at: daysAgo(1) },
+      2: { state: "failure", at: daysAgo(2) }, // a failed rollout is not a delivery
+      3: { state: "success", at: daysAgo(3) },
+    });
+    const r = await run(30);
+    // 2 successes / 30 days, rounded to 2dp for display.
+    expect(r.deploys_per_day).toBe(0.07);
+    expect(r.change_failure_rate_pct).toBe(33); // 1 of 3 conclusive
+  });
+
+  it("excludes pending and in-progress deploys from the failure rate", async () => {
+    listDeployments.mockResolvedValue({
+      data: [
+        dep(1, "production", daysAgo(1)), dep(2, "production", daysAgo(2)),
+        dep(3, "production", daysAgo(3)),
+      ],
+    });
+    statusMap({
+      1: { state: "success", at: daysAgo(1) },
+      2: { state: "in_progress", at: daysAgo(2) },
+      3: { state: "failure", at: daysAgo(3) },
+    });
+    // 1 failure of 2 conclusive — the in-progress one is not counted either way.
+    expect((await run()).change_failure_rate_pct).toBe(50);
+  });
+
+  it("returns a null failure rate rather than 0% when nothing is conclusive", async () => {
+    listDeployments.mockResolvedValue({ data: [dep(1, "production", daysAgo(1))] });
+    statusMap({ 1: { state: "pending", at: daysAgo(1) } });
+    // 0% would read as flawless delivery; null reads as no signal.
+    expect((await run()).change_failure_rate_pct).toBeNull();
+  });
+
+  it("segments stats by environment", async () => {
+    listDeployments.mockResolvedValue({
+      data: [
+        dep(1, "production", daysAgo(1)), dep(2, "staging", daysAgo(2)), dep(3, "staging", daysAgo(3)),
+      ],
+    });
+    statusMap({
+      1: { state: "success", at: daysAgo(1) },
+      2: { state: "failure", at: daysAgo(2) },
+      3: { state: "success", at: daysAgo(3) },
+    });
+    const r = await run();
+    const staging = r.by_environment.find((e) => e.environment === "staging")!;
+    expect(staging.total).toBe(2);
+    expect(staging.failure_rate_pct).toBe(50);
+  });
+});
+
+describe("getDeploymentsSummary — MTTR", () => {
+  it("measures from failure to the next success", async () => {
+    listDeployments.mockResolvedValue({
+      data: [dep(1, "production", hoursAgo(10)), dep(2, "production", hoursAgo(6))],
+    });
+    statusMap({
+      1: { state: "failure", at: hoursAgo(10) },
+      2: { state: "success", at: hoursAgo(6) },
+    });
+    const r = await run();
+    expect(r.mttr_hours).toBeCloseTo(4, 0);
+    expect(r.mttr_samples).toBe(1);
+  });
+
+  it("measures from the FIRST failure of a streak, not the last", async () => {
+    // Recovery starts when things broke, not at the final symptom before the fix.
+    listDeployments.mockResolvedValue({
+      data: [
+        dep(1, "production", hoursAgo(12)),
+        dep(2, "production", hoursAgo(10)),
+        dep(3, "production", hoursAgo(2)),
+      ],
+    });
+    statusMap({
+      1: { state: "failure", at: hoursAgo(12) },
+      2: { state: "failure", at: hoursAgo(10) },
+      3: { state: "success", at: hoursAgo(2) },
+    });
+    const r = await run();
+    expect(r.mttr_hours).toBeCloseTo(10, 0); // 12h → 2h, not 10h → 2h
+    expect(r.mttr_samples).toBe(1);
+  });
+
+  it("returns null with zero samples when nothing ever failed", async () => {
+    listDeployments.mockResolvedValue({ data: [dep(1, "production", daysAgo(1))] });
+    statusMap({ 1: { state: "success", at: daysAgo(1) } });
+    const r = await run();
+    expect(r.mttr_hours).toBeNull();
+    expect(r.mttr_samples).toBe(0);
+  });
+
+  it("ignores a failure that was never recovered", async () => {
+    listDeployments.mockResolvedValue({ data: [dep(1, "production", hoursAgo(5))] });
+    statusMap({ 1: { state: "failure", at: hoursAgo(5) } });
+    const r = await run();
+    expect(r.mttr_hours).toBeNull(); // still broken — not a recovery time
+  });
+
+  it("averages across multiple recoveries", async () => {
+    listDeployments.mockResolvedValue({
+      data: [
+        dep(1, "production", hoursAgo(20)), dep(2, "production", hoursAgo(18)),
+        dep(3, "production", hoursAgo(10)), dep(4, "production", hoursAgo(4)),
+      ],
+    });
+    statusMap({
+      1: { state: "failure", at: hoursAgo(20) },
+      2: { state: "success", at: hoursAgo(18) }, // 2h
+      3: { state: "failure", at: hoursAgo(10) },
+      4: { state: "success", at: hoursAgo(4) },  // 6h
+    });
+    const r = await run();
+    expect(r.mttr_samples).toBe(2);
+    expect(r.mttr_hours).toBeCloseTo(4, 0);
+  });
+});
+
+describe("getDeploymentsSummary — resilience", () => {
+  it("flags partial when a status fetch fails but still returns figures", async () => {
+    listDeployments.mockResolvedValue({
+      data: [dep(1, "production", daysAgo(1)), dep(2, "production", daysAgo(2))],
+    });
+    listDeploymentStatuses.mockImplementation(async ({ deployment_id }: { deployment_id: number }) => {
+      if (deployment_id === 2) throw new Error("boom");
+      return { data: [{ state: "success", created_at: daysAgo(1) }] };
+    });
+    const r = await run();
+    expect(r.partial).toBe(true);
+    expect(r.total_deployments).toBe(2);
+    expect(r.successful).toBe(1);
+  });
+
+  it("treats a deployment with no status as inconclusive rather than failed", async () => {
+    listDeployments.mockResolvedValue({ data: [dep(1, "production", daysAgo(1))] });
+    statusMap({}); // no statuses at all
+    const r = await run();
+    expect(r.failed).toBe(0);
+    expect(r.change_failure_rate_pct).toBeNull();
+  });
+});


### PR DESCRIPTION
Second of the four. Your DORA figures were **inferred from naming conventions**, and the failure mode is that they fail *flatteringly*.

## What was actually being measured

| Metric | Previous derivation | How it failed |
|---|---|---|
| Deploy frequency | Releases → **falls back to every merged PR** | No release tags = your *merge rate* shown as your deploy rate |
| Change failure rate | Branch matches `/hotfix\|revert\|fix-prod\|emergency/` | Different naming = **exactly 0%**, which reads as excellence |
| MTTR | How long those PRs took to merge | Measures *merge speed*, not recovery |

A 0% change-failure rate from "we don't name branches that way" is indistinguishable from a 0% from "we never break production." That's the real bug.

## What this adds

Real metrics from GitHub's Deployments API — deploy frequency, CFR, MTTR — plus per-environment breakdown and recent rollout history.

**Measured figures never silently replace estimated ones.** The response carries `source`, the panel is labelled **Measured**, and when a repo has *no* deployments the panel explains what the DORA cards above actually represent instead of hiding. Knowing which you're reading matters more than the number.

## Definitions chosen not to flatter

- **Only successful production deploys** count toward frequency — a failed rollout isn't a delivery
- Pending/in-progress **excluded** from the failure rate; nothing conclusive returns **null, not 0%**
- A deployment with no status is **inconclusive, never a pass**
- MTTR runs from the **first failure of a streak** — recovery starts when it broke, not at the last symptom
- MTTR from a single recovery is labelled an **anecdote**, not a trend

## Cost

One list call + status lookups for the 40 most recent (concurrency 8). Bounded, cached 10 min, and `partial` is set when the sample was truncated.

## Test plan

- [x] `pnpm exec tsc --noEmit` — **0 errors**
- [x] `pnpm test` — **308/308** (291 → 308, +17)
- [x] `pnpm run lint` — **0 errors** (11 pre-existing warnings, unchanged)
- [x] `rm -rf .next && pnpm run build` — succeeds, route emits
- [x] API Reference parity — clean
- [x] Version bumped in all locations; release-notes entries verified intact

## Rollback

Additive only — the existing DORA calculation is untouched. Promote v4.2.0, or `git revert`. No schema change.

## Next

v4.2.2 issues & triage health, then v4.2.3 ⌘K palette + the 11 reload bugs.