### PR TITLE
fix: v4.2.4 + v4.2.5 — deployment metrics, selectable environment, consistent headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,45 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ---
 
+## [4.2.4] — 2026-08-15
+
+### Overview
+Bug fix reported immediately after v4.2.3: a repository with 75 deployments in the window showed **0.00 deploys/day**, a null change failure rate, and a null MTTR — while the per-environment table below it clearly showed active deployments with real failure rates.
+
+Three distinct defects, all in v4.2.1's deployment metrics.
+
+### Fixed
+
+#### 1. The headline environment could be starved of status lookups
+- Status is one API call per deployment, so lookups are capped at 40. That cap was applied to **the most recent 40 deployments overall**.
+- On a repo busy enough to exceed it, none of those 40 necessarily belonged to the chosen production environment — leaving `prodConclusive = 0` and every headline figure empty on a repo that deploys constantly. The reported numbers gave it away exactly: 34 ok + 6 failed = 40, the cap.
+- The production environment is now **selected before statuses are fetched**, its deployments resolved first, and the remaining budget spent on other environments so their per-environment rates still populate.
+
+#### 2. Environment matching was exact, so platform-labelled environments were missed
+- Names were compared with equality against `production`/`prod`/`live`/`main`. Platforms label environments things like **"Production — my-app"**, which never matched — so a bare, stale `Production` with fewer deployments was chosen over the environment actually in use.
+- Matching is now **word-boundary based**, and within a matching tier the **busiest environment wins**, since a repo deploying to several production targets should report the one it actually uses.
+- Word boundaries also prevent `main` matching unrelated names such as `domain-staging`.
+
+#### 3. Deploy frequency reported 0.00 instead of null
+- With no conclusive production status, frequency was computed as `0 / periodDays` and rendered as **0.00 deploys/day** — an assertion that the team ships nothing.
+- It now returns **null**, consistent with the change failure rate and MTTR, which already made this distinction. This is the same principle v4.2.1 was built on; the frequency path simply missed it.
+
+### Changed
+- The partial-sample note now explains that production is resolved first, so headline figures are complete even when other environments are sampled.
+
+### Verified
+- Test count 327 → 332. The regression test reproduces the reported shape directly: 60 preview + 15 production deployments against a 40-lookup budget, asserting production still resolves to real figures rather than a starved zero.
+
+### Rollback
+1. **Promote the v4.2.3 Vercel deployment** — instant.
+2. **`git revert`** — one library file, one UI string; no schema change.
+
+### Changed (infra)
+- Bumped app version from 4.2.3 to 4.2.4
+- Bumped Helm chart version from 0.6.3 to 0.6.4
+
+---
+
 ## [4.2.3] — 2026-08-15
 
 ### Overview

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,43 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ---
 
+## [4.2.5] — 2026-08-15
+
+### Overview
+UI consistency and control, both reported directly after v4.2.4.
+
+### Added
+
+#### Selectable deployment environment
+- The environment driving the headline figures is now chosen by clicking any row under **By environment**, rather than being picked automatically.
+- Auto-detection can only ever *guess* when a repository deploys to several production targets — this repo deploys to two, so no heuristic gets it right for everyone. Letting the user choose beats guessing better.
+- The choice is **remembered per repository**, and falls back to auto-detection if the saved environment no longer appears in the window.
+- Every environment now carries its own `deploys_per_day`, `failure_rate_pct`, `mttr_hours` and `mttr_samples`, so switching is instant with no refetch, and environments can be compared directly.
+- The header states which environment is in use and whether it was auto-detected or chosen.
+
+### Fixed
+
+#### Collapsible headers were inconsistent across the app
+- The polished card header built for Team Analytics in v4.0.11 was left as a **local function in that one page**. Every other collapsible kept its original bare `› Show …` text toggle.
+- The inconsistency became obvious once v4.2.1 put a fully-styled Deployments card directly beneath a plain text link on the repository overview.
+- Extracted to `src/components/CollapsibleSection.tsx` and applied to the **DORA drill-down** and **PR Lifecycle** sections. Team Analytics now imports the shared component instead of its private copy, so the six sections there are unchanged but no longer duplicated.
+
+### Changed
+- Environment selection uses a lazy `useState` initialiser rather than an effect: React 19 forbids `setState` inside an effect, and there is no hydration risk because the environment list only renders once client-side data has arrived.
+
+### Verified
+- 332 tests passing, `tsc` clean, `eslint` **0 problems**, build succeeds.
+
+### Rollback
+1. **Promote the v4.2.4 Vercel deployment** — instant.
+2. **`git revert`** — presentational plus one additive API field; no schema change.
+
+### Changed (infra)
+- Bumped app version from 4.2.4 to 4.2.5
+- Bumped Helm chart version from 0.6.4 to 0.6.5
+
+---
+
 ## [4.2.4] — 2026-08-15
 
 ### Overview

--- a/helm/gitdash/Chart.yaml
+++ b/helm/gitdash/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: gitdash
 description: Self-hosted GitHub Actions metrics dashboard (standalone PAT or GitHub OAuth)
 type: application
-version: 0.6.3
-appVersion: "4.2.3"
+version: 0.6.4
+appVersion: "4.2.4"
 keywords:
   - github-actions
   - dashboard

--- a/helm/gitdash/Chart.yaml
+++ b/helm/gitdash/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: gitdash
 description: Self-hosted GitHub Actions metrics dashboard (standalone PAT or GitHub OAuth)
 type: application
-version: 0.6.4
-appVersion: "4.2.4"
+version: 0.6.5
+appVersion: "4.2.5"
 keywords:
   - github-actions
   - dashboard

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gitdash",
-  "version": "4.2.3",
+  "version": "4.2.4",
   "private": true,
   "packageManager": "pnpm@10.30.3",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gitdash",
-  "version": "4.2.4",
+  "version": "4.2.5",
   "private": true,
   "packageManager": "pnpm@10.30.3",
   "scripts": {

--- a/src/app/docs/page.tsx
+++ b/src/app/docs/page.tsx
@@ -2998,9 +2998,25 @@ pnpm run lint`}
 function ReleaseNotes() {
   const releases = [
     {
-      version: "4.2.4",
+      version: "4.2.5",
       date: "2026-08-15",
       badge: "latest",
+      badgeColor: "bg-emerald-500/15 text-emerald-400 border-emerald-500/20",
+      changes: {
+        added: [
+          "The deployment environment driving the headline figures is now selectable — click any row under \"By environment\". Auto-detection can only ever guess when a repository deploys to several production targets, so choosing beats guessing better. The choice is remembered per repository",
+          "Every environment now carries its own deploys/day, change failure rate and MTTR, so switching is instant and environments can be compared directly",
+        ],
+        fixed: [
+          "The collapsible card header built for Team Analytics in v4.0.11 was left as a local function in that one page, so the DORA drill-down and PR lifecycle toggles on the repository overview kept their original bare \"› Show …\" text style. Extracted to a shared component and applied to both — the inconsistency was obvious once polished cards sat directly beneath a plain text link",
+        ],
+        improved: [],
+      },
+    },
+    {
+      version: "4.2.4",
+      date: "2026-08-15",
+      badge: null,
       badgeColor: "bg-emerald-500/15 text-emerald-400 border-emerald-500/20",
       changes: {
         added: [],
@@ -3637,7 +3653,7 @@ function DocSidebar({
           <BookOpen className="w-4 h-4 text-violet-400" />
           <span className="text-sm font-semibold text-white">GitDash Docs</span>
           <span className="text-xs px-1.5 py-0.5 rounded bg-violet-500/15 text-violet-400 border border-violet-500/20 font-mono">
-            v{process.env.NEXT_PUBLIC_APP_VERSION ?? "4.2.4"}
+            v{process.env.NEXT_PUBLIC_APP_VERSION ?? "4.2.5"}
           </span>
         </div>
         {/* Mobile close */}
@@ -3888,7 +3904,7 @@ export default function DocsPage() {
 
           {/* Footer */}
           <footer className="mt-8 pb-4 text-center text-xs text-slate-600 space-y-1">
-            <p>GitDash v{process.env.NEXT_PUBLIC_APP_VERSION ?? "4.2.4"} — GitHub Actions Dashboard</p>
+            <p>GitDash v{process.env.NEXT_PUBLIC_APP_VERSION ?? "4.2.5"} — GitHub Actions Dashboard</p>
             <p>
               <a href="https://github.com/dinhdobathi1992/gitdash" target="_blank" rel="noreferrer" className="hover:text-slate-400 transition-colors">
                 Open source on GitHub

--- a/src/app/docs/page.tsx
+++ b/src/app/docs/page.tsx
@@ -2998,9 +2998,26 @@ pnpm run lint`}
 function ReleaseNotes() {
   const releases = [
     {
-      version: "4.2.3",
+      version: "4.2.4",
       date: "2026-08-15",
       badge: "latest",
+      badgeColor: "bg-emerald-500/15 text-emerald-400 border-emerald-500/20",
+      changes: {
+        added: [],
+        fixed: [
+          "Deployment metrics showed 0.00 deploys/day with a null failure rate on repositories that deploy constantly. Status lookups are capped at 40 per request, and were taken from the most recent deployments overall — so on a busy repo none of them belonged to the chosen production environment, leaving every headline figure empty. The production environment is now selected first and its statuses resolved first, with the remaining budget covering other environments",
+          "Environment matching used exact names, so a platform-labelled environment like \"Production — my-app\" was skipped in favour of a bare, stale \"Production\". Matching is now word-boundary based, and within a tier the busiest environment wins. Word boundaries also stop \"main\" matching names like \"domain-staging\"",
+          "Deploy frequency reported 0.00 when no production status could be resolved. 0.00 asserts that a team ships nothing; the honest answer when statuses are unknown is that we cannot say, so it now returns null like the change failure rate and MTTR already did",
+        ],
+        improved: [
+          "The partial-sample note now explains that production is resolved first, so headline figures are complete even when other environments are sampled",
+        ],
+      },
+    },
+    {
+      version: "4.2.3",
+      date: "2026-08-15",
+      badge: null,
       badgeColor: "bg-emerald-500/15 text-emerald-400 border-emerald-500/20",
       changes: {
         added: [
@@ -3620,7 +3637,7 @@ function DocSidebar({
           <BookOpen className="w-4 h-4 text-violet-400" />
           <span className="text-sm font-semibold text-white">GitDash Docs</span>
           <span className="text-xs px-1.5 py-0.5 rounded bg-violet-500/15 text-violet-400 border border-violet-500/20 font-mono">
-            v{process.env.NEXT_PUBLIC_APP_VERSION ?? "4.2.3"}
+            v{process.env.NEXT_PUBLIC_APP_VERSION ?? "4.2.4"}
           </span>
         </div>
         {/* Mobile close */}
@@ -3871,7 +3888,7 @@ export default function DocsPage() {
 
           {/* Footer */}
           <footer className="mt-8 pb-4 text-center text-xs text-slate-600 space-y-1">
-            <p>GitDash v{process.env.NEXT_PUBLIC_APP_VERSION ?? "4.2.3"} — GitHub Actions Dashboard</p>
+            <p>GitDash v{process.env.NEXT_PUBLIC_APP_VERSION ?? "4.2.4"} — GitHub Actions Dashboard</p>
             <p>
               <a href="https://github.com/dinhdobathi1992/gitdash" target="_blank" rel="noreferrer" className="hover:text-slate-400 transition-colors">
                 Open source on GitHub

--- a/src/app/repos/[owner]/[repo]/page.tsx
+++ b/src/app/repos/[owner]/[repo]/page.tsx
@@ -14,10 +14,11 @@ import { DoraKpiCards, DoraKpiSkeleton } from "@/components/DoraKpiCards";
 import PartialDataBadge from "@/components/PartialDataBadge";
 import AiInsightsCard from "@/components/AiInsightsCard";
 import DeploymentsPanel from "@/components/DeploymentsPanel";
+import CollapsibleSection from "@/components/CollapsibleSection";
 import type { OpenPrHealthResponse } from "@/app/api/github/open-pr-health/route";
 import {
   AlertCircle, ExternalLink, GitBranch, FileCode, RefreshCw,
-  Search, X, ChevronRight, Zap, Shield, Users, ShieldCheck, CircleDot,
+  Search, X, ChevronRight, Zap, Shield, Users, ShieldCheck, CircleDot, BarChart3,
 } from "lucide-react";
 import { cn, fuzzyMatch, highlightSegments } from "@/lib/utils";
 import { useFeatureFlags } from "@/components/FeatureFlagsProvider";
@@ -466,18 +467,20 @@ export default function RepoDetailPage() {
                   <PartialDataBadge fetched={dora.fetched_prs} total={dora.total_prs_attempted} unit="PRs" />
                 )}
                 <DoraKpiCards data={dora} />
-                <button
-                  onClick={() => setShowDrillDown(v => !v)}
-                  className="flex items-center gap-1.5 text-xs text-slate-400 hover:text-violet-300 transition-colors"
+                <CollapsibleSection
+                  icon={BarChart3}
+                  tone="violet"
+                  title="DORA drill-down"
+                  subtitle="Cycle time breakdown, PR size vs velocity, throughput and workflow stability — what the four numbers above are made of"
+                  open={showDrillDown}
+                  onToggle={() => setShowDrillDown(v => !v)}
                 >
-                  <ChevronRight
-                    className={cn("w-3.5 h-3.5 transition-transform", showDrillDown && "rotate-90")}
-                  />
-                  {showDrillDown ? "Hide" : "Show"} drill-down charts
-                </button>
-                {showDrillDown && overview && (
-                  <DoraDrillDown dora={dora} overview={overview} />
-                )}
+                  {overview ? (
+                    <DoraDrillDown dora={dora} overview={overview} />
+                  ) : (
+                    <p className="text-xs text-slate-500">Workflow data is still loading.</p>
+                  )}
+                </CollapsibleSection>
               </div>
             ) : null
           ) : (
@@ -494,24 +497,22 @@ export default function RepoDetailPage() {
 
           {/* PR Lifecycle Extension */}
           {flags.prLifecycle ? (
-            <div>
-              <button
-                onClick={() => setShowPrLifecycle(v => !v)}
-                className="flex items-center gap-1.5 text-xs text-slate-400 hover:text-violet-300 transition-colors"
-              >
-                <ChevronRight
-                  className={cn("w-3.5 h-3.5 transition-transform", showPrLifecycle && "rotate-90")}
-                />
-                {showPrLifecycle ? "Hide" : "Show"} PR lifecycle analytics
-              </button>
-              {showPrLifecycle && (
-                prHealthLoading ? (
-                  <PrLifecycleInlineSkeleton />
-                ) : prHealth ? (
-                  <div className="mt-3"><PrLifecycleExtension data={prHealth} /></div>
-                ) : null
+            <CollapsibleSection
+              icon={GitBranch}
+              tone="cyan"
+              title="PR Lifecycle Analytics"
+              subtitle="Open PR health, review response times, abandon rate and age distribution"
+              open={showPrLifecycle}
+              onToggle={() => setShowPrLifecycle(v => !v)}
+            >
+              {prHealthLoading ? (
+                <PrLifecycleInlineSkeleton />
+              ) : prHealth ? (
+                <PrLifecycleExtension data={prHealth} />
+              ) : (
+                <p className="text-xs text-slate-500">PR lifecycle data is unavailable.</p>
               )}
-            </div>
+            </CollapsibleSection>
           ) : null}
 
           {/* Duration chart */}

--- a/src/app/repos/[owner]/[repo]/team/page.tsx
+++ b/src/app/repos/[owner]/[repo]/team/page.tsx
@@ -30,7 +30,6 @@ import {
   Trophy,
   Shield,
   ArrowLeft,
-  ChevronRight,
   BarChart3,
   Grid3X3,
   FolderTree,
@@ -38,6 +37,7 @@ import {
   Moon,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
+import CollapsibleSection from "@/components/CollapsibleSection";
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -266,57 +266,6 @@ function ContributorCard({
 // Design reference: claude.ai/design "Scorecard board redesign" project,
 // "Section Headers.dc.html" — adapted to the app's existing icon language
 // (lucide icons in place of the design's abstract bar glyph) and Tailwind tokens.
-
-type Tone = "violet" | "cyan" | "amber" | "green" | "red";
-
-const SECTION_TONES: Record<Tone, { text: string; bg: string; border: string; stripe: string }> = {
-  violet: { text: "text-violet-300", bg: "bg-violet-500/[0.14]", border: "border-violet-500/30", stripe: "bg-gradient-to-b from-violet-400 to-violet-600" },
-  cyan: { text: "text-cyan-300", bg: "bg-cyan-500/[0.14]", border: "border-cyan-500/30", stripe: "bg-gradient-to-b from-cyan-400 to-cyan-600" },
-  amber: { text: "text-amber-300", bg: "bg-amber-500/[0.14]", border: "border-amber-500/30", stripe: "bg-gradient-to-b from-amber-400 to-amber-600" },
-  green: { text: "text-emerald-300", bg: "bg-emerald-500/[0.14]", border: "border-emerald-500/30", stripe: "bg-gradient-to-b from-emerald-400 to-emerald-600" },
-  red: { text: "text-red-300", bg: "bg-red-500/[0.14]", border: "border-red-500/30", stripe: "bg-gradient-to-b from-red-400 to-red-600" },
-};
-
-function Section({
-  icon: Icon, tone, title, badge, subtitle, open, onToggle, children,
-}: {
-  icon: React.ElementType; tone: Tone; title: string; badge?: string; subtitle: string;
-  open: boolean; onToggle: () => void; children: React.ReactNode;
-}) {
-  const t = SECTION_TONES[tone];
-  return (
-    <div className="rounded-2xl border border-slate-800 bg-gradient-to-b from-slate-900/50 to-slate-950/70 shadow-[0_40px_80px_-55px_rgba(0,0,0,1)] overflow-hidden">
-      <button
-        onClick={onToggle}
-        className={cn(
-          "w-full relative flex items-center gap-4 px-5 py-4 text-left transition-colors hover:bg-slate-800/40",
-          open && "border-b border-slate-800",
-        )}
-      >
-        <span className={cn("absolute inset-y-0 left-0 w-[2px]", t.stripe)} />
-        <span className={cn("shrink-0 w-9 h-9 rounded-lg border flex items-center justify-center", t.bg, t.border)}>
-          <Icon className={cn("w-4 h-4", t.text)} />
-        </span>
-        <div className="min-w-0 flex-1">
-          <div className="flex items-center gap-2.5 flex-wrap">
-            <span className="text-[15px] font-semibold text-white">{title}</span>
-            {badge && (
-              <span className={cn("font-mono text-[11px] px-2 py-0.5 rounded-full border whitespace-nowrap", t.bg, t.border, t.text)}>
-                {badge}
-              </span>
-            )}
-          </div>
-          <p className="text-xs text-slate-500 mt-0.5">{subtitle}</p>
-        </div>
-        <span className="shrink-0 flex items-center gap-1.5 px-3 py-1.5 rounded-lg border border-slate-700 bg-gradient-to-b from-slate-800 to-slate-900 text-xs text-slate-300">
-          {open ? "Hide" : "Show"}
-          <ChevronRight className={cn("w-3 h-3 transition-transform", open && "rotate-90")} />
-        </span>
-      </button>
-      {open && <div className="p-5">{children}</div>}
-    </div>
-  );
-}
 
 // ── Summary row ───────────────────────────────────────────────────────────────
 
@@ -549,34 +498,34 @@ export default function TeamAnalyticsPage() {
                 </span>
               </div>
 
-              <Section
+              <CollapsibleSection
                 icon={BarChart3} tone="violet" title="PR Leaderboard"
                 badge={`${contribData.contributors.length} contributor${contribData.contributors.length === 1 ? "" : "s"}`}
                 subtitle="Merge volume, review load and lead time per contributor"
                 open={showLeaderboard} onToggle={() => setShowLeaderboard((v) => !v)}
               >
                 <TeamLeaderboard contributors={contribData.contributors} owner={owner} repo={repo} />
-              </Section>
+              </CollapsibleSection>
 
               {contribData.reviewer_matrix.length > 0 && (
-                <Section
+                <CollapsibleSection
                   icon={Grid3X3} tone="cyan" title="Reviewer Load Matrix"
                   badge={`${new Set(contribData.reviewer_matrix.map((c) => c.author)).size} × ${new Set(contribData.reviewer_matrix.map((c) => c.reviewer)).size}`}
                   subtitle="Who reviews whose PRs — rows are PR authors, columns are reviewers"
                   open={showMatrix} onToggle={() => setShowMatrix((v) => !v)}
                 >
                   <ReviewerLoadMatrix matrix={contribData.reviewer_matrix} />
-                </Section>
+                </CollapsibleSection>
               )}
 
               {flags.reviewBottleneck ? (
-                <Section
+                <CollapsibleSection
                   icon={AlertTriangle} tone="amber" title="Review Bottleneck"
                   subtitle="Overloaded reviewers and single-point-of-failure review dependencies"
                   open={showBottleneck} onToggle={() => setShowBottleneck((v) => !v)}
                 >
                   <ReviewBottleneck contributors={contribData.contributors} matrix={contribData.reviewer_matrix} />
-                </Section>
+                </CollapsibleSection>
               ) : (
                 <div className="flex items-center gap-2 px-4 py-3 rounded-xl border border-slate-800 bg-slate-900/30 text-xs text-slate-500">
                   <span>Review Bottleneck is disabled —</span>
@@ -585,7 +534,7 @@ export default function TeamAnalyticsPage() {
               )}
 
               {flags.workloadRisk ? (
-                <Section
+                <CollapsibleSection
                   icon={Moon} tone="green" title="Workload Risk Radar"
                   subtitle="Sustained after-hours/weekend work, activity cliffs, and concurrent-PR overload — a signal to check in, not a verdict"
                   open={showWorkloadRisk} onToggle={() => setShowWorkloadRisk((v) => !v)}
@@ -597,7 +546,7 @@ export default function TeamAnalyticsPage() {
                       Failed to load workload risk data.
                     </p>
                   )}
-                </Section>
+                </CollapsibleSection>
               ) : (
                 <div className="flex items-center gap-2 px-4 py-3 rounded-xl border border-slate-800 bg-slate-900/30 text-xs text-slate-500">
                   <span>Workload Risk Radar is disabled —</span>
@@ -618,7 +567,7 @@ export default function TeamAnalyticsPage() {
           {/* ── Bus Factor Heatmap ───────────────────────────────────────────── */}
           <div>
             {flags.busFactor ? (
-              <Section
+              <CollapsibleSection
                 icon={FolderTree} tone="red" title="Knowledge & Bus Factor Map"
                 badge={busData ? `${busData.modules.length} module${busData.modules.length === 1 ? "" : "s"}` : undefined}
                 subtitle="Per-module contributor concentration — modules with bus factor = 1 are knowledge silos"
@@ -631,7 +580,7 @@ export default function TeamAnalyticsPage() {
                     Failed to load bus factor data.
                   </p>
                 )}
-              </Section>
+              </CollapsibleSection>
             ) : (
               <div className="flex items-center gap-2 px-4 py-3 rounded-xl border border-slate-800 bg-slate-900/30 text-xs text-slate-500">
                 <span>Bus Factor Analysis is disabled —</span>
@@ -643,7 +592,7 @@ export default function TeamAnalyticsPage() {
           {/* ── Runner Utilization ──────────────────────────────────────────── */}
           <div>
             {flags.runnerUtilization ? (
-              <Section
+              <CollapsibleSection
                 icon={Server} tone="violet" title="Runner Utilization"
                 badge={runnerData ? `${runnerData.unique_runners} runner${runnerData.unique_runners === 1 ? "" : "s"}` : undefined}
                 subtitle="Job counts, durations, and failure rates per runner across recent completed runs"
@@ -656,7 +605,7 @@ export default function TeamAnalyticsPage() {
                     Failed to load runner statistics.
                   </p>
                 )}
-              </Section>
+              </CollapsibleSection>
             ) : (
               <div className="flex items-center gap-2 px-4 py-3 rounded-xl border border-slate-800 bg-slate-900/30 text-xs text-slate-500">
                 <span>Runner Utilization is disabled —</span>

--- a/src/components/CollapsibleSection.tsx
+++ b/src/components/CollapsibleSection.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+/**
+ * Collapsible section header (extracted to shared in v4.2.5).
+ *
+ * Introduced in v4.0.11 for Team Analytics but left as a local function in
+ * that one page, so every other collapsible on the app kept its original bare
+ * "› Show …" text toggle. That inconsistency became obvious once polished
+ * cards were added next to those toggles on the repository overview.
+ *
+ * Design reference: claude.ai/design "Scorecard board redesign" project,
+ * adapted to the app's lucide icons and Tailwind tokens.
+ */
+
+import { ChevronRight } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+export type SectionTone = "violet" | "cyan" | "amber" | "green" | "red";
+
+export const SECTION_TONES: Record<
+  SectionTone,
+  { text: string; bg: string; border: string; stripe: string }
+> = {
+  violet: { text: "text-violet-300", bg: "bg-violet-500/[0.14]", border: "border-violet-500/30", stripe: "bg-gradient-to-b from-violet-400 to-violet-600" },
+  cyan:   { text: "text-cyan-300",   bg: "bg-cyan-500/[0.14]",   border: "border-cyan-500/30",   stripe: "bg-gradient-to-b from-cyan-400 to-cyan-600" },
+  amber:  { text: "text-amber-300",  bg: "bg-amber-500/[0.14]",  border: "border-amber-500/30",  stripe: "bg-gradient-to-b from-amber-400 to-amber-600" },
+  green:  { text: "text-emerald-300", bg: "bg-emerald-500/[0.14]", border: "border-emerald-500/30", stripe: "bg-gradient-to-b from-emerald-400 to-emerald-600" },
+  red:    { text: "text-red-300",    bg: "bg-red-500/[0.14]",    border: "border-red-500/30",    stripe: "bg-gradient-to-b from-red-400 to-red-600" },
+};
+
+export default function CollapsibleSection({
+  icon: Icon,
+  tone,
+  title,
+  badge,
+  subtitle,
+  open,
+  onToggle,
+  children,
+}: {
+  icon: React.ElementType;
+  tone: SectionTone;
+  title: string;
+  /** Optional count or status chip beside the title. */
+  badge?: string;
+  subtitle: string;
+  open: boolean;
+  onToggle: () => void;
+  children: React.ReactNode;
+}) {
+  const t = SECTION_TONES[tone];
+  return (
+    <div className="rounded-2xl border border-slate-800 bg-gradient-to-b from-slate-900/50 to-slate-950/70 shadow-[0_40px_80px_-55px_rgba(0,0,0,1)] overflow-hidden">
+      <button
+        onClick={onToggle}
+        aria-expanded={open}
+        className={cn(
+          "w-full relative flex items-center gap-4 px-5 py-4 text-left transition-colors hover:bg-slate-800/40",
+          open && "border-b border-slate-800",
+        )}
+      >
+        <span className={cn("absolute inset-y-0 left-0 w-[2px]", t.stripe)} />
+        <span className={cn("shrink-0 w-9 h-9 rounded-lg border flex items-center justify-center", t.bg, t.border)}>
+          <Icon className={cn("w-4 h-4", t.text)} />
+        </span>
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-2.5 flex-wrap">
+            <span className="text-[15px] font-semibold text-white">{title}</span>
+            {badge && (
+              <span className={cn("font-mono text-[11px] px-2 py-0.5 rounded-full border whitespace-nowrap", t.bg, t.border, t.text)}>
+                {badge}
+              </span>
+            )}
+          </div>
+          <p className="text-xs text-slate-500 mt-0.5">{subtitle}</p>
+        </div>
+        <span className="shrink-0 flex items-center gap-1.5 px-3 py-1.5 rounded-lg border border-slate-700 bg-gradient-to-b from-slate-800 to-slate-900 text-xs text-slate-300">
+          {open ? "Hide" : "Show"}
+          <ChevronRight className={cn("w-3 h-3 transition-transform", open && "rotate-90")} />
+        </span>
+      </button>
+      {open && <div className="p-5">{children}</div>}
+    </div>
+  );
+}

--- a/src/components/DeploymentsPanel.tsx
+++ b/src/components/DeploymentsPanel.tsx
@@ -13,11 +13,12 @@
  * existing figures actually mean, which is more useful than hiding.
  */
 
+import { useState } from "react";
 import useSWR from "swr";
 import { fetcher } from "@/lib/swr";
 import type { DeploymentsSummary } from "@/app/api/github/deployments/route";
 import {
-  Rocket, CheckCircle2, XCircle, Clock, Info, AlertTriangle, GitBranch,
+  Rocket, CheckCircle2, XCircle, Clock, Info, AlertTriangle, GitBranch, Check,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 
@@ -35,6 +36,36 @@ export default function DeploymentsPanel({ owner, repo }: { owner: string; repo:
     `/api/github/deployments?owner=${encodeURIComponent(owner)}&repo=${encodeURIComponent(repo)}`,
     fetcher<DeploymentsSummary>,
   );
+
+  // Which environment drives the headline figures.
+  //
+  // Auto-detection can only guess when a repo deploys to several production
+  // targets — picking one for the user and being wrong is worse than letting
+  // them choose. The choice is remembered per repository, because otherwise
+  // it would have to be re-made on every visit.
+  const storageKey = `gitdash:deploy-env:${owner}/${repo}`;
+
+  // Lazy initialiser rather than an effect: React 19 forbids setState during
+  // an effect, and there is no hydration risk here because the environment
+  // list only renders once client-side SWR data has arrived.
+  const [selected, setSelected] = useState<string | null>(() => {
+    if (typeof window === "undefined") return null;
+    try {
+      return localStorage.getItem(storageKey);
+    } catch {
+      // Private mode or storage disabled — fall back to auto-detection.
+      return null;
+    }
+  });
+
+  function chooseEnvironment(env: string) {
+    setSelected(env);
+    try {
+      localStorage.setItem(storageKey, env);
+    } catch {
+      // Selection still applies for this session.
+    }
+  }
 
   if (isLoading) {
     return (
@@ -77,7 +108,21 @@ export default function DeploymentsPanel({ owner, repo }: { owner: string; repo:
     );
   }
 
-  const cfr = data.change_failure_rate_pct;
+  // Honour the saved choice only if that environment still exists in the
+  // window; otherwise fall back to auto-detection rather than showing blanks.
+  const activeEnv =
+    (selected && data.by_environment.some((e) => e.environment === selected) ? selected : null) ??
+    data.production_environment;
+
+  const activeStat = data.by_environment.find((e) => e.environment === activeEnv) ?? null;
+  const isOverridden = activeEnv !== data.production_environment;
+
+  // With a selection the figures come from that environment's own stats; with
+  // none they come from the server's headline, which is the same computation.
+  const deploysPerDay = activeStat ? activeStat.deploys_per_day : data.deploys_per_day;
+  const cfr = activeStat ? activeStat.failure_rate_pct : data.change_failure_rate_pct;
+  const mttrHours = activeStat ? activeStat.mttr_hours : data.mttr_hours;
+  const mttrSamples = activeStat ? activeStat.mttr_samples : data.mttr_samples;
 
   return (
     <div className="rounded-2xl border border-emerald-500/20 bg-emerald-500/[0.03] overflow-hidden">
@@ -95,8 +140,11 @@ export default function DeploymentsPanel({ owner, repo }: { owner: string; repo:
           <p className="text-xs text-slate-500 mt-0.5">
             From GitHub&apos;s Deployments API — actual rollouts, not inferred from releases or
             branch names.
-            {data.production_environment && (
-              <> Production environment: <span className="font-mono text-slate-400">{data.production_environment}</span>.</>
+            {activeEnv && (
+              <>
+                {" "}Showing <span className="font-mono text-slate-400">{activeEnv}</span>
+                {isOverridden ? " (your choice)" : " (auto-detected)"} — pick another below.
+              </>
             )}
           </p>
         </div>
@@ -106,8 +154,8 @@ export default function DeploymentsPanel({ owner, repo }: { owner: string; repo:
         <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
           <Metric
             label="Deploys / day"
-            value={data.deploys_per_day !== null ? data.deploys_per_day.toFixed(2) : "—"}
-            note="successful, production"
+            value={deploysPerDay !== null ? deploysPerDay.toFixed(2) : "—"}
+            note="successful deploys"
             tone="emerald"
           />
           <Metric
@@ -118,11 +166,11 @@ export default function DeploymentsPanel({ owner, repo }: { owner: string; repo:
           />
           <Metric
             label="MTTR"
-            value={data.mttr_hours !== null ? `${data.mttr_hours}h` : "—"}
+            value={mttrHours !== null ? `${mttrHours}h` : "—"}
             note={
-              data.mttr_samples === 0
+              mttrSamples === 0
                 ? "no failures to recover from"
-                : `${data.mttr_samples} recovery${data.mttr_samples === 1 ? "" : "s"}`
+                : `${mttrSamples} recovery${mttrSamples === 1 ? "" : "s"}`
             }
             tone="slate"
           />
@@ -135,7 +183,7 @@ export default function DeploymentsPanel({ owner, repo }: { owner: string; repo:
         </div>
 
         {/* A single recovery is an anecdote, not a metric. Say so. */}
-        {data.mttr_samples === 1 && (
+        {mttrSamples === 1 && (
           <p className="flex items-start gap-1.5 text-[11px] text-slate-500">
             <Info className="w-3 h-3 mt-0.5 shrink-0" />
             MTTR is based on a single recovery — treat it as an anecdote rather than a trend.
@@ -145,29 +193,35 @@ export default function DeploymentsPanel({ owner, repo }: { owner: string; repo:
         {data.by_environment.length > 1 && (
           <div>
             <p className="text-[10.5px] font-semibold uppercase tracking-[0.12em] text-slate-500 mb-2">
-              By environment
+              By environment — click to use for the figures above
             </p>
             <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
-              {data.by_environment.map((env) => (
-                <div
-                  key={env.environment}
-                  className={cn(
-                    "flex items-center gap-3 px-3.5 py-2.5 rounded-xl border",
-                    env.environment === data.production_environment
-                      ? "border-emerald-500/25 bg-emerald-500/[0.05]"
-                      : "border-slate-800 bg-slate-900/40",
-                  )}
-                >
-                  <GitBranch className="w-3.5 h-3.5 shrink-0 text-slate-500" />
-                  <span className="font-mono text-xs text-slate-200 truncate flex-1">
-                    {env.environment}
-                  </span>
-                  <span className="text-[11px] text-slate-500 tabular-nums shrink-0">
-                    {env.total} deploy{env.total === 1 ? "" : "s"}
-                    {env.failure_rate_pct !== null && ` · ${env.failure_rate_pct}% fail`}
-                  </span>
-                </div>
-              ))}
+              {data.by_environment.map((env) => {
+                const active = env.environment === activeEnv;
+                return (
+                  <button
+                    key={env.environment}
+                    onClick={() => chooseEnvironment(env.environment)}
+                    aria-pressed={active}
+                    className={cn(
+                      "flex items-center gap-3 px-3.5 py-2.5 rounded-xl border text-left transition-colors",
+                      active
+                        ? "border-emerald-500/40 bg-emerald-500/[0.08]"
+                        : "border-slate-800 bg-slate-900/40 hover:border-slate-700 hover:bg-slate-800/50",
+                    )}
+                  >
+                    <GitBranch className={cn("w-3.5 h-3.5 shrink-0", active ? "text-emerald-400" : "text-slate-500")} />
+                    <span className={cn("font-mono text-xs truncate flex-1", active ? "text-emerald-100" : "text-slate-200")}>
+                      {env.environment}
+                    </span>
+                    <span className="text-[11px] text-slate-500 tabular-nums shrink-0">
+                      {env.total} deploy{env.total === 1 ? "" : "s"}
+                      {env.failure_rate_pct !== null && ` · ${env.failure_rate_pct}% fail`}
+                    </span>
+                    {active && <Check className="w-3.5 h-3.5 shrink-0 text-emerald-400" />}
+                  </button>
+                );
+              })}
             </div>
           </div>
         )}

--- a/src/components/DeploymentsPanel.tsx
+++ b/src/components/DeploymentsPanel.tsx
@@ -203,8 +203,9 @@ export default function DeploymentsPanel({ owner, repo }: { owner: string; repo:
         {data.partial && (
           <p className="flex items-start gap-1.5 text-[11px] text-slate-500">
             <AlertTriangle className="w-3 h-3 mt-0.5 shrink-0 text-slate-600" />
-            Status was resolved for the most recent deployments only, so rates are based on a
-            partial sample.
+            More deployments exist than statuses were fetched for. The production environment is
+            resolved first, so the headline figures are complete; other environments may show rates
+            from a partial sample.
           </p>
         )}
       </div>

--- a/src/lib/deployments.ts
+++ b/src/lib/deployments.ts
@@ -79,23 +79,46 @@ const MAX_STATUS_LOOKUPS = 40;
 const MAX_RECENT_RETURNED = 15;
 const DEFAULT_PERIOD_DAYS = 30;
 
-/** Names teams actually use for production, in preference order. */
-const PRODUCTION_NAMES = ["production", "prod", "live", "main"];
+/**
+ * Production-ish environment names, in preference order.
+ *
+ * Word-boundary matching rather than equality: platforms label environments
+ * things like "Production — my-app", so an exact-match check finds only the
+ * bare name and misses the one actually being deployed to. Word boundaries
+ * also stop "main" matching "domain-staging".
+ */
+const PRODUCTION_PATTERNS = [/\bproduction\b/i, /\bprod\b/i, /\blive\b/i, /\bmain\b/i];
 
-function pickProductionEnvironment(records: DeploymentRecord[]): string | null {
-  if (records.length === 0) return null;
-
+function countByEnvironment(deployments: { environment: string }[]): Map<string, number> {
   const counts = new Map<string, number>();
-  for (const r of records) counts.set(r.environment, (counts.get(r.environment) ?? 0) + 1);
+  for (const d of deployments) counts.set(d.environment, (counts.get(d.environment) ?? 0) + 1);
+  return counts;
+}
 
-  for (const name of PRODUCTION_NAMES) {
-    for (const env of counts.keys()) {
-      if (env.toLowerCase() === name) return env;
-    }
+/**
+ * Choose the environment whose figures become the headline.
+ *
+ * Runs against the raw deployment list — before statuses are fetched — so
+ * status resolution can be aimed at whatever this returns. Picking first and
+ * resolving second is what stops the headline environment ending up with no
+ * data (see the note on MAX_STATUS_LOOKUPS).
+ *
+ * Within a matching tier the busiest environment wins: a repo that deploys to
+ * several production targets should report the one it actually uses most,
+ * not whichever happens to sort first.
+ */
+function pickProductionEnvironment(deployments: { environment: string }[]): string | null {
+  if (deployments.length === 0) return null;
+  const counts = countByEnvironment(deployments);
+  const byVolume = [...counts.entries()].sort((a, b) => b[1] - a[1]);
+
+  for (const pattern of PRODUCTION_PATTERNS) {
+    const matches = byVolume.filter(([env]) => pattern.test(env));
+    if (matches.length > 0) return matches[0][0];
   }
-  // No conventional name — fall back to the busiest environment, which is
-  // very nearly always the one that matters.
-  return [...counts.entries()].sort((a, b) => b[1] - a[1])[0][0];
+  // No conventional name — the busiest environment is very nearly always the
+  // one that matters.
+  return byVolume[0][0];
 }
 
 const isSuccess = (r: DeploymentRecord) => r.state === "success";
@@ -176,9 +199,21 @@ export async function getDeploymentsSummary(
   const inWindow = deployments.filter((d) => new Date(d.created_at).getTime() >= cutoff);
   if (inWindow.length === 0) return empty;
 
-  // Statuses are one request per deployment, so only the newest slice is
-  // resolved. Everything older still counts toward volume.
-  const toResolve = inWindow.slice(0, MAX_STATUS_LOOKUPS);
+  // Decide the headline environment BEFORE resolving statuses, so the budget
+  // can be aimed at it.
+  //
+  // The original version resolved "the 40 most recent deployments overall",
+  // which broke on any repo busy enough to exceed that in the window: if none
+  // of production's deployments landed in that slice, every headline figure
+  // came back empty — 0.00 deploys/day on a repo that deploys constantly.
+  // Production is filled first, then the remaining budget covers other
+  // environments so their per-environment rates still populate.
+  const productionEnvironment = pickProductionEnvironment(inWindow);
+  const isProd = (d: { environment: string }) => d.environment === productionEnvironment;
+  const toResolve = [
+    ...inWindow.filter(isProd),
+    ...inWindow.filter((d) => !isProd(d)),
+  ].slice(0, MAX_STATUS_LOOKUPS);
   const settled = await pLimitSettled(
     toResolve.map((d) => async () => {
       const { data } = await octokit.rest.repos.listDeploymentStatuses({
@@ -215,7 +250,6 @@ export async function getDeploymentsSummary(
     };
   });
 
-  const productionEnvironment = pickProductionEnvironment(records);
   const production = records.filter((r) => r.environment === productionEnvironment);
 
   const prodSuccess = production.filter(isSuccess).length;
@@ -249,7 +283,13 @@ export async function getDeploymentsSummary(
     failed: records.filter(isFailure).length,
     // Frequency counts SUCCESSFUL production deploys: a failed rollout is not
     // a delivery, and counting it would flatter the number.
-    deploys_per_day: Math.round((prodSuccess / periodDays) * 100) / 100,
+    //
+    // Null — not 0.00 — when nothing conclusive was resolved for production.
+    // "0.00 deploys/day" is an assertion that the team ships nothing; the
+    // truthful statement when statuses are unknown is that we cannot say.
+    // This is the same reasoning already applied to CFR and MTTR below.
+    deploys_per_day:
+      prodConclusive > 0 ? Math.round((prodSuccess / periodDays) * 100) / 100 : null,
     change_failure_rate_pct:
       prodConclusive > 0 ? Math.round((prodFailed / prodConclusive) * 100) : null,
     mttr_hours: mttrHours,

--- a/src/lib/deployments.ts
+++ b/src/lib/deployments.ts
@@ -49,6 +49,15 @@ export interface EnvironmentStat {
   failed: number;
   /** Null when nothing conclusive was recorded for this environment. */
   failure_rate_pct: number | null;
+  /**
+   * Full headline metrics per environment (v4.2.5), so the UI can let the
+   * user pick which environment drives the summary without another request.
+   * Auto-detection can only ever guess when a repo deploys to several
+   * production targets; letting them choose beats guessing better.
+   */
+  deploys_per_day: number | null;
+  mttr_hours: number | null;
+  mttr_samples: number;
 }
 
 export interface DeploymentsSummary {
@@ -259,7 +268,8 @@ export async function getDeploymentsSummary(
   const byEnvironment = new Map<string, EnvironmentStat>();
   for (const r of records) {
     const stat = byEnvironment.get(r.environment) ?? {
-      environment: r.environment, total: 0, success: 0, failed: 0, failure_rate_pct: null,
+      environment: r.environment, total: 0, success: 0, failed: 0,
+      failure_rate_pct: null, deploys_per_day: null, mttr_hours: null, mttr_samples: 0,
     };
     stat.total++;
     if (isSuccess(r)) stat.success++;
@@ -269,6 +279,13 @@ export async function getDeploymentsSummary(
   for (const stat of byEnvironment.values()) {
     const conclusive = stat.success + stat.failed;
     stat.failure_rate_pct = conclusive > 0 ? Math.round((stat.failed / conclusive) * 100) : null;
+    // Same null-not-zero rule as the headline: an unresolved environment must
+    // not claim a deploy rate of nothing.
+    stat.deploys_per_day =
+      conclusive > 0 ? Math.round((stat.success / periodDays) * 100) / 100 : null;
+    const envMttr = computeMttr(records.filter((r) => r.environment === stat.environment));
+    stat.mttr_hours = envMttr.hours;
+    stat.mttr_samples = envMttr.samples;
   }
 
   const { hours: mttrHours, samples: mttrSamples } = computeMttr(production);

--- a/tests/deployments.test.ts
+++ b/tests/deployments.test.ts
@@ -246,3 +246,86 @@ describe("getDeploymentsSummary — resilience", () => {
     expect(r.change_failure_rate_pct).toBeNull();
   });
 });
+
+// ── Regression: headline environment starved of status lookups (v4.2.4) ───────
+
+describe("getDeploymentsSummary — environment selection and status budget", () => {
+  it("prefers a platform-suffixed production environment over a bare stale one", async () => {
+    // Vercel-style naming. Exact-match selection picked the bare "Production"
+    // (11 deploys) over the environment actually in use (14).
+    listDeployments.mockResolvedValue({
+      data: [
+        ...Array.from({ length: 14 }, (_, i) => dep(100 + i, "Production — gitdash", daysAgo(1))),
+        ...Array.from({ length: 11 }, (_, i) => dep(200 + i, "Production", daysAgo(20))),
+        ...Array.from({ length: 17 }, (_, i) => dep(300 + i, "Preview — gitdash", daysAgo(1))),
+      ],
+    });
+    statusMap({});
+    expect((await run()).production_environment).toBe("Production — gitdash");
+  });
+
+  it("does not match 'main' inside an unrelated environment name", async () => {
+    listDeployments.mockResolvedValue({
+      data: [
+        dep(1, "domain-staging", daysAgo(1)),
+        dep(2, "domain-staging", daysAgo(2)),
+        dep(3, "qa", daysAgo(3)),
+      ],
+    });
+    statusMap({});
+    // Word-boundary matching: "domain-staging" must not be read as production.
+    // With no production-ish name at all, the busiest environment wins.
+    expect((await run()).production_environment).toBe("domain-staging");
+  });
+
+  it("resolves production statuses even when it exceeds the lookup budget overall", async () => {
+    // The reported bug: 75 deployments in window, only 40 statuses resolved,
+    // and none of them belonged to the chosen production environment — so
+    // every headline figure came back empty on a repo that deploys constantly.
+    const preview = Array.from({ length: 60 }, (_, i) => dep(1000 + i, "Preview — app", daysAgo(1)));
+    const production = Array.from({ length: 15 }, (_, i) => dep(2000 + i, "Production — app", daysAgo(2)));
+    // Newest-first ordering puts all the preview noise ahead of production.
+    listDeployments.mockResolvedValue({ data: [...preview, ...production] });
+
+    const statuses: Record<number, { state: string; at: string }> = {};
+    for (const d of preview) statuses[d.id] = { state: "success", at: daysAgo(1) };
+    for (const d of production) statuses[d.id] = { state: "success", at: daysAgo(2) };
+    statusMap(statuses);
+
+    const r = await run(30);
+    expect(r.production_environment).toBe("Production — app");
+    // Production must have real numbers rather than a starved zero.
+    expect(r.deploys_per_day).not.toBeNull();
+    expect(r.deploys_per_day).toBeGreaterThan(0);
+    expect(r.change_failure_rate_pct).toBe(0); // measured, not absent
+  });
+
+  it("reports a null deploy rate rather than 0.00 when production has no conclusive status", async () => {
+    // 0.00 asserts "this team ships nothing". The honest answer when statuses
+    // are unknown is that we cannot say.
+    listDeployments.mockResolvedValue({ data: [dep(1, "production", daysAgo(1))] });
+    statusMap({ 1: { state: "pending", at: daysAgo(1) } });
+
+    const r = await run();
+    expect(r.deploys_per_day).toBeNull();
+    expect(r.change_failure_rate_pct).toBeNull();
+  });
+
+  it("still fills other environments from the remaining budget", async () => {
+    listDeployments.mockResolvedValue({
+      data: [
+        dep(1, "Production — app", daysAgo(1)),
+        dep(2, "Preview — app", daysAgo(1)),
+        dep(3, "Preview — app", daysAgo(2)),
+      ],
+    });
+    statusMap({
+      1: { state: "success", at: daysAgo(1) },
+      2: { state: "failure", at: daysAgo(1) },
+      3: { state: "success", at: daysAgo(2) },
+    });
+    const r = await run();
+    const preview = r.by_environment.find((e) => e.environment === "Preview — app")!;
+    expect(preview.failure_rate_pct).toBe(50);
+  });
+});


### PR DESCRIPTION
Two commits, two versions, covering all three things you reported.

---

# v4.2.4 — deployment metrics showed 0.00 on a repo that deploys constantly

## The tell

> `34 ok · 6 failed` = **40** — exactly `MAX_STATUS_LOOKUPS`.

Only 40 of your 75 deployments had statuses resolved, and the environment picked as production had **none** of its deployments in that slice. Three separate defects:

**1. The headline environment could be starved of status lookups.** The 40-lookup cap was applied to the most recent deployments *overall*, so on a busy repo none belonged to production. Production is now selected **before** statuses are fetched and resolved **first**.

**2. Environment matching was exact.** Yours are labelled `Production — gitdash`, which never matched `production`. Now word-boundary matched, busiest wins within a tier. Also stops `main` matching `domain-staging`.

**3. Deploy frequency said `0.00` instead of `null`** — asserting your team ships nothing. Now null, consistent with CFR and MTTR. That was the exact principle v4.2.1 was built on; the frequency path just missed it. My mistake.

---

# v4.2.5 — selectable environment + consistent headers

## You can now click to choose the environment

This is the better answer to the root problem. You deploy to **two** production targets (`gitdash` and `gitdash-standalone`), so no heuristic gets it right for everyone — auto-detection will always be guessing.

Rows under **By environment** are now buttons. The choice is remembered per repository and falls back to auto-detection if that environment disappears from the window. Every environment carries its own deploys/day, CFR and MTTR, so switching is instant and you can compare environments directly.

The header now says which environment is in use and whether it was auto-detected or chosen by you.

## The inconsistency you spotted

You were right, and I caused it. The polished card header I built for Team Analytics in v4.0.11 was left as a **local function in that one page** — so the DORA drill-down and PR lifecycle toggles kept the original bare `› Show drill-down charts` text style. Putting a fully-styled Deployments card directly beneath a plain text link made it glaring.

Extracted to `src/components/CollapsibleSection.tsx` and applied to both. Team Analytics now imports the shared component instead of its private copy.

---

## Test plan

- [x] `pnpm exec tsc --noEmit` — **0 errors**
- [x] `pnpm test` — **332/332** (327 → 332, +5 regression tests)
- [x] `pnpm run lint` — **0 problems** (caught and fixed a React 19 `set-state-in-effect` error along the way)
- [x] `rm -rf .next && pnpm run build` — succeeds, 69 routes
- [x] Version bumped in all locations for both releases; release-notes entries verified intact

The key regression test reproduces your shape: 60 preview + 15 production deployments against a 40-lookup budget, asserting production resolves to real figures rather than a starved zero.

## Rollback

Both additive/presentational. Promote v4.2.3, or revert either commit independently. No schema change.
