### PR TITLE
feat: v4.2.3 — command palette, and a correction on the lint warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,46 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ---
 
+## [4.2.3] — 2026-08-15
+
+### Overview
+Last of the four features from the gap review. A command palette, and a correction: the 11 standing lint warnings were **not** the bug I assumed they were.
+
+### Added
+
+#### Command palette — ⌘K / Ctrl+K
+- Jump to any repository or page from anywhere. GitDash has ~20 pages and, in a real org, hundreds of repositories; navigation was a sidebar plus page-local search, so reaching a specific repo took several clicks from anywhere that wasn't the repo list.
+- Fuzzy matching over both the repository name and `owner/name`, so `acme/api` finds what you expect. Reuses the existing `fuzzyMatch` helper and its highlight rendering.
+- **Repo-scoped destinations** (Overview, Team, Issues, Security, Audit) appear only while you are inside a repository — "Security" is meaningless without knowing which repo it belongs to.
+- The repository list is fetched **lazily on first open** and shares its SWR key with the repositories page, so the palette costs nothing when that data is already cached and warms it for the page when it isn't.
+- Mounted inside the app shell, so it is absent from `/login`, `/setup` and `/demo`, where there is nothing to navigate to.
+- Documented in the existing keyboard-shortcuts modal.
+
+### Fixed
+
+#### All 11 lint warnings resolved — the codebase is now completely clean
+Worth recording what these were **not**. Every one was flagged by
+`@next/next/no-location-assign-relative-destination`, and the obvious "fix" would have been to swap `window.location.href` for `router.push()`.
+
+That would have been a **regression**. All 11 sites are authentication-state transitions — sign-out, PAT change, session expiry, first login — where a full page reload is the point: it discards the SWR cache populated under the old or now-invalid token. Using client-side navigation would leave the previous session's cached data in memory, able to render after sign-out.
+
+They are now documented in place with the specific reason at each site, rather than silently suppressed or wrongly "corrected". Behaviour is unchanged; only the explanation is new.
+
+(`src/lib/demo.ts` also reads `window.location.href`, but to parse a URL rather than to navigate — never a warning, and untouched.)
+
+### Verified
+- 327 tests still passing, `tsc` clean, **`eslint` reports 0 problems** for the first time in this series, build succeeds.
+
+### Rollback
+1. **Promote the v4.2.2 Vercel deployment** — instant.
+2. **`git revert`** — the palette is additive and the lint changes are comments only; no schema change.
+
+### Changed (infra)
+- Bumped app version from 4.2.2 to 4.2.3
+- Bumped Helm chart version from 0.6.2 to 0.6.3
+
+---
+
 ## [4.2.2] — 2026-08-15
 
 ### Overview

--- a/helm/gitdash/Chart.yaml
+++ b/helm/gitdash/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: gitdash
 description: Self-hosted GitHub Actions metrics dashboard (standalone PAT or GitHub OAuth)
 type: application
-version: 0.6.2
-appVersion: "4.2.2"
+version: 0.6.3
+appVersion: "4.2.3"
 keywords:
   - github-actions
   - dashboard

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gitdash",
-  "version": "4.2.2",
+  "version": "4.2.3",
   "private": true,
   "packageManager": "pnpm@10.30.3",
   "scripts": {

--- a/src/app/docs/page.tsx
+++ b/src/app/docs/page.tsx
@@ -2998,9 +2998,26 @@ pnpm run lint`}
 function ReleaseNotes() {
   const releases = [
     {
-      version: "4.2.2",
+      version: "4.2.3",
       date: "2026-08-15",
       badge: "latest",
+      badgeColor: "bg-emerald-500/15 text-emerald-400 border-emerald-500/20",
+      changes: {
+        added: [
+          "Command palette on ⌘K (Ctrl+K on Windows) — jump to any repository or page from anywhere. Repo-scoped destinations like Team, Issues and Security appear only while you are inside a repository, since they are meaningless without knowing which one",
+          "Fuzzy matching over both the repository name and owner/name, so \"acme/api\" finds what you expect. The repository list is fetched lazily on first open and shares its SWR key with the repositories page, so it costs nothing when that data is already cached",
+        ],
+        fixed: [],
+        improved: [
+          "All 11 outstanding lint warnings resolved — the codebase is now completely clean. Worth stating what they were NOT: every one was an authentication transition (sign-out, PAT change, session expiry, first login) where a full page reload is deliberate, because it discards the SWR cache populated under the old token",
+          "Converting those to router.push() would have been a regression: the previous session's cached data would remain in memory and could render after sign-out. They are now documented in place with the reason, rather than silently suppressed or wrongly \"fixed\"",
+        ],
+      },
+    },
+    {
+      version: "4.2.2",
+      date: "2026-08-15",
+      badge: null,
       badgeColor: "bg-emerald-500/15 text-emerald-400 border-emerald-500/20",
       changes: {
         added: [
@@ -3603,7 +3620,7 @@ function DocSidebar({
           <BookOpen className="w-4 h-4 text-violet-400" />
           <span className="text-sm font-semibold text-white">GitDash Docs</span>
           <span className="text-xs px-1.5 py-0.5 rounded bg-violet-500/15 text-violet-400 border border-violet-500/20 font-mono">
-            v{process.env.NEXT_PUBLIC_APP_VERSION ?? "4.2.2"}
+            v{process.env.NEXT_PUBLIC_APP_VERSION ?? "4.2.3"}
           </span>
         </div>
         {/* Mobile close */}
@@ -3854,7 +3871,7 @@ export default function DocsPage() {
 
           {/* Footer */}
           <footer className="mt-8 pb-4 text-center text-xs text-slate-600 space-y-1">
-            <p>GitDash v{process.env.NEXT_PUBLIC_APP_VERSION ?? "4.2.2"} — GitHub Actions Dashboard</p>
+            <p>GitDash v{process.env.NEXT_PUBLIC_APP_VERSION ?? "4.2.3"} — GitHub Actions Dashboard</p>
             <p>
               <a href="https://github.com/dinhdobathi1992/gitdash" target="_blank" rel="noreferrer" className="hover:text-slate-400 transition-colors">
                 Open source on GitHub

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -21,6 +21,7 @@ import { MissionControl, QuickActions } from "@/components/MissionControl";
 
 // ── Keyboard shortcuts modal ───────────────────────────────────────────────────
 const SHORTCUTS = [
+  { keys: ["⌘", "K"], description: "Open command palette (Ctrl+K on Windows)" },
   { keys: ["/"], description: "Focus search" },
   { keys: ["Escape"], description: "Clear search / close modal" },
   { keys: ["↑", "↓"], description: "Navigate repository list" },

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -33,6 +33,9 @@ function PatInlineForm({ login }: { login: string }) {
       });
       const data = await res.json();
       if (!res.ok) { setError(data.error ?? "Something went wrong."); return; }
+      // The PAT just changed, so every cached response was fetched with the old
+      // token. A hard reload discards that cache; router.push would keep it.
+      // eslint-disable-next-line @next/next/no-location-assign-relative-destination
       window.location.href = "/settings";
     } catch {
       setError("Network error — could not reach the server.");
@@ -58,6 +61,9 @@ function PatInlineForm({ login }: { login: string }) {
           <button
             onClick={() => {
               fetch("/api/auth/logout", { method: "POST" })
+                // Full reload on sign-out is deliberate — it clears the SWR cache so the
+              // previous session's data cannot render after logout.
+                // eslint-disable-next-line @next/next/no-location-assign-relative-destination
                 .finally(() => { window.location.href = "/setup"; });
             }}
             className="flex items-center gap-2 px-4 py-2 rounded-xl text-sm text-slate-400 hover:text-red-400 hover:bg-red-500/10 border border-slate-600 hover:border-red-500/20 transition-colors"
@@ -261,6 +267,9 @@ export default function SettingsPage() {
                 <button
                   onClick={() => {
                     fetch("/api/auth/logout", { method: "POST" })
+                      // Full reload on sign-out is deliberate — it clears the SWR cache so the
+                    // previous session's data cannot render after logout.
+                      // eslint-disable-next-line @next/next/no-location-assign-relative-destination
                       .finally(() => { window.location.href = "/login"; });
                   }}
                   className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs text-red-400 hover:text-red-300 hover:bg-red-500/10 border border-red-500/20 transition-colors shrink-0"

--- a/src/app/setup/page.tsx
+++ b/src/app/setup/page.tsx
@@ -25,6 +25,9 @@ export default function SetupPage() {
         setError(data.error ?? "Something went wrong. Try again.");
         return;
       }
+      // A session was just created; a hard load ensures every subsequent fetch
+      // runs with the new token rather than replaying pre-auth cache.
+      // eslint-disable-next-line @next/next/no-location-assign-relative-destination
       window.location.href = "/";
     } catch {
       setError("Network error — could not reach the server.");

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -4,6 +4,7 @@ import { Suspense, useState } from "react";
 import { usePathname } from "next/navigation";
 import { Menu, X } from "lucide-react";
 import Sidebar from "@/components/Sidebar";
+import CommandPalette from "@/components/CommandPalette";
 
 const FULL_PAGE_ROUTES = ["/login", "/setup", "/demo"];
 
@@ -18,6 +19,13 @@ export default function AppShell({ children }: { children: React.ReactNode }) {
   return (
     // `items-stretch` makes all direct flex children fill the full row height
     <div className="flex items-stretch min-h-screen bg-[#0f1117]">
+
+      {/* Global ⌘K. Rendered inside the shell so it is absent from the
+          full-page auth routes, where there is nothing to navigate to. */}
+      <Suspense fallback={null}>
+        <CommandPalette />
+      </Suspense>
+
 
       {/* Desktop sidebar — sticky, full viewport height, scrolls internally */}
       <div className="hidden md:block md:w-60 shrink-0 bg-[#0d1117] border-r border-slate-800">

--- a/src/components/CommandPalette.tsx
+++ b/src/components/CommandPalette.tsx
@@ -1,0 +1,283 @@
+"use client";
+
+/**
+ * Command palette (v4.2.3) — ⌘K / Ctrl+K.
+ *
+ * GitDash has ~20 pages and, in a real org, hundreds of repositories.
+ * Navigation was a sidebar plus page-local search, which means reaching a
+ * specific repo took several clicks from anywhere that wasn't the repo list.
+ *
+ * Two deliberate choices:
+ *
+ *  - Repo results reuse the SAME SWR key as the repositories page, so opening
+ *    the palette costs nothing when that data is already cached, and warms it
+ *    for the page when it isn't.
+ *  - Repo-scoped destinations (Team, Security, Issues…) only appear while you
+ *    are inside a repo, because "Security" is meaningless without knowing
+ *    which repo it belongs to.
+ */
+
+import { useState, useEffect, useMemo, useRef, useCallback } from "react";
+import { useRouter, usePathname } from "next/navigation";
+import useSWR from "swr";
+import { fetcher } from "@/lib/swr";
+import type { Repo } from "@/lib/github";
+import { fuzzyMatch, highlightSegments, cn } from "@/lib/utils";
+import {
+  Search, CornerDownLeft, ArrowUp, ArrowDown, Book, Bell, Settings2,
+  BarChart3, Users, DollarSign, TrendingUp, LayoutGrid, GitBranch,
+  ShieldCheck, FileText, CircleDot, Trophy,
+} from "lucide-react";
+
+interface Command {
+  id: string;
+  label: string;
+  /** Shown to the right — the path, or the repo owner. */
+  hint?: string;
+  href: string;
+  icon: React.ElementType;
+  group: "Repositories" | "This repository" | "Go to";
+}
+
+const STATIC_COMMANDS: Command[] = [
+  { id: "nav-repos", label: "Repositories", href: "/", icon: LayoutGrid, group: "Go to" },
+  { id: "nav-team", label: "Team Insights", href: "/team", icon: Users, group: "Go to" },
+  { id: "nav-cost", label: "Cost Analytics", href: "/cost-analytics", icon: DollarSign, group: "Go to" },
+  { id: "nav-reports", label: "Reports", href: "/reports", icon: TrendingUp, group: "Go to" },
+  { id: "nav-alerts", label: "Alerts", href: "/alerts", icon: Bell, group: "Go to" },
+  { id: "nav-docs", label: "Documentation", href: "/docs", icon: Book, group: "Go to" },
+  { id: "nav-settings", label: "Settings", href: "/settings", icon: Settings2, group: "Go to" },
+];
+
+/** Extract owner/repo when the current path is inside a repository. */
+function currentRepo(path: string): { owner: string; repo: string } | null {
+  const m = path.match(/^\/repos\/([^/]+)\/([^/]+)/);
+  return m ? { owner: decodeURIComponent(m[1]), repo: decodeURIComponent(m[2]) } : null;
+}
+
+const MAX_REPO_RESULTS = 8;
+
+export default function CommandPalette() {
+  const router = useRouter();
+  const path = usePathname();
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState("");
+  const [active, setActive] = useState(0);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const listRef = useRef<HTMLDivElement>(null);
+
+  // Only fetch once the palette has been opened — the shell mounts this on
+  // every page and should not pull a repo list nobody asked for.
+  const [everOpened, setEverOpened] = useState(false);
+  const { data: repos } = useSWR<Repo[]>(
+    everOpened ? "/api/github/repos" : null,
+    fetcher<Repo[]>,
+  );
+
+  const inRepo = currentRepo(path);
+
+  const commands = useMemo<Command[]>(() => {
+    const list: Command[] = [];
+
+    if (inRepo) {
+      const base = `/repos/${inRepo.owner}/${inRepo.repo}`;
+      list.push(
+        { id: "r-overview", label: "Overview", hint: inRepo.repo, href: base, icon: BarChart3, group: "This repository" },
+        { id: "r-team", label: "Team Analytics", hint: inRepo.repo, href: `${base}/team`, icon: Trophy, group: "This repository" },
+        { id: "r-issues", label: "Issue & Triage Health", hint: inRepo.repo, href: `${base}/issues`, icon: CircleDot, group: "This repository" },
+        { id: "r-security", label: "Security", hint: inRepo.repo, href: `${base}/security`, icon: ShieldCheck, group: "This repository" },
+        { id: "r-audit", label: "Audit Trail", hint: inRepo.repo, href: `${base}/audit`, icon: FileText, group: "This repository" },
+      );
+    }
+
+    for (const r of repos ?? []) {
+      list.push({
+        id: `repo-${r.owner}/${r.name}`,
+        label: r.name,
+        hint: r.owner,
+        href: `/repos/${r.owner}/${r.name}`,
+        icon: GitBranch,
+        group: "Repositories",
+      });
+    }
+
+    list.push(...STATIC_COMMANDS);
+    return list;
+  }, [repos, inRepo]);
+
+  const results = useMemo<(Command & { _indices: number[] })[]>(() => {
+    const q = query.trim();
+    if (!q) {
+      // Empty query: repo-scoped actions first, then navigation. Showing the
+      // full repo list unfiltered would bury everything else.
+      return commands
+        .filter((c) => c.group !== "Repositories")
+        .slice(0, 12)
+        .map((c) => ({ ...c, _indices: [] }));
+    }
+
+    const scored: { cmd: Command; indices: number[]; group: string }[] = [];
+    for (const cmd of commands) {
+      const onLabel = fuzzyMatch(cmd.label, q);
+      if (onLabel.match) {
+        scored.push({ cmd, indices: onLabel.indices, group: cmd.group });
+        continue;
+      }
+      // Fall back to "owner/name" so "acme/api" finds a repo.
+      if (cmd.hint && fuzzyMatch(`${cmd.hint}/${cmd.label}`, q).match) {
+        scored.push({ cmd, indices: [], group: cmd.group });
+      }
+    }
+
+    const repoHits = scored.filter((s) => s.group === "Repositories").slice(0, MAX_REPO_RESULTS);
+    const rest = scored.filter((s) => s.group !== "Repositories");
+    return [...rest, ...repoHits].map((s) => ({ ...s.cmd, _indices: s.indices }));
+  }, [commands, query]);
+
+  const close = useCallback(() => {
+    setOpen(false);
+    setQuery("");
+    setActive(0);
+  }, []);
+
+  const run = useCallback(
+    (cmd: Command) => {
+      close();
+      // router.push, not window.location — this is ordinary in-app navigation
+      // with no auth change, so the SWR cache should survive it.
+      router.push(cmd.href);
+    },
+    [close, router],
+  );
+
+  // Global shortcut.
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "k") {
+        e.preventDefault();
+        setEverOpened(true);
+        setOpen((v) => !v);
+        return;
+      }
+      if (e.key === "Escape" && open) close();
+    }
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [open, close]);
+
+  useEffect(() => {
+    if (open) inputRef.current?.focus();
+  }, [open]);
+
+  // Keep the highlighted row in view when navigating by keyboard.
+  useEffect(() => {
+    listRef.current?.querySelector<HTMLElement>(`[data-idx="${active}"]`)?.scrollIntoView({ block: "nearest" });
+  }, [active]);
+
+  if (!open) return null;
+
+  const clamped = Math.min(active, Math.max(0, results.length - 1));
+
+  function onInputKey(e: React.KeyboardEvent<HTMLInputElement>) {
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      setActive((i) => Math.min(i + 1, results.length - 1));
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      setActive((i) => Math.max(i - 1, 0));
+    } else if (e.key === "Enter") {
+      e.preventDefault();
+      const hit = results[clamped];
+      if (hit) run(hit);
+    }
+  }
+
+  let lastGroup = "";
+
+  return (
+    <div
+      className="fixed inset-0 z-[60] flex items-start justify-center pt-[12vh] px-4 bg-black/60 backdrop-blur-sm"
+      onClick={close}
+      role="dialog"
+      aria-modal="true"
+      aria-label="Command palette"
+    >
+      <div
+        className="w-full max-w-xl rounded-2xl border border-slate-700 bg-slate-900 shadow-2xl overflow-hidden"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-center gap-3 px-4 border-b border-slate-800">
+          <Search className="w-4 h-4 text-slate-500 shrink-0" />
+          <input
+            ref={inputRef}
+            value={query}
+            onChange={(e) => { setQuery(e.target.value); setActive(0); }}
+            onKeyDown={onInputKey}
+            placeholder="Search repositories and pages…"
+            className="flex-1 bg-transparent py-3.5 text-sm text-slate-100 placeholder-slate-600 focus:outline-none"
+          />
+          <kbd className="shrink-0 px-1.5 py-0.5 text-[10px] font-mono bg-slate-800 border border-slate-700 rounded text-slate-500">
+            ESC
+          </kbd>
+        </div>
+
+        <div ref={listRef} className="max-h-[52vh] overflow-y-auto py-2">
+          {results.length === 0 && (
+            <p className="px-4 py-8 text-center text-sm text-slate-500">
+              No matches for “{query}”.
+            </p>
+          )}
+
+          {results.map((cmd, i) => {
+            const Icon = cmd.icon;
+            const showGroup = cmd.group !== lastGroup;
+            lastGroup = cmd.group;
+            const segments = cmd._indices.length
+              ? highlightSegments(cmd.label, cmd._indices)
+              : [{ text: cmd.label, highlight: false }];
+
+            return (
+              <div key={cmd.id}>
+                {showGroup && (
+                  <div className="px-4 pt-3 pb-1 text-[10px] font-semibold uppercase tracking-[0.12em] text-slate-600">
+                    {cmd.group}
+                  </div>
+                )}
+                <button
+                  data-idx={i}
+                  onMouseEnter={() => setActive(i)}
+                  onClick={() => run(cmd)}
+                  className={cn(
+                    "w-full flex items-center gap-3 px-4 py-2.5 text-left transition-colors",
+                    i === clamped ? "bg-violet-500/15" : "hover:bg-slate-800/60",
+                  )}
+                >
+                  <Icon className={cn("w-4 h-4 shrink-0", i === clamped ? "text-violet-300" : "text-slate-500")} />
+                  <span className="flex-1 min-w-0 text-sm text-slate-200 truncate">
+                    {segments.map((s, si) =>
+                      s.highlight
+                        ? <mark key={si} className="bg-transparent text-violet-300 font-semibold">{s.text}</mark>
+                        : <span key={si}>{s.text}</span>,
+                    )}
+                  </span>
+                  {cmd.hint && (
+                    <span className="shrink-0 font-mono text-[11px] text-slate-600 truncate max-w-[40%]">
+                      {cmd.hint}
+                    </span>
+                  )}
+                  {i === clamped && <CornerDownLeft className="w-3.5 h-3.5 shrink-0 text-slate-500" />}
+                </button>
+              </div>
+            );
+          })}
+        </div>
+
+        <div className="flex items-center gap-4 px-4 py-2 border-t border-slate-800 text-[11px] text-slate-600">
+          <span className="flex items-center gap-1"><ArrowUp className="w-3 h-3" /><ArrowDown className="w-3 h-3" /> navigate</span>
+          <span className="flex items-center gap-1"><CornerDownLeft className="w-3 h-3" /> open</span>
+          <span className="ml-auto font-mono">⌘K</span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -280,6 +280,8 @@ export default function Sidebar({ onClose }: { onClose?: () => void } = {}) {
                 <button
                   onClick={() => {
                     fetch("/api/auth/logout", { method: "POST" })
+                      // Deliberate hard reload on sign-out — clears the SWR cache.
+                      // eslint-disable-next-line @next/next/no-location-assign-relative-destination
                       .finally(() => { window.location.href = "/setup"; });
                   }}
                   className="flex items-center gap-2.5 px-3 py-2 rounded-lg text-sm text-amber-400 hover:text-amber-300 hover:bg-amber-500/10 transition-colors w-full text-left"
@@ -291,6 +293,8 @@ export default function Sidebar({ onClose }: { onClose?: () => void } = {}) {
                 <button
                   onClick={() => {
                     fetch("/api/auth/logout", { method: "POST" })
+                      // Deliberate hard reload on sign-out — clears the SWR cache.
+                      // eslint-disable-next-line @next/next/no-location-assign-relative-destination
                       .finally(() => { window.location.href = "/login"; });
                   }}
                   className="flex items-center gap-2.5 px-3 py-2 rounded-lg text-sm text-red-400 hover:text-red-300 hover:bg-red-500/10 transition-colors w-full text-left"

--- a/src/components/shell/MobileNavDrawer.tsx
+++ b/src/components/shell/MobileNavDrawer.tsx
@@ -174,6 +174,8 @@ export default function MobileNavDrawer({ open, onClose }: Props) {
                   <button
                     onClick={() => {
                       fetch("/api/auth/logout", { method: "POST" })
+                        // Deliberate hard reload on sign-out — clears the SWR cache.
+                        // eslint-disable-next-line @next/next/no-location-assign-relative-destination
                         .finally(() => { window.location.href = "/setup"; });
                     }}
                     className="flex items-center gap-2.5 px-3 py-2 rounded-lg text-sm text-amber-400 hover:text-amber-300 hover:bg-amber-500/10 transition-colors w-full text-left cursor-pointer"
@@ -185,6 +187,8 @@ export default function MobileNavDrawer({ open, onClose }: Props) {
                   <button
                     onClick={() => {
                       fetch("/api/auth/logout", { method: "POST" })
+                        // Deliberate hard reload on sign-out — clears the SWR cache.
+                        // eslint-disable-next-line @next/next/no-location-assign-relative-destination
                         .finally(() => { window.location.href = "/login"; });
                     }}
                     className="flex items-center gap-2.5 px-3 py-2 rounded-lg text-sm text-red-400 hover:text-red-300 hover:bg-red-500/10 transition-colors w-full text-left cursor-pointer"

--- a/src/components/shell/WorkspacePanel.tsx
+++ b/src/components/shell/WorkspacePanel.tsx
@@ -194,6 +194,8 @@ function AccountCard() {
             <button
               onClick={() => {
                 fetch("/api/auth/logout", { method: "POST" })
+                  // Deliberate hard reload on sign-out — clears the SWR cache.
+                  // eslint-disable-next-line @next/next/no-location-assign-relative-destination
                   .finally(() => { window.location.href = "/setup"; });
               }}
               className="flex items-center gap-2.5 px-3 py-2 rounded-lg text-xs text-amber-400 hover:text-amber-300 hover:bg-amber-500/10 transition-colors w-full text-left cursor-pointer"
@@ -205,6 +207,8 @@ function AccountCard() {
             <button
               onClick={() => {
                 fetch("/api/auth/logout", { method: "POST" })
+                  // Deliberate hard reload on sign-out — clears the SWR cache.
+                  // eslint-disable-next-line @next/next/no-location-assign-relative-destination
                   .finally(() => { window.location.href = "/login"; });
               }}
               className="flex items-center gap-2.5 px-3 py-2 rounded-lg text-xs text-red-400 hover:text-red-300 hover:bg-red-500/10 transition-colors w-full text-left cursor-pointer"

--- a/src/lib/swr.tsx
+++ b/src/lib/swr.tsx
@@ -52,6 +52,9 @@ export function SWRProvider({ children }: { children: React.ReactNode }) {
             typeof window !== "undefined" &&
             !["/login", "/setup", "/docs"].includes(window.location.pathname)
           ) {
+            // The session expired. A hard reload drops the stale cache rather than
+            // carrying it into the re-authenticated session.
+            // eslint-disable-next-line @next/next/no-location-assign-relative-destination
             window.location.href = "/";
           }
         },


### PR DESCRIPTION
Last of the four. Ships the ⌘K palette — and corrects something I told you.

## ⌘K command palette

Jump to any repository or page from anywhere. ~20 pages and, in a real org, hundreds of repos; navigation was sidebar + page-local search, so reaching a specific repo took several clicks from anywhere that wasn't the repo list.

- Fuzzy match on both repo name and `owner/name`, so `acme/api` works
- **Repo-scoped destinations** (Team, Issues, Security, Audit) appear only when you're inside a repo — "Security" is meaningless without knowing which one
- Repo list fetched **lazily on first open**, sharing its SWR key with the repositories page — costs nothing when already cached
- Absent from `/login`, `/setup`, `/demo` where there's nothing to navigate to
- Added to the existing shortcuts modal

## ⚠️ I was wrong about the 11 lint warnings

When I proposed this work I said they were *"a real UX bug — every one triggers a full page reload instead of client navigation."*

**That was incorrect.** Reading each site: all 11 are **authentication-state transitions** — sign-out, PAT change, session expiry, first login. The full reload is deliberate. It discards the SWR cache populated under the old or now-invalid token.

Swapping them for `router.push()` — the "obvious" fix, and what the lint rule suggests — would have been a **regression**: the previous session's cached data would stay in memory and could render after sign-out.

So I documented the intent at each site instead. **Behaviour is unchanged; only the explanation is new.** `eslint` now reports **0 problems** for the first time in this series.

(`src/lib/demo.ts` also touches `window.location.href`, but reads it to parse a URL rather than navigating — never a warning, untouched.)

## Test plan

- [x] `pnpm exec tsc --noEmit` — **0 errors**
- [x] `pnpm test` — **327/327**
- [x] `pnpm run lint` — **0 problems** (was 11 warnings)
- [x] `rm -rf .next && pnpm run build` — succeeds
- [x] API Reference parity — clean (no new routes)
- [x] Version bumped in all locations; release-notes entries verified intact

## Rollback

Palette is additive; lint changes are comments only. Promote v4.2.2 or `git revert`. No schema change.