### PR TITLE
fix: v4.2.8 — pages left a large blank band on the right at wide viewports

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,9 @@
+<!-- BEGIN:nextjs-agent-rules -->
+
+# This is NOT the Next.js you know
+
+This version has breaking changes — APIs, conventions, and file structure may all differ from your training data. Read the relevant guide in `node_modules/next/dist/docs/` (resolved from this file's directory; in monorepos the `next` package may not be visible from the repo root) before writing any code. Heed deprecation notices.
+
+This block is written and re-added by `next dev` — verify at `node_modules/next/dist/server/lib/generate-agent-files.js`. Removing it from a diff only re-creates the uncommitted change; committing it with your work keeps the tree clean.
+
+<!-- END:nextjs-agent-rules -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,45 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ---
 
+## [4.2.8] — 2026-08-16
+
+### Overview
+Layout fix, reported directly: a large band of empty space down the right-hand side of every
+page on a wide display.
+
+### Fixed
+
+#### One centred content container for the whole app
+- Each page declared its own cap and none of them centred:
+
+  | Page | Cap before |
+  |---|---|
+  | Security | `max-w-5xl` (1024px) |
+  | Issues, Contributor, Org Health | `max-w-6xl` (1152px) |
+  | Cost Analytics | `max-w-5xl` |
+  | Team Analytics, Team Insights | `max-w-7xl` (1280px) |
+  | Alerts, Reports, Org, Repo overview | none — full width |
+
+- A left-aligned cap puts every unused pixel in a single block on the right instead of splitting
+  it evenly. On a 2000px display the Security page ended around 1010px with almost as much blank
+  beside it as content, and sibling pages disagreed with each other by up to 256px.
+- The container now lives once in `AppShell` — centred, with a generous cap. Pages declare padding
+  and spacing only.
+- The cap is deliberately wide because this is a dashboard: the PR leaderboard alone is nine
+  columns, and narrowing those tables to a reading measure would trade one layout problem for
+  another.
+- Two exceptions kept on purpose: the contributor **print brief** keeps its narrow measure, and the
+  **documentation** keeps its prose width — both were already centred and both are reading
+  surfaces rather than dashboards.
+
+### Verification
+Captured in a real browser against a live standalone instance at 2000×1150, 1440×900, 834×1100 and
+390×844. Security and Team Analytics both span the full content area at 2000px; the laptop width
+sits below the cap and fills naturally; tablet and mobile are unchanged, with the sidebar still
+collapsing to the drawer and wide tables still scrolling inside their own container.
+
+---
+
 ## [4.2.7] — 2026-08-16
 
 ### Overview

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/helm/gitdash/Chart.yaml
+++ b/helm/gitdash/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: gitdash
 description: Self-hosted GitHub Actions metrics dashboard (standalone PAT or GitHub OAuth)
 type: application
-version: 0.6.7
-appVersion: "4.2.7"
+version: 0.6.8
+appVersion: "4.2.8"
 keywords:
   - github-actions
   - dashboard

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gitdash",
-  "version": "4.2.7",
+  "version": "4.2.8",
   "private": true,
   "packageManager": "pnpm@10.30.3",
   "scripts": {

--- a/src/app/contributor/[login]/page.tsx
+++ b/src/app/contributor/[login]/page.tsx
@@ -281,7 +281,7 @@ export default function ContributorProfilePage() {
   }
 
   return (
-    <div className="p-8 max-w-6xl space-y-6">
+    <div className="p-8 space-y-6">
       <Breadcrumb
         items={[
           { label: "Repositories", href: "/" },

--- a/src/app/cost-analytics/page.tsx
+++ b/src/app/cost-analytics/page.tsx
@@ -283,7 +283,7 @@ export default function CostAnalyticsPage() {
   const isCurrentMonth = year === DEFAULT_YEAR && month === DEFAULT_MONTH;
 
   return (
-    <div className="p-4 md:p-8 max-w-5xl space-y-5">
+    <div className="p-4 md:p-8 space-y-5">
       <Breadcrumb
         items={[
           { label: "Repositories", href: "/" },

--- a/src/app/docs/page.tsx
+++ b/src/app/docs/page.tsx
@@ -3035,9 +3035,23 @@ pnpm run lint`}
 function ReleaseNotes() {
   const releases = [
     {
-      version: "4.2.7",
+      version: "4.2.8",
       date: "2026-08-16",
       badge: "latest",
+      badgeColor: "bg-emerald-500/15 text-emerald-400 border-emerald-500/20",
+      changes: {
+        added: [],
+        fixed: [
+          "Pages left a large band of empty space down the right-hand side on wide screens. Every page declared its own width cap — max-w-5xl on Security, max-w-6xl on Issues and Org Health, max-w-7xl on Team Analytics, none at all on Alerts and Reports — and none of them centred, so all the unused width collected in one block on the right rather than splitting evenly. On a 2000px display the Security page ended around 1010px with almost as much blank beside it as content",
+          "The app now has a single centred content container, so every page agrees on width and stays centred at any viewport. The cap is deliberately generous because this is a dashboard — the PR leaderboard alone is nine columns, and narrowing those tables to a reading measure would trade one layout problem for another. The contributor print brief keeps its narrow measure, and the documentation keeps its prose width",
+        ],
+        improved: [],
+      },
+    },
+    {
+      version: "4.2.7",
+      date: "2026-08-16",
+      badge: null,
       badgeColor: "bg-emerald-500/15 text-emerald-400 border-emerald-500/20",
       changes: {
         added: [],
@@ -3719,7 +3733,7 @@ function DocSidebar({
           <BookOpen className="w-4 h-4 text-violet-400" />
           <span className="text-sm font-semibold text-white">GitDash Docs</span>
           <span className="text-xs px-1.5 py-0.5 rounded bg-violet-500/15 text-violet-400 border border-violet-500/20 font-mono">
-            v{process.env.NEXT_PUBLIC_APP_VERSION ?? "4.2.7"}
+            v{process.env.NEXT_PUBLIC_APP_VERSION ?? "4.2.8"}
           </span>
         </div>
         {/* Mobile close */}
@@ -3970,7 +3984,7 @@ export default function DocsPage() {
 
           {/* Footer */}
           <footer className="mt-8 pb-4 text-center text-xs text-slate-600 space-y-1">
-            <p>GitDash v{process.env.NEXT_PUBLIC_APP_VERSION ?? "4.2.7"} — GitHub Actions Dashboard</p>
+            <p>GitDash v{process.env.NEXT_PUBLIC_APP_VERSION ?? "4.2.8"} — GitHub Actions Dashboard</p>
             <p>
               <a href="https://github.com/dinhdobathi1992/gitdash" target="_blank" rel="noreferrer" className="hover:text-slate-400 transition-colors">
                 Open source on GitHub

--- a/src/app/org/[orgName]/health/page.tsx
+++ b/src/app/org/[orgName]/health/page.tsx
@@ -298,7 +298,7 @@ export default function OrgHealthScorecardPage({
   const total = repos.length;
 
   return (
-    <div className="p-8 space-y-6 max-w-6xl">
+    <div className="p-8 space-y-6">
       <Breadcrumb
         items={[
           { label: "Repositories", href: "/" },

--- a/src/app/repos/[owner]/[repo]/issues/page.tsx
+++ b/src/app/repos/[owner]/[repo]/issues/page.tsx
@@ -38,7 +38,7 @@ export default function IssuesPage() {
   );
 
   return (
-    <div className="p-8 max-w-6xl space-y-6">
+    <div className="p-8 space-y-6">
       <RepoWorkflowBreadcrumb owner={owner} repo={repo} />
 
       <div className="flex items-start justify-between gap-4 flex-wrap">

--- a/src/app/repos/[owner]/[repo]/security/page.tsx
+++ b/src/app/repos/[owner]/[repo]/security/page.tsx
@@ -401,7 +401,7 @@ export default function SecurityPage() {
   );
 
   return (
-    <div className="p-8 max-w-5xl space-y-6">
+    <div className="p-8 space-y-6">
       <RepoWorkflowBreadcrumb owner={owner} repo={repo} />
 
       {/* Header */}

--- a/src/app/repos/[owner]/[repo]/team/page.tsx
+++ b/src/app/repos/[owner]/[repo]/team/page.tsx
@@ -375,7 +375,7 @@ export default function TeamAnalyticsPage() {
   );
 
   return (
-    <div className="p-8 max-w-7xl space-y-6">
+    <div className="p-8 space-y-6">
       <RepoWorkflowBreadcrumb owner={owner} repo={repo} />
 
       {/* Header */}

--- a/src/app/team/page.tsx
+++ b/src/app/team/page.tsx
@@ -181,7 +181,7 @@ export default function TeamInsightsPage() {
   const selfMerges = data?.contributors.reduce((s, c) => s + c.self_merge_count, 0) ?? 0;
 
   return (
-    <div className="p-8 max-w-7xl">
+    <div className="p-8">
       <Breadcrumb items={[{ label: "Team Insights" }]} />
 
       {/* Page header */}

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -75,7 +75,22 @@ export default function AppShell({ children }: { children: React.ReactNode }) {
           <span className="font-semibold text-white text-sm tracking-tight">GitDash</span>
         </header>
 
-        <main className="flex-1">{children}</main>
+        {/* One content container for the whole app (v4.2.8).
+
+            Pages previously each declared their own cap — max-w-5xl on
+            Security, max-w-6xl on Issues, max-w-7xl on Team Analytics, none at
+            all on Alerts and Reports — and none of them centred. Left-aligned
+            caps put every pixel of unused width in a single block on the right,
+            which on a wide monitor left the Security page ending around 1010px
+            with almost as much empty space beside it as content.
+
+            Centring here fixes the asymmetry once, and the cap is generous
+            because this is a dashboard: the PR leaderboard alone is nine
+            columns, and narrowing those tables to a reading measure would be
+            the wrong trade. */}
+        <main className="flex-1 min-w-0">
+          <div className="mx-auto w-full max-w-[1600px]">{children}</div>
+        </main>
 
         {/* Footer — hidden on docs (it has its own) */}
         {!path.startsWith("/docs") && (


### PR DESCRIPTION
Reported directly: a large band of empty space down the right-hand side on a wide display.

## Cause

Every page declared its own width cap, and **none of them centred**:

| Page | Cap before |
|---|---|
| Security | `max-w-5xl` — 1024px |
| Issues · Contributor · Org Health | `max-w-6xl` — 1152px |
| Cost Analytics | `max-w-5xl` |
| Team Analytics · Team Insights | `max-w-7xl` — 1280px |
| Alerts · Reports · Org · Repo overview | none — full width |

A left-aligned cap puts every unused pixel in **one block on the right** instead of splitting it evenly. On a 2000px display the Security page ended around 1010px with almost as much blank beside it as content — and sibling pages disagreed with each other by up to 256px.

## Fix

One centred container in `AppShell`. Pages now declare padding and spacing only.

The cap is deliberately generous because this is a dashboard: the PR leaderboard alone is nine columns, and narrowing those tables to a reading measure would trade one layout problem for another.

**Two exceptions kept on purpose** — the contributor *print brief* keeps its narrow measure, and the *documentation* keeps its prose width. Both were already centred, and both are reading surfaces rather than dashboards.

## Verified in a real browser

Not by reasoning about CSS — a live standalone instance was driven through login and captured at four viewports:

| Viewport | Result |
|---|---|
| 2000×1150 | Security and Team Analytics both span the full content area (~1885px), previously 1010px / 1250px |
| 1440×900 | below the cap, fills naturally, no centring gap |
| 834×1100 | unchanged |
| 390×844 | unchanged — sidebar still collapses to the drawer, wide tables still scroll in their own container |

## Verification

```
tsc --noEmit          0 errors
pnpm test             338 passed (20 files)
pnpm run lint         clean
rm -rf .next && build compiled successfully
API reference parity  no drift
```

Version bumped in all 7 locations; release-notes entry added.
