### PR TITLE
fix: release workflow rejected 'v4.2.5' and would have failed on the commit step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: "Release version (semver, e.g. 2.1.0)"
+        description: "Release version — 4.2.5 or v4.2.5 (leading v is stripped)"
         required: true
         type: string
       prerelease:
@@ -33,23 +33,65 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Validate semver input
+      - name: Validate and normalise version
         id: validate
         run: |
-          VERSION="${{ github.event.inputs.version }}"
+          RAW="${{ github.event.inputs.version }}"
+          # Accept both "4.2.5" and "v4.2.5" — typing the tag form is the
+          # natural mistake, and failing on it wastes a run for no reason.
+          VERSION="${RAW#v}"
+
           if ! echo "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$'; then
-            echo "ERROR: '$VERSION' is not a valid semver (expected e.g. 2.1.0 or 2.1.0-beta.1)"
+            echo "::error::'$RAW' is not a valid semver. Expected 4.2.5 or v4.2.5 (pre-release suffixes allowed)."
             exit 1
           fi
+
           TAG="v${VERSION}"
           if git rev-parse "$TAG" >/dev/null 2>&1; then
-            echo "ERROR: Tag '$TAG' already exists."
+            echo "::error::Tag '$TAG' already exists."
             exit 1
           fi
+
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "tag=$TAG"         >> "$GITHUB_OUTPUT"
+          echo "Releasing $TAG"
+
+      # Versions are bumped in the feature PR (package.json, Helm chart, docs
+      # and CHANGELOG all move together), so by the time this runs the repo is
+      # normally already at the target version. This step therefore VERIFIES
+      # rather than assumes, and only bumps when something is genuinely behind.
+      #
+      # A mismatch between the Helm chart and package.json is a release bug
+      # worth stopping for: it ships a chart claiming the wrong appVersion.
+      - name: Verify version consistency
+        id: consistency
+        run: |
+          VERSION="${{ steps.validate.outputs.version }}"
+          PKG=$(node -p "require('./package.json').version")
+          CHART_APP=$(grep -E '^appVersion:' helm/gitdash/Chart.yaml | sed 's/appVersion:[[:space:]]*//; s/"//g')
+
+          echo "requested=$VERSION  package.json=$PKG  chart appVersion=$CHART_APP"
+
+          if [ "$CHART_APP" != "$VERSION" ]; then
+            echo "::error::helm/gitdash/Chart.yaml appVersion is '$CHART_APP' but the release is '$VERSION'. Bump it in the PR before releasing."
+            exit 1
+          fi
+
+          if ! grep -q "^## \[${VERSION}\]" CHANGELOG.md; then
+            echo "::error::CHANGELOG.md has no '## [${VERSION}]' section. Add release notes before releasing."
+            exit 1
+          fi
+
+          if [ "$PKG" = "$VERSION" ]; then
+            echo "needs_bump=false" >> "$GITHUB_OUTPUT"
+            echo "package.json already at $VERSION — nothing to bump."
+          else
+            echo "needs_bump=true" >> "$GITHUB_OUTPUT"
+            echo "package.json at $PKG — will bump to $VERSION."
+          fi
 
       - name: Bump package.json version
+        if: steps.consistency.outputs.needs_bump == 'true'
         run: |
           VERSION="${{ steps.validate.outputs.version }}"
           node -e "
@@ -64,13 +106,11 @@ jobs:
         id: notes
         run: |
           VERSION="${{ steps.validate.outputs.version }}"
-          # Extract the section for this version: from "## [VERSION]" to the next "## ["
+          # Section for this version: from "## [VERSION]" to the next "## [".
           NOTES=$(awk "/^## \[${VERSION}\]/{found=1; next} found && /^## \[/{exit} found{print}" CHANGELOG.md)
           if [ -z "$NOTES" ]; then
-            echo "WARNING: No CHANGELOG entry found for version $VERSION — using generic message."
             NOTES="See [CHANGELOG.md](https://github.com/${{ github.repository }}/blob/main/CHANGELOG.md) for details."
           fi
-          # Write to a temp file to avoid issues with special chars in GITHUB_OUTPUT
           echo "$NOTES" > /tmp/release_notes.md
           {
             echo "notes<<RELEASE_NOTES_EOF"
@@ -79,21 +119,37 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Configure git
+        if: steps.consistency.outputs.needs_bump == 'true'
         run: |
           git config user.name  "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
       - name: Commit version bump
+        if: steps.consistency.outputs.needs_bump == 'true'
         run: |
           TAG="${{ steps.validate.outputs.tag }}"
           git add package.json
-          git commit -m "chore: release ${TAG}"
+          # Guard anyway: `git commit` exits non-zero on an empty index, which
+          # would fail the release for the least interesting possible reason.
+          if git diff --cached --quiet; then
+            echo "Nothing staged — skipping commit."
+          else
+            git commit -m "chore: release ${TAG}"
+          fi
 
       - name: Create and push tag
         run: |
           TAG="${{ steps.validate.outputs.tag }}"
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
           git tag -a "$TAG" -m "Release ${TAG}"
-          git push origin HEAD:main "$TAG"
+          # Push the branch only when this run actually created a commit;
+          # otherwise HEAD already matches origin/main and the tag is enough.
+          if [ "${{ steps.consistency.outputs.needs_bump }}" = "true" ]; then
+            git push origin HEAD:main "$TAG"
+          else
+            git push origin "$TAG"
+          fi
 
   # ── 2. CI gate (lint + typecheck + build) ────────────────────────────────────
   ci:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,14 @@ UI consistency and control, both reported directly after v4.2.4.
 ### Changed
 - Environment selection uses a lazy `useState` initialiser rather than an effect: React 19 forbids `setState` inside an effect, and there is no hydration risk because the environment list only renders once client-side data has arrived.
 
+#### Release workflow now matches how releases actually happen
+The workflow had never been run successfully against the current process, and failed twice over:
+
+- **`v4.2.5` was rejected as invalid.** The input regex required a bare `4.2.5`, and the workflow then built `TAG="v${VERSION}"` — so even a passing value would have produced `vv4.2.5`. A leading `v` is now stripped and normalised, since typing the tag form is the natural mistake.
+- **The next step would have failed too.** Versions are bumped in the feature PR, so `package.json` is already at the target when the workflow runs — making `git commit` exit non-zero with "nothing to commit". The bump and commit steps are now conditional, and the commit is guarded against an empty index regardless.
+- **The workflow only ever bumped `package.json`**, silently ignoring the Helm chart. It now *verifies* rather than assumes: a `Chart.yaml` `appVersion` that disagrees with the release version fails the run with a clear message, as does a missing CHANGELOG section. Shipping a chart that claims the wrong `appVersion` is a release bug worth stopping for.
+- The tag push no longer assumes a new commit exists.
+
 ### Verified
 - 332 tests passing, `tsc` clean, `eslint` **0 problems**, build succeeds.
 


### PR DESCRIPTION
Fixes the failed run, plus the failure waiting immediately behind it.

## Why it failed

The input was **`v4.2.5`**. The regex requires a bare `4.2.5`:

```
VERSION="v4.2.5"
grep -qE '^[0-9]+\.[0-9]+\.[0-9]+...'   # rejects the leading v
```

Worse, the workflow then builds `TAG="v${VERSION}"` — so even a passing value would have produced **`vv4.2.5`**.

**Fixed:** a leading `v` is stripped and normalised. Typing the tag form is the natural mistake, not a user error worth burning a run over. Verified against `v4.2.5`, `4.2.5`, `v4.2.5-beta.1`, `4.2`, `banana`.

## The failure you hadn't hit yet

You asked "you didn't use it?" — correct, and that's exactly why it broke.

I bump versions **inside each feature PR** (`package.json`, Helm chart, both docs fallbacks, CHANGELOG). So by the time this workflow runs, `package.json` is *already* at the target version — which makes:

```
git add package.json
git commit -m "chore: release ${TAG}"   # exits non-zero: nothing to commit
```

…fail immediately after the semver fix. Confirmed by simulating locally: `needs_bump=false`.

**Fixed:** bump and commit are now conditional, and the commit is guarded against an empty index regardless. The tag push no longer assumes a new commit exists either.

## Turned it into a real safety gate

The workflow only ever bumped `package.json` and **silently ignored the Helm chart**. Since versions now move in the PR, its useful job is verification, not mutation. It now fails loudly when:

- `helm/gitdash/Chart.yaml` `appVersion` disagrees with the release version — shipping a chart claiming the wrong version is a genuine release bug
- `CHANGELOG.md` has no `## [VERSION]` section

## No version bump

**v4.2.5 has no tag yet**, so this ships *as part of* it rather than becoming v4.2.6. The CHANGELOG entry for 4.2.5 is amended instead.

## ⚠️ Separate finding: 20+ versions have no tags

```
package.json:  4.2.5
newest tag:    v4.0.5
```

Everything from **v4.0.6 to v4.2.5** has a CHANGELOG entry but no git tag and no GitHub Release. That's why this was the first dispatch in a while.

Once this merges, dispatching Release with `4.2.5` (or `v4.2.5` — both work now) will tag the current state. Say the word if you want the missing versions backfilled as tags; I'd suggest tags only, not 20 GitHub Releases.

## Test plan

- [x] YAML parses
- [x] Version normalisation simulated across 5 inputs including the failing one
- [x] Consistency check simulated against the live repo — chart and CHANGELOG both agree at 4.2.5, `needs_bump=false`
- [x] Release-notes extraction verified against the real CHANGELOG
- [x] App untouched: `tsc` 0 errors, **332/332** tests, lint 0 problems
