### PR TITLE
fix: v4.2.6 — deployments panel reported 36 records as "no deployments"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,47 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ---
 
+## [4.2.6] — 2026-08-15
+
+### Overview
+The deployments panel told the truth in a way that read as a lie. Reported against
+`tesda-backend`, which deploys to ECS every day and was shown as having no deployments.
+
+### Added
+
+#### "Recording stopped" — a stale window is a finding, not an absence
+- A repository with deployment history whose newest record predates the window now returns
+  `source: "stale"` instead of `"none"`, and the panel says how many deployments are on record and
+  how long ago the last one was.
+- The two situations were previously indistinguishable in the response, because both produce an
+  empty window. They are opposites: one team has never used the Deployments API, the other *did*
+  and then stopped — which usually means a replaced pipeline or a deploy step that lost its
+  `environment:` key.
+- `tesda-backend` is the worked example: **36 deployments on record, newest 2026-06-18**, i.e. 58
+  days before the 30-day cutoff. Reported as "no deployments" before this change.
+- Two new response fields, `all_time_count` and `newest_deployment_at`, describe history at any age.
+  `newest_deployment_at` is computed by value rather than taken from index 0 — `listDeployments` is
+  documented newest-first, but the UI states that date as fact and should not depend on it.
+
+### Fixed
+
+#### "No deployments" read as "you do not deploy"
+- The empty-state copy named the Deployments API but never explained what writes to it, so a
+  repository deploying daily through GitHub Actions looked like one that never ships.
+- The panel now states the mechanism directly: GitHub writes a deployment record only when a job
+  declares an `environment:` key, or when something calls the Deployments API. A plain `run:` step
+  that deploys to ECS, Kubernetes or a VM creates nothing, however often it runs.
+- The one-line fix — a job-level `environment: production` — is named in the panel and in the
+  metrics documentation, including the trap that a `workflow_dispatch` **input** named
+  `environment` does not count. That is exactly what `tesda-backend`'s `cd.yml` has.
+
+### Documentation
+- The DORA metrics section gains a "What actually creates a deployment record" table covering both
+  triggers, and a callout describing the Recording stopped state.
+- API Reference updated for `source: "stale"` and the two new fields.
+
+---
+
 ## [4.2.5] — 2026-08-15
 
 ### Overview

--- a/helm/gitdash/Chart.yaml
+++ b/helm/gitdash/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: gitdash
 description: Self-hosted GitHub Actions metrics dashboard (standalone PAT or GitHub OAuth)
 type: application
-version: 0.6.5
-appVersion: "4.2.5"
+version: 0.6.6
+appVersion: "4.2.6"
 keywords:
   - github-actions
   - dashboard

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gitdash",
-  "version": "4.2.5",
+  "version": "4.2.6",
   "private": true,
   "packageManager": "pnpm@10.30.3",
   "scripts": {

--- a/src/app/docs/page.tsx
+++ b/src/app/docs/page.tsx
@@ -1994,6 +1994,32 @@ function MetricsDora() {
           deployments, the panel says so and explains what the numbers above actually represent.
           Knowing which of the two you are reading matters more than the number itself.
         </Callout>
+        <ProseP>
+          <strong>What actually creates a deployment record</strong> — the most common surprise here
+          is a repository that deploys every day through GitHub Actions and still shows nothing
+          measured. A workflow that deploys is not the same thing as a deployment record. GitHub
+          writes one only when:
+        </ProseP>
+        <DocTable
+          headers={["Trigger", "What it looks like"]}
+          rows={[
+            ["A job declares an environment", <>A job-level <Code>environment: production</Code> key. This is the usual one-line fix — note that a <Code>workflow_dispatch</Code> input <em>named</em> <Code>environment</Code> does not count, since it is an input rather than a job key.</>],
+            ["Something calls the API directly", <>A <Code>POST /repos/&#123;owner&#125;/&#123;repo&#125;/deployments</Code> call, or an action that wraps it. Platform integrations such as Vercel and Heroku do this automatically.</>],
+          ]}
+        />
+        <ProseP>
+          Deploying to ECS, Kubernetes or a VM from a plain <Code>run:</Code> step creates no record,
+          so those rollouts are invisible to these metrics no matter how often they happen. Adding
+          the <Code>environment:</Code> key to the deploy job is normally enough to turn all three
+          figures from estimated into measured.
+        </ProseP>
+        <Callout type="warning">
+          If a repository has deployment history but nothing inside the 30-day window, the panel
+          flags it <strong>Recording stopped</strong> rather than reporting an absence — it shows how
+          many deployments are on record and how long ago the last one was. That gap is usually a
+          replaced pipeline or a deploy step that lost its <Code>environment:</Code> key, and it is
+          worth investigating rather than ignoring.
+        </Callout>
       </DocCard>
       <DocCard>
         <SubHeading>Throughput &amp; Velocity</SubHeading>
@@ -2700,7 +2726,7 @@ function APIReference() {
         {
           method: "GET",
           path: "/api/github/deployments",
-          description: "Measured delivery metrics from GitHub's Deployments API. Returns { source, production_environment, deploys_per_day, change_failure_rate_pct, mttr_hours, mttr_samples, by_environment[], recent[], partial }. source is \"deployments\" when the repo genuinely uses the API and \"none\" otherwise — the caller keeps its release/PR estimates in that case rather than being handed zeros. Rates exclude pending and in-progress deploys, and return null rather than 0% when nothing is conclusive.",
+          description: "Measured delivery metrics from GitHub's Deployments API. Returns { source, production_environment, deploys_per_day, change_failure_rate_pct, mttr_hours, mttr_samples, by_environment[], recent[], partial, all_time_count, newest_deployment_at }. source is \"deployments\" when the window has data, \"stale\" when the repo has deployment history but none inside the window, and \"none\" when it has never recorded one — the caller keeps its release/PR estimates for the latter two rather than being handed zeros. all_time_count and newest_deployment_at describe history at any age, so a stale window can state how much exists and when it stopped. Rates exclude pending and in-progress deploys, and return null rather than 0% when nothing is conclusive.",
           params: [
             { name: "owner", type: "string", optional: false, desc: "Repository owner" },
             { name: "repo", type: "string", optional: false, desc: "Repository name" },
@@ -2998,9 +3024,24 @@ pnpm run lint`}
 function ReleaseNotes() {
   const releases = [
     {
-      version: "4.2.5",
+      version: "4.2.6",
       date: "2026-08-15",
       badge: "latest",
+      badgeColor: "bg-emerald-500/15 text-emerald-400 border-emerald-500/20",
+      changes: {
+        added: [
+          "The deployments panel now separates \"no deployments recorded in the last 30 days\" from \"none ever recorded\". A repository with deployment history whose newest record is older than the window is flagged \"Recording stopped\", with the total on record and how long ago the last one was — a gap that usually means the pipeline was replaced or its deploy step removed, which the previous wording hid entirely",
+        ],
+        fixed: [
+          "\"This repository has no deployments\" read as \"you do not deploy\", which was misleading on repositories that deploy daily through GitHub Actions. The panel now states the actual mechanism: GitHub only writes a deployment record when a job declares an environment: key or something calls the Deployments API, so a deploy workflow without one is invisible to these metrics. The one-line fix is named directly",
+        ],
+        improved: [],
+      },
+    },
+    {
+      version: "4.2.5",
+      date: "2026-08-15",
+      badge: null,
       badgeColor: "bg-emerald-500/15 text-emerald-400 border-emerald-500/20",
       changes: {
         added: [
@@ -3653,7 +3694,7 @@ function DocSidebar({
           <BookOpen className="w-4 h-4 text-violet-400" />
           <span className="text-sm font-semibold text-white">GitDash Docs</span>
           <span className="text-xs px-1.5 py-0.5 rounded bg-violet-500/15 text-violet-400 border border-violet-500/20 font-mono">
-            v{process.env.NEXT_PUBLIC_APP_VERSION ?? "4.2.5"}
+            v{process.env.NEXT_PUBLIC_APP_VERSION ?? "4.2.6"}
           </span>
         </div>
         {/* Mobile close */}
@@ -3904,7 +3945,7 @@ export default function DocsPage() {
 
           {/* Footer */}
           <footer className="mt-8 pb-4 text-center text-xs text-slate-600 space-y-1">
-            <p>GitDash v{process.env.NEXT_PUBLIC_APP_VERSION ?? "4.2.5"} — GitHub Actions Dashboard</p>
+            <p>GitDash v{process.env.NEXT_PUBLIC_APP_VERSION ?? "4.2.6"} — GitHub Actions Dashboard</p>
             <p>
               <a href="https://github.com/dinhdobathi1992/gitdash" target="_blank" rel="noreferrer" className="hover:text-slate-400 transition-colors">
                 Open source on GitHub

--- a/src/components/DeploymentsPanel.tsx
+++ b/src/components/DeploymentsPanel.tsx
@@ -80,28 +80,85 @@ export default function DeploymentsPanel({ owner, repo }: { owner: string; repo:
 
   if (error || !data) return null;
 
-  // No deployments recorded — explain what the DORA cards above are actually
-  // measuring, rather than leaving the reader to assume they are exact.
-  if (data.source === "none") {
+  // Nothing in the window. Two very different situations share that symptom,
+  // and collapsing them (as v4.2.5 did) threw away the more interesting one.
+  if (data.source === "none" || data.source === "stale") {
+    const stale = data.source === "stale";
+    // Age comes from the server: render must stay pure under React 19, and the
+    // server clock is the one that decided the window this age is relative to.
+    const daysAgo = data.newest_deployment_age_days;
+
     return (
-      <div className="rounded-2xl border border-slate-800 bg-slate-900/40 p-5">
+      <div
+        className={cn(
+          "rounded-2xl border p-5",
+          stale ? "border-amber-500/25 bg-amber-500/[0.03]" : "border-slate-800 bg-slate-900/40",
+        )}
+      >
         <div className="flex items-start gap-3">
-          <span className="shrink-0 w-9 h-9 rounded-lg border border-slate-700 bg-slate-800/60 flex items-center justify-center">
-            <Rocket className="w-4 h-4 text-slate-400" />
+          <span
+            className={cn(
+              "shrink-0 w-9 h-9 rounded-lg border flex items-center justify-center",
+              stale ? "border-amber-500/30 bg-amber-500/[0.12]" : "border-slate-700 bg-slate-800/60",
+            )}
+          >
+            <Rocket className={cn("w-4 h-4", stale ? "text-amber-300" : "text-slate-400")} />
           </span>
           <div className="min-w-0">
-            <h3 className="text-[15px] font-semibold text-white">Deployments</h3>
-            <p className="text-xs text-slate-500 mt-1 leading-relaxed">
-              This repository has no deployments recorded through GitHub&apos;s Deployments API in
-              the last {data.period_days} days, so the DORA figures above are{" "}
+            <div className="flex items-center gap-2 flex-wrap">
+              <h3 className="text-[15px] font-semibold text-white">Deployments</h3>
+              {stale && (
+                <span className="text-[10px] font-semibold uppercase tracking-wide px-2 py-0.5 rounded-full border border-amber-500/25 bg-amber-500/10 text-amber-300">
+                  Recording stopped
+                </span>
+              )}
+            </div>
+
+            {stale ? (
+              <p className="text-xs text-slate-400 mt-1 leading-relaxed">
+                This repository has{" "}
+                <strong className="text-amber-200">{data.all_time_count} deployments</strong> on
+                record, but the most recent was{" "}
+                <strong className="text-amber-200">
+                  {daysAgo} day{daysAgo === 1 ? "" : "s"} ago
+                </strong>
+                {data.newest_deployment_at && (
+                  <> ({new Date(data.newest_deployment_at).toLocaleDateString()})</>
+                )}{" "}
+                — outside the {data.period_days}-day window. Something used to record deployments
+                here and no longer does, which usually means the pipeline was replaced or its
+                deployment step was removed.
+              </p>
+            ) : (
+              <p className="text-xs text-slate-500 mt-1 leading-relaxed">
+                This repository has never recorded a deployment through GitHub&apos;s Deployments
+                API.
+              </p>
+            )}
+
+            <p className="text-xs text-slate-500 mt-2 leading-relaxed">
+              Until then the DORA figures above are{" "}
               <strong className="text-slate-400">estimated</strong>: deployment frequency from
               releases (or merged PRs when there are no releases), and change failure rate from PRs
               whose branch looks like a hotfix or revert.
             </p>
-            <p className="text-xs text-slate-500 mt-2 leading-relaxed">
-              If your pipeline creates GitHub deployments, those numbers become measured instead —
-              actual deploys, actual failed rollouts, actual recovery time.
-            </p>
+
+            {/* The point people miss: a workflow that deploys is not the same
+                thing as a deployment record. Worth stating explicitly, because
+                the obvious reading of "no deployments" is "you don't deploy". */}
+            <div className="mt-3 rounded-xl border border-slate-800 bg-slate-950/50 p-3">
+              <p className="flex items-start gap-1.5 text-[11px] text-slate-400 leading-relaxed">
+                <Info className="w-3 h-3 mt-0.5 shrink-0 text-slate-500" />
+                <span>
+                  A workflow that deploys does not create a deployment record on its own. GitHub
+                  writes one only when a job declares an{" "}
+                  <code className="font-mono text-slate-300">environment:</code> key, or when
+                  something calls the Deployments API directly. A job-level{" "}
+                  <code className="font-mono text-slate-300">environment: production</code> on your
+                  deploy job is usually the whole change, and it makes all three figures measured.
+                </span>
+              </p>
+            </div>
           </div>
         </div>
       </div>

--- a/src/lib/deployments.ts
+++ b/src/lib/deployments.ts
@@ -27,8 +27,17 @@
 import { getOctokit } from "@/lib/github";
 import { pLimitSettled } from "@/lib/concurrency";
 
-/** Where a metric came from. Surfaced in the UI — never hidden. */
-export type DeployMetricSource = "deployments" | "none";
+/**
+ * Where a metric came from. Surfaced in the UI — never hidden.
+ *
+ * `stale` is distinct from `none` on purpose (v4.2.6). A repo with 36
+ * deployments whose newest is two months old was previously reported the same
+ * way as a repo that has never recorded one, because both produce an empty
+ * window. But those are opposite situations: the second team does not use the
+ * Deployments API, while the first one *did* and then stopped — which is
+ * usually a broken or replaced pipeline, and is worth saying out loud.
+ */
+export type DeployMetricSource = "deployments" | "stale" | "none";
 
 export interface DeploymentRecord {
   id: number;
@@ -81,6 +90,21 @@ export interface DeploymentsSummary {
   recent: DeploymentRecord[];
   /** True when some status fetches failed — figures are from a partial sample. */
   partial: boolean;
+  /**
+   * Deployments on record regardless of the window, capped at the 100 fetched
+   * (v4.2.6). Reported so an empty window can still say how much history
+   * exists rather than implying there is none.
+   */
+  all_time_count: number;
+  /** Newest deployment on record at any age, or null when there are none. */
+  newest_deployment_at: string | null;
+  /**
+   * Whole days since that deployment, computed here rather than in the client.
+   * Render must stay pure under React 19, and the server clock is the one that
+   * decided the window — deriving the age from the browser's clock could
+   * disagree with the very cutoff that produced this response.
+   */
+  newest_deployment_age_days: number | null;
 }
 
 /** Status lookups are one call each, so the newest slice is the bounded part. */
@@ -186,6 +210,9 @@ export async function getDeploymentsSummary(
     by_environment: [],
     recent: [],
     partial: false,
+    all_time_count: 0,
+    newest_deployment_at: null,
+    newest_deployment_age_days: null,
   };
 
   let deployments: { id: number; environment: string; created_at: string; ref: string; sha: string }[];
@@ -204,9 +231,30 @@ export async function getDeploymentsSummary(
     return empty;
   }
 
+  // History is reported even when the window is empty, so "nothing recent" can
+  // be told apart from "nothing ever". Computed rather than taking index 0:
+  // listDeployments is documented newest-first, but the ordering is not worth
+  // depending on for a value the UI states as fact.
+  const newestAt =
+    deployments.length > 0
+      ? deployments.reduce((newest, d) => (d.created_at > newest ? d.created_at : newest),
+          deployments[0].created_at)
+      : null;
+  const history = {
+    all_time_count: deployments.length,
+    newest_deployment_at: newestAt,
+    newest_deployment_age_days: newestAt
+      ? Math.floor((Date.now() - new Date(newestAt).getTime()) / 86_400_000)
+      : null,
+  };
+
   const cutoff = Date.now() - periodDays * 86_400_000;
   const inWindow = deployments.filter((d) => new Date(d.created_at).getTime() >= cutoff);
-  if (inWindow.length === 0) return empty;
+  if (inWindow.length === 0) {
+    // Deployments exist but all predate the window: the pipeline that recorded
+    // them stopped. That is a finding, not an absence.
+    return { ...empty, source: deployments.length > 0 ? "stale" : "none", ...history };
+  }
 
   // Decide the headline environment BEFORE resolving statuses, so the budget
   // can be aimed at it.
@@ -316,5 +364,6 @@ export async function getDeploymentsSummary(
       .sort((a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime())
       .slice(0, MAX_RECENT_RETURNED),
     partial: partial || inWindow.length > toResolve.length,
+    ...history,
   };
 }

--- a/tests/deployments.test.ts
+++ b/tests/deployments.test.ts
@@ -60,10 +60,48 @@ describe("getDeploymentsSummary — provenance", () => {
     expect(r.total_deployments).toBe(0);
   });
 
-  it('reports source "none" when every deployment predates the window', async () => {
-    listDeployments.mockResolvedValue({ data: [dep(1, "production", daysAgo(90))] });
+  // v4.2.6: "nothing recent" and "nothing ever" used to be indistinguishable
+  // in the response, so a repo whose pipeline stopped recording two months ago
+  // was reported exactly like one that has never used the API.
+  it('reports source "stale" — not "none" — when every deployment predates the window', async () => {
+    listDeployments.mockResolvedValue({
+      data: [dep(1, "production", daysAgo(90)), dep(2, "production", daysAgo(58))],
+    });
     const r = await run(30);
+    expect(r.source).toBe("stale");
+    expect(r.all_time_count).toBe(2);
+    // Figures stay null: a stale window is still nothing to measure.
+    expect(r.deploys_per_day).toBeNull();
+    expect(r.total_deployments).toBe(0);
+  });
+
+  it("reports the newest deployment date so a stale window can be dated", async () => {
+    const newest = daysAgo(58);
+    listDeployments.mockResolvedValue({
+      data: [dep(1, "production", daysAgo(90)), dep(2, "production", newest)],
+    });
+    const r = await run(30);
+    expect(r.newest_deployment_at).toBe(newest);
+    // Age is computed server-side so the client can render it without calling
+    // Date.now() during render, which React 19 rejects as impure.
+    expect(r.newest_deployment_age_days).toBe(58);
+  });
+
+  it("takes the newest date by value, not by list position", async () => {
+    const newest = daysAgo(40);
+    // Deliberately oldest-first: the real API is newest-first, but the UI
+    // states this date as fact, so it must not depend on that ordering.
+    listDeployments.mockResolvedValue({
+      data: [dep(1, "production", daysAgo(120)), dep(2, "production", newest)],
+    });
+    expect((await run(30)).newest_deployment_at).toBe(newest);
+  });
+
+  it('keeps source "none" when there is genuinely no history', async () => {
+    const r = await run();
     expect(r.source).toBe("none");
+    expect(r.all_time_count).toBe(0);
+    expect(r.newest_deployment_at).toBeNull();
   });
 
   it('reports source "deployments" once there is data in the window', async () => {
@@ -71,6 +109,7 @@ describe("getDeploymentsSummary — provenance", () => {
     statusMap({ 1: { state: "success", at: daysAgo(2) } });
     const r = await run();
     expect(r.source).toBe("deployments");
+    expect(r.all_time_count).toBe(1);
   });
 });
 


### PR DESCRIPTION
## What you reported

`tesda-backend` deploys to ECS every day, and the panel said it had no deployments.

## What was actually true

| Check | Result |
|---|---|
| Deployment records on `tesda-backend` | **36** |
| Newest record | `2026-06-18` — **58 days** before the 30-day cutoff |
| `cd.yml` line 13 `environment:` | a `workflow_dispatch` **input**, not a job key → records nothing |
| `cd.yml` recent runs | daily, branch `develop`, `run-name: "[NON PROD]"` |

So the window really was empty — but the panel was still wrong in two ways.

## 1. A stale window is a finding, not an absence

"36 deployments, newest two months ago" and "never recorded one" both produce an empty window, and both returned `source: "none"`. They are opposites: one team does not use the Deployments API, the other **did and stopped** — a replaced pipeline or a deploy step that lost its `environment:` key.

Now returns `source: "stale"` with `all_time_count`, `newest_deployment_at` and `newest_deployment_age_days`, and the panel shows a **Recording stopped** state naming the count and the gap.

## 2. "No deployments" read as "you do not deploy"

The copy named the Deployments API but never said what writes to it. GitHub records a deployment only when a **job declares an `environment:` key**, or when something calls the API directly. A plain `run:` step deploying to ECS, Kubernetes or a VM creates nothing, however often it runs.

The panel and the DORA metrics docs now state that mechanism and name the one-line fix — including the trap that a `workflow_dispatch` input named `environment` does not count, which is exactly the case here.

## Notes

- `newest_deployment_at` is computed by value, not read from index 0. `listDeployments` is documented newest-first, but the UI states that date as fact.
- Age is computed **server-side**: render must stay pure under React 19 (`react-hooks/purity` caught the first attempt), and the server clock is the one that decided the window.

## Verification

```
tsc --noEmit          0 errors
pnpm test             335 passed (20 files)
pnpm run lint         clean
rm -rf .next && build clean
API reference parity  no drift
```

Version bumped in all 7 locations; docs updated with a new release-notes entry and a "What actually creates a deployment record" section.