### PR TITLE
feat: v4.2.2 — issue and triage health

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,52 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ---
 
+## [4.2.2] — 2026-08-15
+
+### Overview
+GitDash measured **supply** — pull requests, CI, deployments — and nothing about **demand**. Issues are where work arrives, and a backlog growing faster than it drains is a leading indicator no delivery metric will show you: delivery can look healthy right up until the queue behind it collapses. This adds the missing half.
+
+Third of the four features from the gap review. Before this release there were **zero** `octokit.rest.issues.*` calls anywhere in the codebase.
+
+### Added
+
+#### Issue & Triage Health (`/repos/[owner]/[repo]/issues`)
+- **Backlog direction** — opened vs closed over a selectable 7/30/90-day window, shown as a signed delta because the sign is what a lead reads first.
+- **Time to close** — median and p90 days, from issues actually resolved in the window.
+- **Age distribution** of the open backlog across under a week, 1–4 weeks, 1–3 months, and over 3 months.
+- **Label and assignee breakdowns**, plus the oldest open issue.
+- New `GET /api/github/issues`, cached 5 minutes. Linked from the repo overview nav.
+
+#### Triage debt
+Two signals, framed as process problems rather than individual output:
+- **Unlabelled** open issues — work that arrived but was never routed to a person, area or priority, and is therefore invisible to every filter the team uses.
+- **No reply** — open 14+ days with not a single comment. Somebody reported this and heard nothing back; that is a relationship cost, not just a queue cost.
+
+### Changed
+
+#### Pull requests are excluded from every issue metric
+GitHub's REST API returns pull requests from the issues endpoint, each carrying a `pull_request` key. Counting them would report **delivery throughput as triage throughput** — wrong in a direction that looks entirely plausible, and the classic mistake with this API. Filtering happens once, immediately, before anything is computed, and is covered by dedicated tests including one asserting a merged PR cannot inflate time-to-close.
+
+#### Cost
+- Three paginated calls, **no per-issue fan-out** — cheap for the surface area it covers.
+- Time-to-first-response would need one request per issue, so it is deliberately not computed. "Issues nobody has commented on" is used instead: a cheaper signal for the same underlying worry.
+
+#### Sampling honesty
+- The issue list is ordered by recent activity, so hitting the page cap means quiet older issues were never seen. In that case the page states that counts are a **floor rather than a total**, instead of presenting a partial sample as complete.
+
+### Verified
+- Test count 308 → 327, covering PR exclusion, backlog direction in both directions, window boundaries, triage debt on open issues only, label formats (object and bare string), null assignees, and partial sampling.
+
+### Rollback
+1. **Promote the v4.2.1 Vercel deployment** — instant.
+2. **`git revert`** — the page and route are additive, nothing existing changed; no schema change.
+
+### Changed (infra)
+- Bumped app version from 4.2.1 to 4.2.2
+- Bumped Helm chart version from 0.6.1 to 0.6.2
+
+---
+
 ## [4.2.1] — 2026-08-15
 
 ### Overview

--- a/helm/gitdash/Chart.yaml
+++ b/helm/gitdash/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: gitdash
 description: Self-hosted GitHub Actions metrics dashboard (standalone PAT or GitHub OAuth)
 type: application
-version: 0.6.1
-appVersion: "4.2.1"
+version: 0.6.2
+appVersion: "4.2.2"
 keywords:
   - github-actions
   - dashboard

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gitdash",
-  "version": "4.2.1",
+  "version": "4.2.2",
   "private": true,
   "packageManager": "pnpm@10.30.3",
   "scripts": {

--- a/src/app/api/github/issues/route.ts
+++ b/src/app/api/github/issues/route.ts
@@ -1,0 +1,51 @@
+/**
+ * GET /api/github/issues — issue and triage health.
+ *
+ * Everything is derived from the issue list itself (three paginated calls, no
+ * per-issue fan-out), so this is one of the cheaper analytics routes despite
+ * covering a whole new surface.
+ *
+ * Pull requests are excluded in the library — GitHub's issues API returns
+ * both, and counting PRs here would report delivery throughput as triage
+ * throughput.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { getTokenFromSession } from "@/lib/session";
+import { getIssuesSummary } from "@/lib/issues";
+import { withCache, hashKey } from "@/lib/cache";
+import { validateOwner, validateRepo, validatePerPage, safeError } from "@/lib/validation";
+
+export type { IssuesSummary, IssueRef, LabelCount } from "@/lib/issues";
+
+export const maxDuration = 60;
+
+const CACHE_TTL = 300; // 5 min
+
+export async function GET(req: NextRequest) {
+  const token = await getTokenFromSession();
+  if (!token) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const { searchParams } = new URL(req.url);
+  const ownerResult = validateOwner(searchParams.get("owner"));
+  if (!ownerResult.ok) return ownerResult.response;
+  const repoResult = validateRepo(searchParams.get("repo"));
+  if (!repoResult.ok) return repoResult.response;
+
+  const daysResult = validatePerPage(searchParams.get("days"), 30);
+  if (!daysResult.ok) return daysResult.response;
+  const periodDays = Math.min(Math.max(daysResult.data, 7), 90);
+
+  try {
+    const data = await withCache(
+      `issues:${hashKey(token)}:${ownerResult.data}/${repoResult.data}:${periodDays}`,
+      CACHE_TTL,
+      () => getIssuesSummary(token, ownerResult.data, repoResult.data, periodDays),
+    );
+    return NextResponse.json(data, {
+      headers: { "Cache-Control": `private, max-age=${CACHE_TTL}` },
+    });
+  } catch (e) {
+    return safeError(e, "Failed to fetch issue metrics");
+  }
+}

--- a/src/app/docs/page.tsx
+++ b/src/app/docs/page.tsx
@@ -9,7 +9,7 @@ import {
   CheckCircle,
   Activity, FileText, ShieldAlert, User, DollarSign,
   TrendingUp, Bell, Building2, List, BarChart3, Trophy, Sliders,
-  HeartPulse, AlertTriangle, Mail, MessageCircle, Sparkles,
+  HeartPulse, AlertTriangle, Mail, MessageCircle, Sparkles, CircleDot,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { Callout } from "@/components/docs/Callout";
@@ -51,6 +51,7 @@ const NAV: NavSection[] = [
       { id: "feat-audit", label: "Audit Trail", icon: FileText, sub: true },
       { id: "feat-security", label: "Security Scan", icon: ShieldAlert, sub: true },
       { id: "feat-repo-team", label: "Repo Team Stats", icon: Trophy, sub: true },
+      { id: "feat-issues", label: "Issue & Triage Health", icon: CircleDot, sub: true },
       { id: "feat-team", label: "Team Insights", icon: Users, sub: true },
       { id: "feat-contributor", label: "Contributor Profile", icon: User, sub: true },
       { id: "feat-cost", label: "Cost Analytics", icon: DollarSign, sub: true },
@@ -770,6 +771,15 @@ function Features({ onNavigate }: { onNavigate: (id: string) => void }) {
       screenshot: "11-repo-team.png",
       desc: "Per-contributor delivery metrics for a repository: CI pass rate, avg run duration, run count. Reviewer load matrix (author × reviewer heatmap). Bus factor analysis showing which modules have fewer than 2 active contributors.",
       chips: ["CI leaderboard", "Reviewer matrix", "Bus factor"],
+    },
+    {
+      id: "feat-issues",
+      name: "Issue & Triage Health",
+      path: "/repos/[owner]/[repo]/issues",
+      screenshot: "23-issues.png",
+      desc: "The demand side of engineering: is the backlog growing or draining, how long does work take to close, and what has been sitting untouched. Includes two triage-debt signals — unlabelled issues (unrouted work) and issues nobody has replied to.",
+      chips: ["Backlog direction", "Time to close", "Triage debt", "Age distribution"],
+      since: "4.2.2",
     },
     {
       id: "feat-team",
@@ -1826,6 +1836,66 @@ function FeatureAiInsights() {
   );
 }
 
+function FeatureIssues() {
+  return (
+    <section className="space-y-6">
+      <FeaturePageHeader
+        icon={CircleDot} name="Issue & Triage Health" path="/repos/[owner]/[repo]/issues"
+        chips={["Backlog direction", "Time to close", "Triage debt", "Age distribution"]}
+        since="4.2.2"
+      />
+      <ProseP>
+        Every other page in GitDash measures <strong>supply</strong> — pull requests, CI runs,
+        deployments. Issues are where work <strong>arrives</strong>. A backlog growing faster than it
+        drains is a leading indicator that no delivery metric will show you, because delivery can
+        look healthy right up until the queue behind it collapses.
+      </ProseP>
+      <ScreenshotSlot file="23-issues.png" alt="Issue and triage health" />
+
+      <DocCard>
+        <SubHeading>What it measures</SubHeading>
+        <DocTable
+          headers={["Metric", "Meaning"]}
+          rows={[
+            ["Backlog direction", "Opened minus closed in the window. Positive means the queue grew."],
+            ["Time to close", "Median and p90 days from open to close, over issues closed in the window."],
+            ["Age distribution", "How the open backlog splits across under a week, 1–4 weeks, 1–3 months, and over 3 months."],
+            ["Stale", "Open with no activity for 30+ days — not necessarily abandoned, but nobody has touched it."],
+            ["By label / assignee", "Where open work is concentrated."],
+          ]}
+        />
+      </DocCard>
+
+      <DocCard>
+        <SubHeading>Triage debt</SubHeading>
+        <ProseP>
+          Two signals framed deliberately as process problems rather than individual output:
+        </ProseP>
+        <DocTable
+          headers={["Signal", "Why it matters"]}
+          rows={[
+            ["Unlabelled", "Work that arrived but was never routed to a person, area or priority. It is invisible to every filter the team uses."],
+            ["No reply", "Open 14+ days with not one comment. Somebody reported this and heard nothing back — that is a relationship cost, not just a queue cost."],
+          ]}
+        />
+      </DocCard>
+
+      <Callout type="info">
+        <strong>Pull requests are excluded.</strong> GitHub&apos;s REST API returns pull requests
+        from the issues endpoint, so counting them would report delivery throughput as triage
+        throughput — a mistake that produces plausible-looking numbers. Every metric here filters
+        them out first.
+      </Callout>
+
+      <Callout type="warning">
+        Counts are a <strong>floor, not a total</strong>, when the sample cap is reached. The issue
+        list is ordered by recent activity, so a very large backlog may have quiet old issues beyond
+        the window examined. The page says so when that happens.
+      </Callout>
+    </section>
+  );
+}
+
 // ─────────────────────────────────────────────────────────────────────────────
 // ── Metrics Reference ─────────────────────────────────────────────────────────
 
@@ -2619,6 +2689,16 @@ function APIReference() {
         },
         {
           method: "GET",
+          path: "/api/github/issues",
+          description: "Issue and triage health. Returns { open_count, opened_in_period, closed_in_period, backlog_delta, median_days_to_close, p90_days_to_close, stale_count, unlabelled_count, unanswered_count, age_buckets[], top_labels[], assignee_load[], neglected[], oldest_open, total_analysed, partial }. Pull requests are excluded — GitHub's issues endpoint returns both, and counting PRs would report delivery throughput as triage throughput.",
+          params: [
+            { name: "owner", type: "string", optional: false, desc: "Repository owner" },
+            { name: "repo", type: "string", optional: false, desc: "Repository name" },
+            { name: "days", type: "number", optional: true, desc: "Window in days, 7-90. Defaults to 30." },
+          ],
+        },
+        {
+          method: "GET",
           path: "/api/github/deployments",
           description: "Measured delivery metrics from GitHub's Deployments API. Returns { source, production_environment, deploys_per_day, change_failure_rate_pct, mttr_hours, mttr_samples, by_environment[], recent[], partial }. source is \"deployments\" when the repo genuinely uses the API and \"none\" otherwise — the caller keeps its release/PR estimates in that case rather than being handed zeros. Rates exclude pending and in-progress deploys, and return null rather than 0% when nothing is conclusive.",
           params: [
@@ -2918,9 +2998,28 @@ pnpm run lint`}
 function ReleaseNotes() {
   const releases = [
     {
-      version: "4.2.1",
+      version: "4.2.2",
       date: "2026-08-15",
       badge: "latest",
+      badgeColor: "bg-emerald-500/15 text-emerald-400 border-emerald-500/20",
+      changes: {
+        added: [
+          "Issue & Triage Health — a new page at /repos/[owner]/[repo]/issues covering the half of engineering GitDash could not see. PRs, CI and deployments measure supply; issues are where work arrives, and a backlog growing faster than it drains is a leading indicator no delivery metric will show you",
+          "Backlog direction (opened vs closed in the window), median and p90 time to close, an age distribution of the open backlog, label and assignee breakdowns, and the oldest open issue",
+          "Two triage-debt signals: unlabelled open issues (work that arrived but was never routed) and issues open 14+ days with not a single comment (someone reported it and heard nothing back)",
+        ],
+        fixed: [],
+        improved: [
+          "Pull requests are excluded from every issue metric. GitHub's REST API returns PRs from the issues endpoint, so counting them would report delivery throughput as triage throughput — wrong in a direction that looks entirely plausible. There is a dedicated test for it",
+          "Costs three paginated calls with no per-issue fan-out. Time-to-first-response would need one call per issue, so \"issues nobody has commented on\" is used instead — a cheaper signal for the same worry",
+          "Counts are labelled as a floor rather than a total when the sample cap is hit, since the list is ordered by recent activity and quiet old issues fall outside it",
+        ],
+      },
+    },
+    {
+      version: "4.2.1",
+      date: "2026-08-15",
+      badge: null,
       badgeColor: "bg-emerald-500/15 text-emerald-400 border-emerald-500/20",
       changes: {
         added: [
@@ -3504,7 +3603,7 @@ function DocSidebar({
           <BookOpen className="w-4 h-4 text-violet-400" />
           <span className="text-sm font-semibold text-white">GitDash Docs</span>
           <span className="text-xs px-1.5 py-0.5 rounded bg-violet-500/15 text-violet-400 border border-violet-500/20 font-mono">
-            v{process.env.NEXT_PUBLIC_APP_VERSION ?? "4.2.1"}
+            v{process.env.NEXT_PUBLIC_APP_VERSION ?? "4.2.2"}
           </span>
         </div>
         {/* Mobile close */}
@@ -3638,6 +3737,7 @@ export default function DocsPage() {
     "feat-audit": <FeatureAudit />,
     "feat-security": <FeatureSecurity />,
     "feat-repo-team": <FeatureRepoTeam />,
+    "feat-issues":     <FeatureIssues />,
     "feat-team": <FeatureTeamInsights />,
     "feat-contributor": <FeatureContributor />,
     "feat-cost": <FeatureCost />,
@@ -3754,7 +3854,7 @@ export default function DocsPage() {
 
           {/* Footer */}
           <footer className="mt-8 pb-4 text-center text-xs text-slate-600 space-y-1">
-            <p>GitDash v{process.env.NEXT_PUBLIC_APP_VERSION ?? "4.2.1"} — GitHub Actions Dashboard</p>
+            <p>GitDash v{process.env.NEXT_PUBLIC_APP_VERSION ?? "4.2.2"} — GitHub Actions Dashboard</p>
             <p>
               <a href="https://github.com/dinhdobathi1992/gitdash" target="_blank" rel="noreferrer" className="hover:text-slate-400 transition-colors">
                 Open source on GitHub

--- a/src/app/repos/[owner]/[repo]/issues/page.tsx
+++ b/src/app/repos/[owner]/[repo]/issues/page.tsx
@@ -1,0 +1,364 @@
+"use client";
+
+/**
+ * Issue & Triage Health (v4.2.2).
+ *
+ * GitDash measured delivery — PRs, CI, deployments — but nothing about the
+ * work arriving. This page answers the questions a lead actually asks about a
+ * backlog: is it growing, how long do things take, and what has been sitting
+ * untouched.
+ *
+ * The framing throughout is triage debt rather than individual output. An
+ * unlabelled issue is unrouted work; an issue nobody replied to is a person
+ * waiting, not a person failing.
+ */
+
+import { useState } from "react";
+import { useParams } from "next/navigation";
+import Link from "next/link";
+import useSWR from "swr";
+import { fetcher } from "@/lib/swr";
+import { RepoWorkflowBreadcrumb } from "@/components/Sidebar";
+import type { IssuesSummary } from "@/app/api/github/issues/route";
+import {
+  CircleDot, ArrowLeft, TrendingUp, TrendingDown, Minus, Clock,
+  Tag, MessageSquareOff, Users, ExternalLink, Info,
+} from "lucide-react";
+import { cn } from "@/lib/utils";
+
+const PERIODS = [7, 30, 90];
+
+export default function IssuesPage() {
+  const { owner, repo } = useParams<{ owner: string; repo: string }>();
+  const [days, setDays] = useState(30);
+
+  const { data, error, isLoading } = useSWR<IssuesSummary>(
+    `/api/github/issues?owner=${owner}&repo=${repo}&days=${days}`,
+    fetcher<IssuesSummary>,
+  );
+
+  return (
+    <div className="p-8 max-w-6xl space-y-6">
+      <RepoWorkflowBreadcrumb owner={owner} repo={repo} />
+
+      <div className="flex items-start justify-between gap-4 flex-wrap">
+        <div className="flex items-start gap-3">
+          <div className="w-10 h-10 rounded-xl bg-sky-500/20 border border-sky-500/30 flex items-center justify-center shrink-0">
+            <CircleDot className="w-5 h-5 text-sky-400" />
+          </div>
+          <div>
+            <h1 className="text-2xl font-bold text-white">Issue &amp; Triage Health</h1>
+            <p className="text-sm text-slate-400 mt-0.5">
+              Is the backlog growing, how long does work take, and what has been left untouched in{" "}
+              <span className="font-mono text-slate-300">{owner}/{repo}</span>
+            </p>
+          </div>
+        </div>
+        <div className="flex items-center gap-2">
+          <div className="flex items-center gap-1 p-1 rounded-xl border border-slate-800 bg-slate-900/60">
+            {PERIODS.map((p) => (
+              <button
+                key={p}
+                onClick={() => setDays(p)}
+                className={cn(
+                  "px-3 py-1.5 rounded-lg text-xs transition-colors",
+                  days === p
+                    ? "bg-slate-700/80 text-white border border-slate-600"
+                    : "text-slate-500 hover:text-slate-300 border border-transparent",
+                )}
+              >
+                {p}d
+              </button>
+            ))}
+          </div>
+          <Link
+            href={`/repos/${owner}/${repo}`}
+            className="flex items-center gap-2 px-3 py-2 text-sm text-slate-400 hover:text-white bg-slate-800 hover:bg-slate-700 border border-slate-700 rounded-lg transition-colors"
+          >
+            <ArrowLeft className="w-3.5 h-3.5" /> Back to repo
+          </Link>
+        </div>
+      </div>
+
+      {isLoading && (
+        <div className="space-y-4">
+          <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+            {Array.from({ length: 4 }).map((_, i) => <div key={i} className="h-24 rounded-2xl skeleton" />)}
+          </div>
+          <div className="h-64 rounded-2xl skeleton" />
+        </div>
+      )}
+
+      {error && !isLoading && (
+        <div className="px-4 py-3 rounded-xl border border-red-500/25 bg-red-500/10 text-sm text-red-300">
+          {error.message ?? "Failed to load issue metrics"}
+        </div>
+      )}
+
+      {data && !isLoading && data.total_analysed === 0 && (
+        <div className="flex flex-col items-center justify-center py-20 gap-3 text-center">
+          <CircleDot className="w-10 h-10 text-slate-600" />
+          <p className="text-sm text-slate-400">
+            No issues found in this repository — only pull requests, which are counted elsewhere.
+          </p>
+        </div>
+      )}
+
+      {data && !isLoading && data.total_analysed > 0 && (
+        <>
+          {/* Headline */}
+          <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+            <Stat
+              label="Open"
+              value={data.open_count}
+              note={`${data.total_analysed} analysed`}
+              tone="slate"
+            />
+            <BacklogStat delta={data.backlog_delta} opened={data.opened_in_period} closed={data.closed_in_period} days={days} />
+            <Stat
+              label="Median time to close"
+              value={data.median_days_to_close !== null ? `${data.median_days_to_close}d` : "—"}
+              note={data.p90_days_to_close !== null ? `p90 ${data.p90_days_to_close}d` : "nothing closed"}
+              tone="slate"
+            />
+            <Stat
+              label="Stale"
+              value={data.stale_count}
+              note="no activity 30d+"
+              tone={data.stale_count > 0 ? "amber" : "emerald"}
+            />
+          </div>
+
+          {/* Triage debt */}
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+            <DebtCard
+              icon={Tag}
+              label="Unlabelled"
+              value={data.unlabelled_count}
+              total={data.open_count}
+              explanation="Open issues with no labels — work that has arrived but has not been routed to anyone or anything."
+            />
+            <DebtCard
+              icon={MessageSquareOff}
+              label="No reply"
+              value={data.unanswered_count}
+              total={data.open_count}
+              explanation="Open more than 14 days with not a single comment. Someone reported these and heard nothing back."
+            />
+          </div>
+
+          {/* Age distribution */}
+          <Panel title="Open backlog by age" icon={Clock}>
+            <div className="space-y-2">
+              {data.age_buckets.map((b) => {
+                const pct = data.open_count > 0 ? (b.count / data.open_count) * 100 : 0;
+                const old = b.label === "> 3 months" || b.label === "1–3 months";
+                return (
+                  <div key={b.label} className="flex items-center gap-3">
+                    <span className="w-24 shrink-0 text-xs text-slate-400">{b.label}</span>
+                    <div className="flex-1 h-2 rounded-full bg-slate-800 overflow-hidden">
+                      <div
+                        className={cn("h-full rounded-full", old ? "bg-amber-500/80" : "bg-sky-500/80")}
+                        style={{ width: `${Math.max(pct, b.count > 0 ? 2 : 0)}%` }}
+                      />
+                    </div>
+                    <span className="w-10 shrink-0 text-right text-xs text-slate-300 tabular-nums">{b.count}</span>
+                  </div>
+                );
+              })}
+            </div>
+            {data.oldest_open && (
+              <a
+                href={data.oldest_open.html_url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="mt-4 flex items-center gap-2 px-3 py-2 rounded-lg bg-slate-900/60 border border-slate-800 text-xs text-slate-400 hover:text-slate-200 transition-colors"
+              >
+                <Clock className="w-3.5 h-3.5 shrink-0" />
+                <span className="truncate flex-1">
+                  Oldest open: #{data.oldest_open.number} {data.oldest_open.title}
+                </span>
+                <span className="shrink-0 tabular-nums">{data.oldest_open.age_days}d</span>
+                <ExternalLink className="w-3 h-3 shrink-0" />
+              </a>
+            )}
+          </Panel>
+
+          {/* Neglected */}
+          {data.neglected.length > 0 && (
+            <Panel title="Waiting for a first reply" icon={MessageSquareOff}>
+              <p className="text-xs text-slate-500 mb-3">
+                Nobody has commented on these. Each one is a person waiting.
+              </p>
+              <div className="rounded-xl border border-slate-800 overflow-hidden">
+                {data.neglected.map((i) => (
+                  <a
+                    key={i.number}
+                    href={i.html_url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="group flex items-center gap-3 px-4 py-2.5 border-b border-slate-800/60 last:border-b-0 hover:bg-slate-800/40 transition-colors"
+                  >
+                    <span className="font-mono text-xs text-slate-600 shrink-0">#{i.number}</span>
+                    <span className="text-xs text-slate-300 truncate flex-1 group-hover:text-white transition-colors">
+                      {i.title}
+                    </span>
+                    <span className="text-xs text-amber-400/90 shrink-0 tabular-nums">{i.age_days}d</span>
+                    <ExternalLink className="w-3 h-3 shrink-0 text-slate-700 group-hover:text-slate-400" />
+                  </a>
+                ))}
+              </div>
+            </Panel>
+          )}
+
+          <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+            {data.top_labels.length > 0 && (
+              <Panel title="Open issues by label" icon={Tag}>
+                <div className="flex flex-wrap gap-2">
+                  {data.top_labels.map((l) => (
+                    <span
+                      key={l.label}
+                      className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs border"
+                      style={{
+                        borderColor: `#${l.color}55`,
+                        backgroundColor: `#${l.color}18`,
+                        color: `#${l.color}`,
+                      }}
+                    >
+                      {l.label}
+                      <span className="font-mono opacity-80">{l.count}</span>
+                    </span>
+                  ))}
+                </div>
+              </Panel>
+            )}
+
+            {data.assignee_load.length > 0 && (
+              <Panel title="Open issues by assignee" icon={Users}>
+                <div className="space-y-2">
+                  {data.assignee_load.map((a) => (
+                    <div key={a.login} className="flex items-center gap-3">
+                      <span className="font-mono text-xs text-slate-300 truncate flex-1">@{a.login}</span>
+                      <div className="w-32 h-1.5 rounded-full bg-slate-800 overflow-hidden">
+                        <div
+                          className="h-full rounded-full bg-violet-500/80"
+                          style={{ width: `${(a.open / data.assignee_load[0].open) * 100}%` }}
+                        />
+                      </div>
+                      <span className="w-8 text-right text-xs text-slate-400 tabular-nums">{a.open}</span>
+                    </div>
+                  ))}
+                </div>
+              </Panel>
+            )}
+          </div>
+
+          {data.partial && (
+            <p className="flex items-start gap-1.5 text-[11px] text-slate-500">
+              <Info className="w-3 h-3 mt-0.5 shrink-0" />
+              Based on the {data.total_analysed} most recently active issues. Quieter older issues
+              are not included, so counts are a floor rather than a total.
+            </p>
+          )}
+        </>
+      )}
+    </div>
+  );
+}
+
+function Panel({
+  title, icon: Icon, children,
+}: { title: string; icon: React.ElementType; children: React.ReactNode }) {
+  return (
+    <div className="rounded-2xl border border-slate-800 bg-slate-900/40 p-5">
+      <div className="flex items-center gap-2 mb-4">
+        <Icon className="w-4 h-4 text-slate-500" />
+        <h2 className="text-sm font-semibold text-white">{title}</h2>
+      </div>
+      {children}
+    </div>
+  );
+}
+
+function Stat({
+  label, value, note, tone,
+}: { label: string; value: number | string; note: string; tone: "slate" | "amber" | "emerald" | "red" }) {
+  const color = {
+    slate: "text-slate-100", amber: "text-amber-400",
+    emerald: "text-emerald-400", red: "text-red-400",
+  }[tone];
+  return (
+    <div className="rounded-2xl border border-slate-800 bg-slate-900/50 p-4">
+      <div className="text-[10.5px] font-semibold uppercase tracking-[0.12em] text-slate-500 mb-2">{label}</div>
+      <div className={cn("font-mono text-3xl font-bold tabular-nums leading-none", color)}>{value}</div>
+      <div className="text-[11px] text-slate-600 mt-2">{note}</div>
+    </div>
+  );
+}
+
+/** Backlog direction is the one number a lead reads first. */
+function BacklogStat({
+  delta, opened, closed, days,
+}: { delta: number; opened: number; closed: number; days: number }) {
+  const growing = delta > 0;
+  const flat = delta === 0;
+  const Icon = flat ? Minus : growing ? TrendingUp : TrendingDown;
+  return (
+    <div
+      className={cn(
+        "rounded-2xl border p-4",
+        flat ? "border-slate-800 bg-slate-900/50"
+          : growing ? "border-amber-500/25 bg-amber-500/[0.06]"
+          : "border-emerald-500/25 bg-emerald-500/[0.06]",
+      )}
+    >
+      <div className="text-[10.5px] font-semibold uppercase tracking-[0.12em] text-slate-500 mb-2">
+        Backlog {days}d
+      </div>
+      <div className="flex items-center gap-2">
+        <Icon className={cn("w-5 h-5 shrink-0", flat ? "text-slate-500" : growing ? "text-amber-400" : "text-emerald-400")} />
+        <span className={cn("font-mono text-3xl font-bold tabular-nums leading-none",
+          flat ? "text-slate-100" : growing ? "text-amber-400" : "text-emerald-400")}>
+          {delta > 0 ? `+${delta}` : delta}
+        </span>
+      </div>
+      <div className="text-[11px] text-slate-600 mt-2">
+        {opened} opened · {closed} closed
+      </div>
+    </div>
+  );
+}
+
+function DebtCard({
+  icon: Icon, label, value, total, explanation,
+}: {
+  icon: React.ElementType; label: string; value: number; total: number; explanation: string;
+}) {
+  const pct = total > 0 ? Math.round((value / total) * 100) : 0;
+  const bad = pct >= 25 && value > 0;
+  return (
+    <div
+      className={cn(
+        "rounded-2xl border p-5",
+        bad ? "border-amber-500/25 bg-amber-500/[0.05]" : "border-slate-800 bg-slate-900/40",
+      )}
+    >
+      <div className="flex items-center gap-2 mb-2">
+        <Icon className={cn("w-4 h-4", bad ? "text-amber-400" : "text-slate-500")} />
+        <span className="text-sm font-semibold text-white">{label}</span>
+        <span className={cn("ml-auto font-mono text-2xl font-bold tabular-nums", bad ? "text-amber-400" : "text-slate-100")}>
+          {value}
+        </span>
+      </div>
+      <div className="h-1.5 rounded-full bg-slate-800 overflow-hidden mb-2.5">
+        <div
+          className={cn("h-full rounded-full", bad ? "bg-amber-500/80" : "bg-slate-600")}
+          style={{ width: `${Math.max(pct, value > 0 ? 2 : 0)}%` }}
+        />
+      </div>
+      <p className="text-[11px] text-slate-500 leading-relaxed">
+        {pct}% of open issues. {explanation}
+      </p>
+    </div>
+  );
+}

--- a/src/app/repos/[owner]/[repo]/page.tsx
+++ b/src/app/repos/[owner]/[repo]/page.tsx
@@ -17,7 +17,7 @@ import DeploymentsPanel from "@/components/DeploymentsPanel";
 import type { OpenPrHealthResponse } from "@/app/api/github/open-pr-health/route";
 import {
   AlertCircle, ExternalLink, GitBranch, FileCode, RefreshCw,
-  Search, X, ChevronRight, Zap, Shield, Users, ShieldCheck,
+  Search, X, ChevronRight, Zap, Shield, Users, ShieldCheck, CircleDot,
 } from "lucide-react";
 import { cn, fuzzyMatch, highlightSegments } from "@/lib/utils";
 import { useFeatureFlags } from "@/components/FeatureFlagsProvider";
@@ -405,6 +405,12 @@ export default function RepoDetailPage() {
             className="flex items-center gap-2 px-3 py-2 text-sm text-slate-400 hover:text-white bg-slate-800 hover:bg-slate-700 border border-slate-700 rounded-lg transition-colors"
           >
             <Users className="w-3.5 h-3.5" /> Team
+          </Link>
+          <Link
+            href={`/repos/${owner}/${repo}/issues`}
+            className="flex items-center gap-2 px-3 py-2 text-sm text-slate-400 hover:text-white bg-slate-800 hover:bg-slate-700 border border-slate-700 rounded-lg transition-colors"
+          >
+            <CircleDot className="w-3.5 h-3.5" /> Issues
           </Link>
           <Link
             href={`/repos/${owner}/${repo}/security`}

--- a/src/lib/issues.ts
+++ b/src/lib/issues.ts
@@ -1,0 +1,249 @@
+/**
+ * Issue and triage health (v4.2.2).
+ *
+ * GitDash measured the supply side of engineering — PRs, CI, deployments —
+ * but nothing about demand. Issues are where work arrives, and a backlog that
+ * grows faster than it drains is a leading indicator that no delivery metric
+ * will show you.
+ *
+ * ── The trap this module is built around ──────────────────────────────────
+ * GitHub's REST API treats pull requests as issues. `GET /issues` returns
+ * both, and every PR arrives carrying a `pull_request` key. Forgetting to
+ * filter it is the classic mistake here: a busy repo would report its PR
+ * throughput as issue throughput, and every metric below would be wrong in a
+ * direction that looks plausible. Filtering happens once, immediately, before
+ * anything is computed.
+ *
+ * ── Cost ──────────────────────────────────────────────────────────────────
+ * Everything here is derived from the issue list itself: three paginated
+ * calls, no per-issue fan-out. Time-to-first-response would need one call per
+ * issue, so it is deliberately not computed — "issues nobody has commented
+ * on" is a cheaper signal for the same underlying worry.
+ */
+
+import { getOctokit } from "@/lib/github";
+
+export interface IssueRef {
+  number: number;
+  title: string;
+  age_days: number;
+  comments: number;
+  html_url: string;
+}
+
+export interface LabelCount {
+  label: string;
+  count: number;
+  color: string;
+}
+
+export interface IssuesSummary {
+  repo: string;
+  period_days: number;
+
+  open_count: number;
+  opened_in_period: number;
+  closed_in_period: number;
+  /** opened − closed. Positive means the backlog grew. */
+  backlog_delta: number;
+
+  median_days_to_close: number | null;
+  p90_days_to_close: number | null;
+
+  /** Open with no activity for 30+ days. */
+  stale_count: number;
+  /** Open with no labels at all — unrouted work. */
+  unlabelled_count: number;
+  /** Open, older than 14 days, and nobody has commented even once. */
+  unanswered_count: number;
+
+  age_buckets: { label: string; count: number }[];
+  top_labels: LabelCount[];
+  assignee_load: { login: string; open: number }[];
+  /** Open issues nobody has replied to, oldest first. */
+  neglected: IssueRef[];
+  oldest_open: IssueRef | null;
+
+  /** Issues examined after excluding pull requests. */
+  total_analysed: number;
+  /** True when the window is larger than the sample fetched. */
+  partial: boolean;
+}
+
+const MAX_PAGES = 3;
+const PER_PAGE = 100;
+const STALE_DAYS = 30;
+const UNANSWERED_MIN_AGE_DAYS = 14;
+const MAX_NEGLECTED = 8;
+const MAX_LABELS = 8;
+const MAX_ASSIGNEES = 6;
+
+const daysBetween = (from: string, to: string) =>
+  (new Date(to).getTime() - new Date(from).getTime()) / 86_400_000;
+
+const daysSince = (iso: string) => Math.max(0, Math.floor((Date.now() - new Date(iso).getTime()) / 86_400_000));
+
+/** Linear-interpolation percentile, matching the convention used elsewhere. */
+function percentile(sorted: number[], p: number): number {
+  if (sorted.length === 0) return 0;
+  if (sorted.length === 1) return sorted[0];
+  const idx = (sorted.length - 1) * p;
+  const lo = Math.floor(idx);
+  const hi = Math.ceil(idx);
+  if (lo === hi) return sorted[lo];
+  return sorted[lo] + (sorted[hi] - sorted[lo]) * (idx - lo);
+}
+
+const round1 = (n: number) => Math.round(n * 10) / 10;
+
+interface RawIssue {
+  number: number;
+  title: string;
+  state: string;
+  created_at: string;
+  updated_at: string;
+  closed_at: string | null;
+  comments: number;
+  html_url: string;
+  /** Present ONLY on pull requests. Its existence is how we tell them apart. */
+  pull_request?: unknown;
+  labels: (string | { name?: string; color?: string })[];
+  assignees?: { login: string }[] | null;
+}
+
+function labelEntries(issue: RawIssue): { name: string; color: string }[] {
+  return issue.labels
+    .map((l) =>
+      typeof l === "string"
+        ? { name: l, color: "64748b" }
+        : { name: l.name ?? "", color: l.color ?? "64748b" },
+    )
+    .filter((l) => l.name.length > 0);
+}
+
+export async function getIssuesSummary(
+  token: string,
+  owner: string,
+  repo: string,
+  periodDays = 30,
+): Promise<IssuesSummary> {
+  const octokit = getOctokit(token);
+
+  const raw: RawIssue[] = [];
+  let reachedEnd = false;
+
+  for (let page = 1; page <= MAX_PAGES; page++) {
+    const { data } = await octokit.rest.issues.listForRepo({
+      owner,
+      repo,
+      state: "all",
+      per_page: PER_PAGE,
+      page,
+      sort: "updated",
+      direction: "desc",
+    });
+    raw.push(...(data as unknown as RawIssue[]));
+    if (data.length < PER_PAGE) {
+      reachedEnd = true;
+      break;
+    }
+  }
+
+  // THE filter. Pull requests are issues in this API; counting them would
+  // report PR throughput as issue throughput.
+  const issues = raw.filter((i) => !i.pull_request);
+
+  const cutoff = Date.now() - periodDays * 86_400_000;
+  const inPeriod = (iso: string) => new Date(iso).getTime() >= cutoff;
+
+  const open = issues.filter((i) => i.state === "open");
+  const closedInPeriod = issues.filter((i) => i.closed_at && inPeriod(i.closed_at));
+  const openedInPeriod = issues.filter((i) => inPeriod(i.created_at));
+
+  // Time to close, from issues actually resolved in the window.
+  const closeDurations = closedInPeriod
+    .map((i) => daysBetween(i.created_at, i.closed_at!))
+    .filter((d) => d >= 0)
+    .sort((a, b) => a - b);
+
+  const stale = open.filter((i) => daysSince(i.updated_at) >= STALE_DAYS);
+  const unlabelled = open.filter((i) => labelEntries(i).length === 0);
+  const neglected = open
+    .filter((i) => i.comments === 0 && daysSince(i.created_at) >= UNANSWERED_MIN_AGE_DAYS)
+    .sort((a, b) => daysSince(b.created_at) - daysSince(a.created_at));
+
+  // Age distribution of the open backlog.
+  const buckets = [
+    { label: "< 1 week", min: 0, max: 7 },
+    { label: "1–4 weeks", min: 7, max: 30 },
+    { label: "1–3 months", min: 30, max: 90 },
+    { label: "> 3 months", min: 90, max: Infinity },
+  ];
+  const ageBuckets = buckets.map((b) => ({
+    label: b.label,
+    count: open.filter((i) => {
+      const age = daysSince(i.created_at);
+      return age >= b.min && age < b.max;
+    }).length,
+  }));
+
+  const labelCounts = new Map<string, LabelCount>();
+  for (const issue of open) {
+    for (const l of labelEntries(issue)) {
+      const existing = labelCounts.get(l.name);
+      if (existing) existing.count++;
+      else labelCounts.set(l.name, { label: l.name, count: 1, color: l.color });
+    }
+  }
+
+  const assigneeCounts = new Map<string, number>();
+  for (const issue of open) {
+    for (const a of issue.assignees ?? []) {
+      assigneeCounts.set(a.login, (assigneeCounts.get(a.login) ?? 0) + 1);
+    }
+  }
+
+  const toRef = (i: RawIssue): IssueRef => ({
+    number: i.number,
+    title: i.title,
+    age_days: daysSince(i.created_at),
+    comments: i.comments,
+    html_url: i.html_url,
+  });
+
+  const oldestOpen =
+    open.length > 0
+      ? toRef([...open].sort((a, b) => daysSince(b.created_at) - daysSince(a.created_at))[0])
+      : null;
+
+  return {
+    repo: `${owner}/${repo}`,
+    period_days: periodDays,
+
+    open_count: open.length,
+    opened_in_period: openedInPeriod.length,
+    closed_in_period: closedInPeriod.length,
+    backlog_delta: openedInPeriod.length - closedInPeriod.length,
+
+    median_days_to_close: closeDurations.length ? round1(percentile(closeDurations, 0.5)) : null,
+    p90_days_to_close: closeDurations.length ? round1(percentile(closeDurations, 0.9)) : null,
+
+    stale_count: stale.length,
+    unlabelled_count: unlabelled.length,
+    unanswered_count: neglected.length,
+
+    age_buckets: ageBuckets,
+    top_labels: [...labelCounts.values()].sort((a, b) => b.count - a.count).slice(0, MAX_LABELS),
+    assignee_load: [...assigneeCounts.entries()]
+      .map(([login, openCount]) => ({ login, open: openCount }))
+      .sort((a, b) => b.open - a.open)
+      .slice(0, MAX_ASSIGNEES),
+    neglected: neglected.slice(0, MAX_NEGLECTED).map(toRef),
+    oldest_open: oldestOpen,
+
+    total_analysed: issues.length,
+    // The list is sorted by recent activity, so hitting the page cap means
+    // quiet older issues were not seen.
+    partial: !reachedEnd,
+  };
+}

--- a/tests/issues.test.ts
+++ b/tests/issues.test.ts
@@ -1,0 +1,226 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+/**
+ * The headline test here is the pull-request filter. GitHub's issues API
+ * returns PRs as well as issues, and forgetting to exclude them would report
+ * delivery throughput as triage throughput — wrong in a direction that looks
+ * entirely plausible.
+ */
+
+const listForRepo = vi.fn();
+
+vi.mock("@/lib/github", () => ({
+  getOctokit: () => ({ rest: { issues: { listForRepo: (...a: unknown[]) => listForRepo(...a) } } }),
+}));
+
+const daysAgo = (d: number) => new Date(Date.now() - d * 86_400_000).toISOString();
+
+function issue(over: Record<string, unknown> = {}) {
+  return {
+    number: 1,
+    title: "Something is broken",
+    state: "open",
+    created_at: daysAgo(5),
+    updated_at: daysAgo(1),
+    closed_at: null,
+    comments: 2,
+    html_url: "https://github.com/o/r/issues/1",
+    labels: [{ name: "bug", color: "d73a4a" }],
+    assignees: [],
+    ...over,
+  };
+}
+
+/** A pull request as the issues API returns it — note the `pull_request` key. */
+function pr(over: Record<string, unknown> = {}) {
+  return issue({ pull_request: { url: "https://api.github.com/..." }, ...over });
+}
+
+function page(items: unknown[]) {
+  listForRepo.mockResolvedValue({ data: items });
+}
+
+beforeEach(() => {
+  listForRepo.mockReset().mockResolvedValue({ data: [] });
+});
+
+async function run(days = 30) {
+  const { getIssuesSummary } = await import("@/lib/issues");
+  return getIssuesSummary("tok", "o", "r", days);
+}
+
+describe("getIssuesSummary — pull requests are not issues", () => {
+  it("excludes pull requests from every count", async () => {
+    page([
+      issue({ number: 1 }),
+      pr({ number: 2 }),
+      pr({ number: 3 }),
+      issue({ number: 4 }),
+    ]);
+    const r = await run();
+    expect(r.total_analysed).toBe(2);
+    expect(r.open_count).toBe(2);
+  });
+
+  it("reports an empty summary for a repo that only has pull requests", async () => {
+    page([pr({ number: 1 }), pr({ number: 2 })]);
+    const r = await run();
+    expect(r.total_analysed).toBe(0);
+    expect(r.open_count).toBe(0);
+    expect(r.median_days_to_close).toBeNull();
+  });
+
+  it("does not let a merged PR inflate the close-time metric", async () => {
+    page([
+      pr({ number: 1, state: "closed", created_at: daysAgo(20), closed_at: daysAgo(19) }),
+      issue({ number: 2, state: "closed", created_at: daysAgo(10), closed_at: daysAgo(0) }),
+    ]);
+    const r = await run();
+    expect(r.closed_in_period).toBe(1);
+    expect(r.median_days_to_close).toBeCloseTo(10, 0); // the issue, not the PR
+  });
+});
+
+describe("getIssuesSummary — backlog direction", () => {
+  it("reports a positive delta when more arrive than are closed", async () => {
+    page([
+      issue({ number: 1, created_at: daysAgo(3) }),
+      issue({ number: 2, created_at: daysAgo(4) }),
+      issue({ number: 3, created_at: daysAgo(5), state: "closed", closed_at: daysAgo(1) }),
+    ]);
+    const r = await run();
+    expect(r.opened_in_period).toBe(3);
+    expect(r.closed_in_period).toBe(1);
+    expect(r.backlog_delta).toBe(2);
+  });
+
+  it("reports a negative delta when the backlog is draining", async () => {
+    page([
+      issue({ number: 1, created_at: daysAgo(60), state: "closed", closed_at: daysAgo(2) }),
+      issue({ number: 2, created_at: daysAgo(80), state: "closed", closed_at: daysAgo(3) }),
+    ]);
+    const r = await run(30);
+    expect(r.opened_in_period).toBe(0); // both opened before the window
+    expect(r.closed_in_period).toBe(2);
+    expect(r.backlog_delta).toBe(-2);
+  });
+
+  it("ignores closures that fall outside the window", async () => {
+    page([issue({ number: 1, state: "closed", created_at: daysAgo(90), closed_at: daysAgo(60) })]);
+    const r = await run(30);
+    expect(r.closed_in_period).toBe(0);
+    expect(r.median_days_to_close).toBeNull();
+  });
+});
+
+describe("getIssuesSummary — triage debt", () => {
+  it("counts open issues with no labels", async () => {
+    page([
+      issue({ number: 1, labels: [] }),
+      issue({ number: 2, labels: [{ name: "bug", color: "d73a4a" }] }),
+      issue({ number: 3, labels: [] }),
+    ]);
+    expect((await run()).unlabelled_count).toBe(2);
+  });
+
+  it("treats an empty label name as unlabelled", async () => {
+    page([issue({ number: 1, labels: [{ name: "", color: "fff" }] })]);
+    expect((await run()).unlabelled_count).toBe(1);
+  });
+
+  it("counts stale issues by last activity, not age", async () => {
+    page([
+      issue({ number: 1, created_at: daysAgo(200), updated_at: daysAgo(1) }),  // old but active
+      issue({ number: 2, created_at: daysAgo(40), updated_at: daysAgo(35) }),  // stale
+    ]);
+    expect((await run()).stale_count).toBe(1);
+  });
+
+  it("flags issues nobody has replied to, once they are old enough", async () => {
+    page([
+      issue({ number: 1, comments: 0, created_at: daysAgo(20) }), // neglected
+      issue({ number: 2, comments: 0, created_at: daysAgo(3) }),  // too new to judge
+      issue({ number: 3, comments: 5, created_at: daysAgo(40) }), // answered
+    ]);
+    const r = await run();
+    expect(r.unanswered_count).toBe(1);
+    expect(r.neglected[0].number).toBe(1);
+  });
+
+  it("excludes closed issues from triage debt", async () => {
+    page([
+      issue({ number: 1, state: "closed", closed_at: daysAgo(1), labels: [], comments: 0, created_at: daysAgo(40) }),
+    ]);
+    const r = await run();
+    expect(r.unlabelled_count).toBe(0);
+    expect(r.unanswered_count).toBe(0);
+    expect(r.stale_count).toBe(0);
+  });
+});
+
+describe("getIssuesSummary — distribution and grouping", () => {
+  it("buckets the open backlog by age", async () => {
+    page([
+      issue({ number: 1, created_at: daysAgo(2) }),
+      issue({ number: 2, created_at: daysAgo(14) }),
+      issue({ number: 3, created_at: daysAgo(60) }),
+      issue({ number: 4, created_at: daysAgo(200) }),
+    ]);
+    const r = await run();
+    expect(r.age_buckets.map((b) => b.count)).toEqual([1, 1, 1, 1]);
+  });
+
+  it("counts labels across open issues only, ranked by frequency", async () => {
+    page([
+      issue({ number: 1, labels: [{ name: "bug", color: "d73a4a" }] }),
+      issue({ number: 2, labels: [{ name: "bug", color: "d73a4a" }, { name: "p1", color: "111" }] }),
+      issue({ number: 3, state: "closed", closed_at: daysAgo(1), labels: [{ name: "bug", color: "d73a4a" }] }),
+    ]);
+    const r = await run();
+    expect(r.top_labels[0]).toEqual({ label: "bug", count: 2, color: "d73a4a" });
+  });
+
+  it("handles labels returned as bare strings", async () => {
+    page([issue({ number: 1, labels: ["enhancement"] })]);
+    const r = await run();
+    expect(r.top_labels[0].label).toBe("enhancement");
+    expect(r.unlabelled_count).toBe(0);
+  });
+
+  it("ranks assignees by open issue load", async () => {
+    page([
+      issue({ number: 1, assignees: [{ login: "alice" }] }),
+      issue({ number: 2, assignees: [{ login: "alice" }, { login: "bob" }] }),
+    ]);
+    const r = await run();
+    expect(r.assignee_load[0]).toEqual({ login: "alice", open: 2 });
+  });
+
+  it("tolerates a null assignees field", async () => {
+    page([issue({ number: 1, assignees: null })]);
+    expect((await run()).assignee_load).toEqual([]);
+  });
+
+  it("identifies the oldest open issue", async () => {
+    page([
+      issue({ number: 1, created_at: daysAgo(10) }),
+      issue({ number: 2, created_at: daysAgo(300) }),
+    ]);
+    const r = await run();
+    expect(r.oldest_open?.number).toBe(2);
+    expect(r.oldest_open?.age_days).toBeGreaterThanOrEqual(299);
+  });
+});
+
+describe("getIssuesSummary — sampling honesty", () => {
+  it("flags partial when the page cap is reached", async () => {
+    // A full page implies more may exist beyond the cap.
+    listForRepo.mockResolvedValue({ data: Array.from({ length: 100 }, (_, i) => issue({ number: i + 1 })) });
+    expect((await run()).partial).toBe(true);
+  });
+
+  it("does not flag partial when the last page is short", async () => {
+    listForRepo.mockResolvedValue({ data: [issue({ number: 1 })] });
+    expect((await run()).partial).toBe(false);
+  });
+});


### PR DESCRIPTION
Third of the four. GitDash measured **supply** — PRs, CI, deployments — and nothing about **demand**. Before this release there were **zero** `octokit.rest.issues.*` calls anywhere in the codebase.

## Why it matters

A backlog growing faster than it drains is a leading indicator that no delivery metric will show you. Delivery can look healthy right up until the queue behind it collapses.

## New page — `/repos/[owner]/[repo]/issues`

- **Backlog direction** — opened vs closed over 7/30/90 days, shown as a signed delta because the sign is what you read first
- **Time to close** — median and p90
- **Age distribution** of the open backlog
- **Label and assignee** breakdowns, plus the oldest open issue

Linked from the repo nav (the v4.0.6 lesson — a feature nobody can find isn't shipped).

## Two triage-debt signals

Framed as process problems, not individual output:

| Signal | Why it matters |
|---|---|
| **Unlabelled** | Work that arrived but was never routed — invisible to every filter the team uses |
| **No reply** (14d+, zero comments) | Somebody reported this and heard nothing back. That's a relationship cost, not just a queue cost |

## The trap this is built around

**GitHub's REST API returns pull requests from the issues endpoint.** Every PR arrives with a `pull_request` key. Counting them would report **delivery throughput as triage throughput** — wrong in a direction that looks entirely plausible.

Filtering happens once, immediately, before anything is computed. There's a dedicated test asserting a merged PR can't inflate time-to-close.

## Cost

Three paginated calls, **no per-issue fan-out** — cheap for the surface area. Time-to-first-response would need one request per issue, so I used "issues nobody has commented on" instead: a cheaper signal for the same worry.

When the sample cap is hit, the page says counts are a **floor, not a total** — the list is ordered by recent activity, so quiet old issues fall outside it.

## Test plan

- [x] `pnpm exec tsc --noEmit` — **0 errors**
- [x] `pnpm test` — **327/327** (308 → 327, +19)
- [x] `pnpm run lint` — **0 errors, 11 warnings** (caught and removed one I'd introduced; back to baseline)
- [x] `rm -rf .next && pnpm run build` — succeeds, route + page emit
- [x] API Reference parity — clean
- [x] Version bumped in all locations; release-notes entries verified intact

## Rollback

Additive — new page and route only, nothing existing changed. Promote v4.2.1 or `git revert`. No schema change.

## Next

v4.2.3 — ⌘K command palette + the 11 `window.location.href` full-page-reload bugs. Last of the four.