### PR TITLE
fix: v4.2.7 — security panel blamed the token for features that were simply off

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,43 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ---
 
+## [4.2.7] — 2026-08-16
+
+### Overview
+The security panel blamed the reader's token for problems it had not caused. Found while
+answering "where can I check it — I don't see any error in the UI", which turned out to be the
+right question: there was no error, and the guidance about needing a scope was wrong.
+
+### Fixed
+
+#### A disabled feature is not a permission problem
+- GitHub answers `403` both when a token is insufficient **and** when a security feature is
+  switched off for a repository. `statusFromError` mapped every `403` to `forbidden`, rendered as
+  **"Token lacks permission"** with `needs_scope: true`.
+- Measured on a real repository without Code Security:
+  `403 {"message":"Code Security must be enabled for this repository to use code scanning."}`
+  Nothing about that is a permission failure, but the panel told the reader to regenerate a PAT —
+  a fix that could not possibly work.
+- A `403` is now classified by its response body, checked on both `.message` and
+  `.response.data.message` rather than depending on one Octokit shape. A disabled feature becomes
+  `not_enabled`; anything else stays `forbidden`.
+- Ambiguity deliberately resolves toward `forbidden`: a wrongly reported permission gap is at
+  least actionable, whereas a wrong "not enabled" hides a real access problem on a security page.
+
+#### The `security_events` claim was wrong
+- The module header, the panel warning and the Security documentation all stated that reading
+  these alerts requires the `security_events` scope and that "most existing tokens will 403 here".
+- Measured against the API, a classic PAT with `repo` reads all three sources. That false premise
+  is what produced the 403 mapping above, so it is corrected at the source rather than papered over.
+- Fine-grained PATs *do* have separate permissions, so those are now named on their own — read
+  access to **Dependabot alerts**, **Code scanning alerts** and **Secret scanning alerts**.
+
+### Documentation
+- The Security section explains that `403` carries two meanings and how they are told apart.
+- API Reference updated: no scope requirement, and the body-based classification described.
+
+---
+
 ## [4.2.6] — 2026-08-15
 
 ### Overview

--- a/helm/gitdash/Chart.yaml
+++ b/helm/gitdash/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: gitdash
 description: Self-hosted GitHub Actions metrics dashboard (standalone PAT or GitHub OAuth)
 type: application
-version: 0.6.6
-appVersion: "4.2.6"
+version: 0.6.7
+appVersion: "4.2.7"
 keywords:
   - github-actions
   - dashboard

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gitdash",
-  "version": "4.2.6",
+  "version": "4.2.7",
   "private": true,
   "packageManager": "pnpm@10.30.3",
   "scripts": {

--- a/src/app/docs/page.tsx
+++ b/src/app/docs/page.tsx
@@ -1135,12 +1135,23 @@ function FeatureSecurity() {
           belief.
         </ProseP>
 
-        <Callout type="warning">
-          <strong>Requires the <Code>security_events</Code> scope</strong>, which GitDash does not
-          request by default — so an existing token will most likely be refused. Add it to a classic
-          PAT, or grant <em>Dependabot alerts</em>, <em>Code scanning alerts</em> and{" "}
-          <em>Secret scanning alerts</em> read access on a fine-grained PAT.
+        <Callout type="info">
+          <strong>A classic PAT with <Code>repo</Code> reads all three sources</strong> — no extra
+          scope is needed. Earlier versions of this page claimed <Code>security_events</Code> was
+          required and that most tokens would be refused; measured against the API, that is not the
+          case. On a <em>fine-grained</em> PAT the permissions are separate, so grant read access to{" "}
+          <em>Dependabot alerts</em>, <em>Code scanning alerts</em> and <em>Secret scanning
+          alerts</em>.
         </Callout>
+        <ProseP>
+          <strong>&ldquo;Not enabled&rdquo; is not a permission problem.</strong> GitHub answers with{" "}
+          <Code>403</Code> when a security feature is switched off for a repository, using the same
+          status code as a genuine permission failure — for example{" "}
+          <em>&ldquo;Code Security must be enabled for this repository to use code scanning&rdquo;</em>.
+          The two are told apart by the response body, so a source that is merely switched off is
+          labelled <strong>Not enabled for this repo</strong> and never prompts you to widen a token
+          that is already sufficient.
+        </ProseP>
 
         <Callout type="info">
           <strong>An unreadable source never looks like a clean one.</strong> Each source carries its
@@ -2735,7 +2746,7 @@ function APIReference() {
         {
           method: "GET",
           path: "/api/github/security-alerts",
-          description: "GitHub's own security findings: Dependabot, code scanning and secret scanning alerts. Returns { sources, alerts[], counts, total_open, oldest_open_days, partial, needs_scope } where each source carries its own status (ok | forbidden | not_enabled | error) plus 90-day fix count and mean time to remediate. Requires the security_events scope; a 403 on any source sets needs_scope rather than failing the request, so an unreadable source is never reported as a clean one.",
+          description: "GitHub's own security findings: Dependabot, code scanning and secret scanning alerts. Returns { sources, alerts[], counts, total_open, oldest_open_days, partial, needs_scope } where each source carries its own status (ok | forbidden | not_enabled | error) plus 90-day fix count and mean time to remediate. A classic PAT with repo reads all three; no security_events scope is required. A 403 is classified by its response body — a disabled feature becomes not_enabled, a genuine permission failure becomes forbidden and sets needs_scope — so an unreadable source is never reported as a clean one, and a switched-off one never prompts a pointless token change.",
           params: [
             { name: "owner", type: "string", optional: false, desc: "Repository owner" },
             { name: "repo", type: "string", optional: false, desc: "Repository name" },
@@ -3024,9 +3035,23 @@ pnpm run lint`}
 function ReleaseNotes() {
   const releases = [
     {
+      version: "4.2.7",
+      date: "2026-08-16",
+      badge: "latest",
+      badgeColor: "bg-emerald-500/15 text-emerald-400 border-emerald-500/20",
+      changes: {
+        added: [],
+        fixed: [
+          "The security panel blamed your token for problems it had not caused. GitHub answers with 403 both when a token is insufficient and when a security feature is simply switched off for a repository — and every 403 was mapped to \"Token lacks permission\", which told people to regenerate a PAT that was already sufficient. A 403 is now classified by its response body, so \"Code Security must be enabled for this repository\" is reported as \"Not enabled for this repo\" and never prompts a token change that could not have helped. Anything genuinely ambiguous still reports a permission problem, because that fix is at least in your hands",
+          "The documented claim that reading security alerts requires the security_events scope was wrong. Measured against the API, a classic PAT with repo reads Dependabot, code scanning and secret scanning alerts. The panel warning and the Security documentation now say what is actually needed, and the fine-grained PAT permissions — which genuinely are separate — are named on their own",
+        ],
+        improved: [],
+      },
+    },
+    {
       version: "4.2.6",
       date: "2026-08-15",
-      badge: "latest",
+      badge: null,
       badgeColor: "bg-emerald-500/15 text-emerald-400 border-emerald-500/20",
       changes: {
         added: [
@@ -3694,7 +3719,7 @@ function DocSidebar({
           <BookOpen className="w-4 h-4 text-violet-400" />
           <span className="text-sm font-semibold text-white">GitDash Docs</span>
           <span className="text-xs px-1.5 py-0.5 rounded bg-violet-500/15 text-violet-400 border border-violet-500/20 font-mono">
-            v{process.env.NEXT_PUBLIC_APP_VERSION ?? "4.2.6"}
+            v{process.env.NEXT_PUBLIC_APP_VERSION ?? "4.2.7"}
           </span>
         </div>
         {/* Mobile close */}
@@ -3945,7 +3970,7 @@ export default function DocsPage() {
 
           {/* Footer */}
           <footer className="mt-8 pb-4 text-center text-xs text-slate-600 space-y-1">
-            <p>GitDash v{process.env.NEXT_PUBLIC_APP_VERSION ?? "4.2.6"} — GitHub Actions Dashboard</p>
+            <p>GitDash v{process.env.NEXT_PUBLIC_APP_VERSION ?? "4.2.7"} — GitHub Actions Dashboard</p>
             <p>
               <a href="https://github.com/dinhdobathi1992/gitdash" target="_blank" rel="noreferrer" className="hover:text-slate-400 transition-colors">
                 Open source on GitHub

--- a/src/components/SecurityAlertsPanel.tsx
+++ b/src/components/SecurityAlertsPanel.tsx
@@ -99,10 +99,12 @@ export default function SecurityAlertsPanel({ owner, repo }: { owner: string; re
             <div className="space-y-1">
               <p className="font-semibold">Some sources could not be read — this is not an all-clear.</p>
               <p className="text-amber-200/80">
-                Reading security alerts needs the <code className="text-amber-100">security_events</code>{" "}
-                scope, which GitDash does not request by default. Regenerate your token with it
-                added (classic PAT), or grant <em>Dependabot alerts</em>, <em>Code scanning
-                alerts</em> and <em>Secret scanning alerts</em> read access on a fine-grained PAT.
+                A classic PAT with <code className="text-amber-100">repo</code> reads all three
+                sources, so this usually means the token is fine-grained or more narrowly scoped.
+                On a fine-grained PAT, grant read access to <em>Dependabot alerts</em>, <em>Code
+                scanning alerts</em> and <em>Secret scanning alerts</em>. Sources that are simply
+                switched off for the repository are labelled <em>Not enabled</em> below and need no
+                token change.
               </p>
             </div>
           </div>

--- a/src/lib/security-alerts.ts
+++ b/src/lib/security-alerts.ts
@@ -6,14 +6,15 @@
  * GitHub's own findings. This module adds those.
  *
  * ── Access is the hard part ───────────────────────────────────────────────
- * All three endpoints need the `security_events` scope, which GitDash has
- * never asked for — so most existing tokens will 403 here. That is not an
- * error state to bury: each source reports its own status so the UI can say
- * "your token can't read this, here's how to fix it" instead of showing an
- * empty list that looks like good news.
+ * Each source reports its own status so the UI can say why it has no data,
+ * instead of showing an empty list that looks like good news. An empty result
+ * and an inaccessible result must never look the same on a security page.
  *
- * An empty result and an inaccessible result must never look the same on a
- * security page.
+ * The original version of this file assumed the `security_events` scope was
+ * required and that "most existing tokens will 403 here". Measured against the
+ * real API (v4.2.7), that is wrong: a plain `repo` scope reads all three
+ * endpoints. Which matters, because it produced a mapping that blamed the
+ * token for every 403 — see `statusFromError`.
  */
 
 import { getOctokit } from "@/lib/github";
@@ -83,10 +84,39 @@ function normaliseSeverity(raw: string | null | undefined): AlertSeverity {
   }
 }
 
-/** Classify a failure so the UI can distinguish "can't read" from "nothing found". */
+/**
+ * GitHub returns 403 for a disabled *feature* as readily as for an
+ * insufficient token, and the two demand opposite responses from the reader.
+ *
+ * Measured on a real repository without Code Security:
+ *
+ *   403 {"message":"Code Security must be enabled for this repository
+ *        to use code scanning."}
+ *
+ * Nothing about that is a permission problem, but v4.2.6 and earlier mapped it
+ * to "forbidden" → "Token lacks permission" → `needs_scope: true`. The panel
+ * therefore told people to widen a token that was already sufficient, which
+ * sends them to rotate a PAT for a change that cannot possibly help.
+ *
+ * The message body is the only thing that separates the two cases, so match on
+ * it. Anything that does not name a disabled feature stays "forbidden": when
+ * in doubt, reporting a permission problem is the safer error, because the
+ * fix for it is at least under the reader's control.
+ */
+const FEATURE_DISABLED_PATTERN =
+  /must be enabled|not enabled|no.{0,12}(advanced security|code security)|disabled for/i;
+
 function statusFromError(e: unknown): SourceStatus {
-  const status = (e as { status?: number })?.status;
-  if (status === 403) return "forbidden";
+  const err = e as { status?: number; message?: string; response?: { data?: { message?: string } } };
+  const status = err?.status;
+
+  if (status === 403) {
+    // Octokit surfaces the API message on `.message`, but the raw body is kept
+    // on the response — check both rather than depending on one shape.
+    const message = `${err?.message ?? ""} ${err?.response?.data?.message ?? ""}`;
+    return FEATURE_DISABLED_PATTERN.test(message) ? "not_enabled" : "forbidden";
+  }
+
   // 404 here means the feature is off for this repo (or the repo is private
   // without Advanced Security) — not an error worth alarming anyone about.
   if (status === 404) return "not_enabled";

--- a/tests/security-alerts.test.ts
+++ b/tests/security-alerts.test.ts
@@ -20,9 +20,20 @@ vi.mock("@/lib/github", () => ({
   }),
 }));
 
-function httpError(status: number) {
-  const e = new Error(`HTTP ${status}`) as Error & { status: number };
+function httpError(status: number, message?: string) {
+  const e = new Error(message ?? `HTTP ${status}`) as Error & { status: number };
   e.status = status;
+  return e;
+}
+
+/** A 403 whose body arrives on the response rather than on `.message`. */
+function httpErrorWithBody(status: number, bodyMessage: string) {
+  const e = new Error(`HTTP ${status}`) as Error & {
+    status: number;
+    response: { data: { message: string } };
+  };
+  e.status = status;
+  e.response = { data: { message: bodyMessage } };
   return e;
 }
 
@@ -73,6 +84,42 @@ describe("getSecurityAlerts — permission and availability failures", () => {
     expect(r.partial).toBe(true);
     // Crucially, this is NOT reported as a clean repo.
     expect(r.sources.dependabot.open_count).toBe(0);
+  });
+
+  // v4.2.7: GitHub answers 403 for a *disabled feature* as well as for an
+  // insufficient token. Blaming the token for both told people to widen a PAT
+  // that was already sufficient — a fix that cannot possibly work.
+  it("treats a 403 that names a disabled feature as not_enabled, not a scope gap", async () => {
+    listCodeScanning.mockRejectedValue(
+      httpError(403, "Code Security must be enabled for this repository to use code scanning."),
+    );
+    const r = await run();
+
+    expect(r.sources.code_scanning.status).toBe("not_enabled");
+    expect(r.needs_scope).toBe(false);
+    // Still not a clean repo — the source remains unreadable.
+    expect(r.partial).toBe(true);
+  });
+
+  it("reads the disabled-feature message from the response body too", async () => {
+    listSecretScanning.mockRejectedValue(
+      httpErrorWithBody(403, "Advanced Security must be enabled for this repository."),
+    );
+    const r = await run();
+
+    expect(r.sources.secret_scanning.status).toBe("not_enabled");
+    expect(r.needs_scope).toBe(false);
+  });
+
+  it("keeps a 403 with no disabled-feature message as forbidden", async () => {
+    // Ambiguity resolves toward "permission problem": that fix is at least
+    // under the reader's control, whereas a wrong "not enabled" hides a real
+    // access gap on a security page.
+    listDependabot.mockRejectedValue(httpError(403, "Resource not accessible by personal access token"));
+    const r = await run();
+
+    expect(r.sources.dependabot.status).toBe("forbidden");
+    expect(r.needs_scope).toBe(true);
   });
 
   it("marks a 404 source not_enabled without claiming a scope problem", async () => {


### PR DESCRIPTION
Found while answering *"where can I check it — I don't see any error in the UI"*. That was the right question: there was no error, and the guidance about needing a scope was wrong.

## Two defects, one false premise

The module header asserted that these endpoints need the `security_events` scope and that "most existing tokens will 403 here". Measured against the API with a classic PAT carrying only `repo`:

| Endpoint on `dinhdobathi1992/gitdash` | Result |
|---|---|
| `code-scanning/alerts` | **200** |
| `dependabot/alerts` | **200** |
| `secret-scanning/alerts` | **200** |

No extra scope is needed. That false premise then produced the real bug.

## 1. A disabled feature is not a permission problem

GitHub answers `403` for **both** an insufficient token and a switched-off feature. Every `403` was mapped to `forbidden` → **"Token lacks permission"** → `needs_scope: true`.

On `aboitiz-data-innovation/tesda-backend`:

```
403 {"message":"Code Security must be enabled for this repository to use code scanning."}
```

The panel told the reader to regenerate a PAT for a change that could not possibly help.

A `403` is now classified by its response body — checked on both `.message` and `.response.data.message` rather than depending on one Octokit shape. **Ambiguity resolves toward `forbidden`** on purpose: a wrongly reported permission gap is at least actionable, whereas a wrong "not enabled" hides a real access problem on a security page.

## 2. The scope claim, corrected everywhere it appeared

Module header, panel warning, Security docs section, and API Reference. Fine-grained PATs genuinely do have separate permissions, so those are now named on their own instead of being conflated with classic scopes.

## Tests exercise the fix, not the implementation

Temporarily reverted `statusFromError` to the old mapping and re-ran:

```
× treats a 403 that names a disabled feature as not_enabled, not a scope gap
× reads the disabled-feature message from the response body too
  Tests  2 failed | 14 passed (16)
```

Restored → 16 passed. The tests fail against the old behaviour, so they are not tautological.

## Verification

```
tsc --noEmit          0 errors
pnpm test             338 passed (20 files)
pnpm run lint         clean
rm -rf .next && build compiled successfully
API reference parity  no drift
```

Version bumped in all 7 locations; release-notes entry added.

**Note:** the v4.2.0 release-notes entry still repeats the old `security_events` claim. Left as-is deliberately — shipped release notes are a record of what shipped, and this entry corrects it rather than rewriting history.
